### PR TITLE
Add CI for deploying pull request previews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
       - main
   workflow_dispatch:
 concurrency:
-  group: staging
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 jobs:
   deploy:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -33,6 +33,8 @@ jobs:
           # Preview URLs look like this: https://[owner].github.io/[repo]/pr-preview/pr-[number]/
           # https://github.com/marketplace/actions/deploy-pr-preview
           DOCUSAURUS_BASE_URL: /${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}/
+          # Prevent PR previews from being indexed by search engines
+          DOCUSAURUS_NO_INDEX: 1
       # Deploy preview
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,42 @@
+name: Deploy pull request preview
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+concurrency: preview-${{ github.ref }}
+jobs:
+  pr-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: true
+      # Build the website
+      - name: Use Node.js 20
+        if: github.event.action != 'closed'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Build
+        if: github.event.action != 'closed'
+        run: |
+          npm ci
+          npm run build
+        env:
+          THEOPLAYER_LICENSE: ${{ vars.THEOPLAYER_LICENSE }}
+          # Preview URLs look like this: https://[owner].github.io/[repo]/pr-preview/pr-[number]/
+          # https://github.com/marketplace/actions/deploy-pr-preview
+          DOCUSAURUS_BASE_URL: /${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}/
+      # Deploy preview
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./build/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -48,6 +48,7 @@ const config: Config = {
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: process.env.DOCUSAURUS_BASE_URL || '/docs/',
   trailingSlash: true,
+  noIndex: !!process.env.DOCUSAURUS_NO_INDEX,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -46,7 +46,7 @@ const config: Config = {
   url: 'https://theoplayer.prudentgiraffe.com/',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/docs/',
+  baseUrl: process.env.DOCUSAURUS_BASE_URL || '/docs/',
   trailingSlash: true,
 
   // GitHub pages deployment config.


### PR DESCRIPTION
Uses the [deploy-pr-preview](https://github.com/marketplace/actions/deploy-pr-preview) action to deploy to the `gh-pages` branch.