### PR TITLE
Use relative URL for `licenseUrl` in examples

### DIFF
--- a/theoplayer/static/theoplayer/v6/examples/basic/demo.html
+++ b/theoplayer/static/theoplayer/v6/examples/basic/demo.html
@@ -26,7 +26,7 @@
         // to point to THEOplayer's location on your own website.
         libraryLocation: 'https://cdn.theoplayer.com/dash/theoplayer/',
         // Change this property to point to your THEOplayer license file:
-        licenseUrl: '/docs/theoplayer-license.txt',
+        licenseUrl: '../../../../theoplayer-license.txt',
         // Alternatively, uncomment this, change its value to your THEOplayer license, and remove "licenseUrl":
         // license: 'your_theoplayer_license',
     });


### PR DESCRIPTION
This makes them also work on [pull request previews](https://github.com/THEOplayer/documentation/commit/232ff8b663c586eb141f8d3364d77f8dbc6c7e91).