### PR TITLE
Pin React Native docs for THEOplayer v4

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Create branch
         run: git checkout -b $UPDATE_BRANCH
       - name: Update submodules with upstream
-        run: git submodule update --init --remote --checkout
+        run: git submodule update --init --remote --checkout --single-branch
       - name: Commit changes
         run: git commit --allow-empty -a -m 'Update submodules'
       - name: Check for relevant doc changes

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,8 @@
 [submodule "react-native-v4"]
 	path = theoplayer_versioned_docs/version-v4/external/react-native-theoplayer
 	url = https://github.com/THEOplayer/react-native-theoplayer.git
-	branch = master
+	branch = 3.x
+	shallow = true
 [submodule "react-native-theoplayer-ui"]
 	path = open-video-ui/external/react-native-theoplayer-ui
 	url = https://github.com/THEOplayer/react-native-theoplayer-ui.git


### PR DESCRIPTION
As suggested in https://github.com/THEOplayer/react-native-theoplayer/pull/310#discussion_r1572148403, we will pin the v4 docs for the React Native SDK to an older version, so https://github.com/THEOplayer/react-native-theoplayer/pull/310 can clean up the React Native docs for v6 and beyond.