### PR TITLE
Add CI for THEOplayer releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          submodules: true
       # Build the website
       - name: Use Node.js 20
         uses: actions/setup-node@v4

--- a/.github/workflows/theoplayer-release.yml
+++ b/.github/workflows/theoplayer-release.yml
@@ -23,7 +23,6 @@ jobs:
         if: ${{ steps.check_pr_exists.outputs.result == '0' }}
         run: |
           theoplayer_version = $(<theoplayer/version.txt)
-          commit_msg = $(git log -1 --pretty=%s)
           gh pr create \
             --base main \
             --title "THEOplayer ${theoplayer_version}" \

--- a/.github/workflows/theoplayer-release.yml
+++ b/.github/workflows/theoplayer-release.yml
@@ -24,6 +24,9 @@ jobs:
         run: |
           theoplayer_version = $(<theoplayer/version.txt)
           commit_msg = $(git log -1 --pretty=%s)
-          gh pr create --base main --title "THEOplayer ${theoplayer_version}" --body "This PR contains the new documentation and API references for THEOplayer version ${theoplayer_version}"
+          gh pr create \
+            --base main \
+            --title "THEOplayer ${theoplayer_version}" \
+            --body "This PR contains the new documentation and API references for THEOplayer version ${theoplayer_version}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/theoplayer-release.yml
+++ b/.github/workflows/theoplayer-release.yml
@@ -1,0 +1,21 @@
+name: Auto-open PRs for THEOplayer releases
+on:
+  push:
+    branches:
+      - 'release/theoplayer-**'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: true
+      - name: Create pull request
+        run: |
+          theoplayer_version = $(<theoplayer/version.txt)
+          commit_msg = $(git log -1 --pretty=%s)
+          gh pr create --base main --title "THEOplayer ${theoplayer_version}" --body "This PR contains the new documentation and API references for THEOplayer version ${theoplayer_version}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/theoplayer-release.yml
+++ b/.github/workflows/theoplayer-release.yml
@@ -12,7 +12,15 @@ jobs:
         with:
           fetch-depth: 1
           submodules: true
+      - name: Check if pull request already exists
+        id: check_pr_exists
+        run: |
+          pr_exists = $(gh pr list --base main --head $GITHUB_REF --state open --limit 1 --json number --jq length)
+          echo "result=$pr_exists\n" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create pull request
+        if: ${{ steps.check_pr_exists.outputs.result == '0' }}
         run: |
           theoplayer_version = $(<theoplayer/version.txt)
           commit_msg = $(git log -1 --pretty=%s)


### PR DESCRIPTION
Whenever THEOplayer pushes a new branch named `release/theoplayer-x.y.z`, we will automatically create a pull request for it using [the GitHub CLI](https://cli.github.com/manual/gh_pr_create).

Open questions:
* [x] Should we automatically merge that PR?
    * No, we should review the PR manually first.
    * (We should probably add some proper CI first, so we don't break our website. 😅)
* [x] Who should be assigned as reviewer on the PR?
    * I've created the @THEOplayer/documentation-reviewers team, and added them to CODEOWNERS. 2 members of the team will be auto-assigned to each pull request, and 1 approval is required to merge. [See the ruleset for details.](https://github.com/THEOplayer/documentation/rules/479513?ref=refs%2Fheads%2Fmain)