### PR TITLE
Add CI to automatically update submodules nightly

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -1,0 +1,74 @@
+name: Update submodules
+on:
+  # Runs every day at midnight UTC
+  schedule:
+    - cron: '0 0 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      # The branch that will receive the submodule updates (will be created if it doesn't exist)
+      # Will automatically open a new PR (if no PR exists yet)
+      UPDATE_BRANCH: update-submodules
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: true
+      - name: Checkout or create branch
+        run: git switch $UPDATE_BRANCH || git switch --create $UPDATE_BRANCH
+      - name: Update submodules with upstream
+        run: git submodule update --checkout --remote
+      - name: Commit changes
+        run: git commit --allow-empty -a -m 'Update submodules'
+      - name: Check for relevant doc changes
+        shell: bash
+        id: check_doc_changes
+        # https://stackoverflow.com/q/67724347/7976758
+        # We only care about changes to CHANGELOG.md or inside /doc/ or /docs/
+        run: |
+          compare () {
+            if [ -z "$3" ];
+              then git diff --name-only --ignore-submodules=all --diff-filter=ACMR "$1" "$2"
+              else git diff --name-only --ignore-submodules=all --diff-filter=ACMR "$1" "$2" | awk -v r=$3 '{print "" r "/" $0}'
+            fi
+          
+            for submodule in `git submodule | awk '{print $2}'`
+            do
+              old=$(git ls-tree $1 $submodule | awk '{print $3}')
+              new=$(git ls-tree $2 $submodule | awk '{print $3}')
+              (cd $submodule; compare $old $new $submodule)
+            done
+          }
+          change_count=compare "HEAD~1" "HEAD" | grep -c -E 'CHANGELOG|/docs?/'
+          if ((change_count > 0)); then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Push to branch
+        if: ${{ steps.check_doc_changes.outputs.changed }}
+        run: git push origin HEAD:$UPDATE_BRANCH
+      - name: Check if pull request already exists
+        if: ${{ steps.check_doc_changes.outputs.changed }}
+        id: check_pr_exists
+        shell: bash
+        run: |
+          pr_count=$(gh pr list --base main --head "$UPDATE_BRANCH" --state open --limit 1 --json number --jq length)
+          if ((pr_count > 0)); then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create pull request
+        if: ${{ steps.check_doc_changes.outputs.changed && !steps.check_pr_exists.outputs.exists }}
+        shell: bash
+        run: |
+          gh pr create \
+            --base main \
+            --head "$UPDATE_BRANCH" \
+            --title "Update documentation from submodules" \
+            --body "This PR pulls in the latest documentation changes from the external submodules."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,24 @@
 [submodule "web-ui"]
 	path = open-video-ui/external/web-ui
 	url = https://github.com/THEOplayer/web-ui.git
+	branch = main
 [submodule "android-ui"]
 	path = open-video-ui/external/android-ui
 	url = https://github.com/THEOplayer/android-ui.git
+	branch = main
 [submodule "react-native"]
 	path = theoplayer/external/react-native-theoplayer
 	url = https://github.com/THEOplayer/react-native-theoplayer.git
+	branch = develop
 [submodule "react-native-v4"]
 	path = theoplayer_versioned_docs/version-v4/external/react-native-theoplayer
 	url = https://github.com/THEOplayer/react-native-theoplayer.git
+	branch = develop
 [submodule "react-native-theoplayer-ui"]
 	path = open-video-ui/external/react-native-theoplayer-ui
 	url = https://github.com/THEOplayer/react-native-theoplayer-ui.git
+	branch = develop
 [submodule "react-native-v6"]
 	path = theoplayer_versioned_docs/version-v6/external/react-native-theoplayer
 	url = https://github.com/THEOplayer/react-native-theoplayer.git
+	branch = develop


### PR DESCRIPTION
This adds a new workflow that will:
1. Create a new `update-submodules` branch (if it doesn't exist yet)
2. Update all submodules in the project
3. If the submodules have any relevant docs changes (i.e. changes to `CHANGELOG.md`, `doc/` or `docs/`):
    1. Push a new commit to the `update-submodules` branch
    2. Open a pull request (if non exists yet)
4. (Otherwise, it discards the update)