### PR TITLE
Navigate to matching page when switching platforms

### DIFF
--- a/src/components/PlatformSelect/index.tsx
+++ b/src/components/PlatformSelect/index.tsx
@@ -7,7 +7,6 @@ import styles from './styles.module.css';
 import { useActiveDocContext, useDocsVersionCandidates } from '@docusaurus/plugin-content-docs/client';
 import { findSidebarInVersions } from '@site/src/util/sidebar';
 import { useLocation } from '@docusaurus/router';
-import { useBaseUrlUtils } from '@docusaurus/useBaseUrl';
 import clsx from 'clsx';
 
 interface PlatformSelectProps extends Omit<SelectProps<any>, 'items' | 'children'> {
@@ -23,7 +22,6 @@ export default function PlatformSelect({ docsPluginId, version, className, ...pr
   const { activeVersion, activeDoc } = useActiveDocContext(docsPluginId);
   const versionCandidates = useDocsVersionCandidates(docsPluginId);
   const { lastPlatformName } = useLastPlatformByPluginId(docsPluginId);
-  const baseUrlUtils = useBaseUrlUtils();
   const platforms = getPlatformsByVersion(docsPluginId, version);
   return (
     <Select
@@ -51,7 +49,7 @@ export default function PlatformSelect({ docsPluginId, version, className, ...pr
       {(desc) => {
         const { platform, label, description, icon } = desc;
         const sidebar = findSidebarInVersions(platform, versionCandidates);
-        const sidebarLink = (activeDoc && getPlatformDoc(docsPluginId, activeVersion, activeDoc, platform, baseUrlUtils)?.path) ?? sidebar.link.path;
+        const sidebarLink = (activeDoc && getPlatformDoc(docsPluginId, activeVersion, activeDoc, platform)?.path) ?? sidebar.link.path;
         return (
           <Item
             id={platform}

--- a/src/components/PlatformSelect/index.tsx
+++ b/src/components/PlatformSelect/index.tsx
@@ -7,6 +7,7 @@ import styles from './styles.module.css';
 import { useActiveDocContext, useDocsVersionCandidates } from '@docusaurus/plugin-content-docs/client';
 import { findSidebarInVersions } from '@site/src/util/sidebar';
 import { useLocation } from '@docusaurus/router';
+import { useBaseUrlUtils } from '@docusaurus/useBaseUrl';
 import clsx from 'clsx';
 
 interface PlatformSelectProps extends Omit<SelectProps<any>, 'items' | 'children'> {
@@ -22,6 +23,7 @@ export default function PlatformSelect({ docsPluginId, version, className, ...pr
   const { activeVersion, activeDoc } = useActiveDocContext(docsPluginId);
   const versionCandidates = useDocsVersionCandidates(docsPluginId);
   const { lastPlatformName } = useLastPlatformByPluginId(docsPluginId);
+  const baseUrlUtils = useBaseUrlUtils();
   const platforms = getPlatformsByVersion(docsPluginId, version);
   return (
     <Select
@@ -49,7 +51,7 @@ export default function PlatformSelect({ docsPluginId, version, className, ...pr
       {(desc) => {
         const { platform, label, description, icon } = desc;
         const sidebar = findSidebarInVersions(platform, versionCandidates);
-        const sidebarLink = (activeDoc && getPlatformDoc(docsPluginId, activeVersion, activeDoc, platform)?.path) ?? sidebar.link.path;
+        const sidebarLink = (activeDoc && getPlatformDoc(docsPluginId, activeVersion, activeDoc, platform, baseUrlUtils)?.path) ?? sidebar.link.path;
         return (
           <Item
             id={platform}

--- a/src/components/PlatformSelect/index.tsx
+++ b/src/components/PlatformSelect/index.tsx
@@ -1,6 +1,6 @@
 import React, { JSX } from 'react';
 import Select, { Item, SelectProps } from '@site/src/components/Select';
-import { defaultPlatformName, getPlatformsByVersion, isDocSharedWithPlatform } from '@site/src/util/platform';
+import { defaultPlatformName, getPlatformDoc, getPlatformsByVersion } from '@site/src/util/platform';
 import { useLastPlatformByPluginId } from '@site/src/contexts/lastPlatform';
 import Icon from '@site/src/components/Icon';
 import styles from './styles.module.css';
@@ -19,7 +19,7 @@ interface PlatformSelectProps extends Omit<SelectProps<any>, 'items' | 'children
  */
 export default function PlatformSelect({ docsPluginId, version, className, ...props }: PlatformSelectProps): JSX.Element {
   const { search, hash } = useLocation();
-  const { activeDoc } = useActiveDocContext(docsPluginId);
+  const { activeVersion, activeDoc } = useActiveDocContext(docsPluginId);
   const versionCandidates = useDocsVersionCandidates(docsPluginId);
   const { lastPlatformName } = useLastPlatformByPluginId(docsPluginId);
   const platforms = getPlatformsByVersion(docsPluginId, version);
@@ -49,8 +49,7 @@ export default function PlatformSelect({ docsPluginId, version, className, ...pr
       {(desc) => {
         const { platform, label, description, icon } = desc;
         const sidebar = findSidebarInVersions(platform, versionCandidates);
-        const isDocInSidebar = activeDoc ? isDocSharedWithPlatform(docsPluginId, activeDoc.id, platform) : false;
-        const sidebarLink = isDocInSidebar ? activeDoc.path : sidebar.link.path;
+        const sidebarLink = (activeDoc && getPlatformDoc(docsPluginId, activeVersion, activeDoc, platform)?.path) ?? sidebar.link.path;
         return (
           <Item
             id={platform}

--- a/src/contexts/lastPlatform.tsx
+++ b/src/contexts/lastPlatform.tsx
@@ -74,7 +74,7 @@ function LastPlatformContextProviderUnsafe({ children }: { children: ReactNode }
   const docSidebarName = activeDoc?.sidebar;
   const lastPlatformName = state[pluginId].lastPlatformName;
   if (activeDoc && (!lastPlatformName || lastPlatformName !== docSidebarName)) {
-    if (isDocSharedWithPlatform(pluginId, activeDoc.id, lastPlatformName || defaultPlatformName)) {
+    if (isDocSharedWithPlatform(pluginId, activeDoc, lastPlatformName || defaultPlatformName)) {
       if (lastPlatformName && activeVersion.sidebars[lastPlatformName]) {
         // Prefer last platform for cross-platform docs
       } else {

--- a/src/theme/DocRoot/Layout/index.tsx
+++ b/src/theme/DocRoot/Layout/index.tsx
@@ -15,7 +15,7 @@ function PlatformSidebarProvider({ children }: { children: ReactNode }) {
   const { lastPlatformName } = useLastPlatform();
 
   // Override sidebar for certain docs that are shared across platforms
-  if (isDocSharedWithPlatform(pluginId, activeDoc.id, lastPlatformName)) {
+  if (isDocSharedWithPlatform(pluginId, activeDoc, lastPlatformName)) {
     return (
       <DocsSidebarProvider name={lastPlatformName} items={versionMetadata.docsSidebars[lastPlatformName]}>
         {children}

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -178,36 +178,14 @@ function findMatchingTheoplayerDoc(version: GlobalVersion, doc: GlobalDoc, platf
   const gettingStartedMatch = docPath.match(/^\/getting-started\/(?:sdks|frameworks)\/[a-z\-]+\/(.*)$/);
   if (gettingStartedMatch) {
     const isFrameworkPlatform = platformName === 'react-native' || platformName === 'flutter';
-    const docPathPrefix = `${version.path}/getting-started/${isFrameworkPlatform ? 'frameworks' : 'sdks'}/${platformName}`;
-    // Find exact match
-    const exactDocPath = `${docPathPrefix}/${gettingStartedMatch[1]}`;
-    if (doc.path === exactDocPath) {
-      return doc;
-    }
-    const exactDoc = version.docs.find((otherDoc) => otherDoc.path === exactDocPath);
-    if (exactDoc) {
-      return exactDoc;
-    }
-    // Find main Getting Started page
-    const mainDocPath = `${docPathPrefix}/getting-started`;
-    return version.docs.find((otherDoc) => otherDoc.path === mainDocPath);
+    const prefix = `${version.path}/getting-started/${isFrameworkPlatform ? 'frameworks' : 'sdks'}/${platformName}`;
+    return findMatchingDoc(version, doc, prefix, gettingStartedMatch[1], 'getting-started');
   }
   // Connectors
   const connectorMatch = docPath.match(/^\/connectors\/[a-z\-]+\/(.*)$/);
   if (connectorMatch) {
-    const docPathPrefix = `${version.path}/connectors/${platformName}`;
-    // Find exact match
-    const exactDocPath = `${docPathPrefix}/${connectorMatch[1]}`;
-    if (doc.path === exactDocPath) {
-      return doc;
-    }
-    const exactDoc = version.docs.find((otherDoc) => otherDoc.path === exactDocPath);
-    if (exactDoc) {
-      return exactDoc;
-    }
-    // Find index page
-    const indexDocPath = `${docPathPrefix}/`;
-    return version.docs.find((otherDoc) => otherDoc.path === indexDocPath);
+    const prefix = `${version.path}/connectors/${platformName}`;
+    return findMatchingDoc(version, doc, prefix, connectorMatch[1], '');
   }
 }
 
@@ -215,18 +193,33 @@ function findMatchingOpenVideoUiDoc(version: GlobalVersion, doc: GlobalDoc, plat
   const docPath = doc.path.replace(version.path, '');
   const match = docPath.match(/^\/[a-z\-]+\/(.*)$/);
   if (match) {
-    const docPathPrefix = `${version.path}/${platformName}`;
-    // Find exact match
-    const exactDocPath = `${docPathPrefix}/${match[1]}`;
-    if (doc.path === exactDocPath) {
-      return doc;
-    }
-    const exactDoc = version.docs.find((otherDoc) => otherDoc.path === exactDocPath);
-    if (exactDoc) {
-      return exactDoc;
-    }
-    // Find index page
-    const indexDocPath = `${docPathPrefix}/`;
-    return version.docs.find((otherDoc) => otherDoc.path === indexDocPath);
+    const prefix = `${version.path}/${platformName}`;
+    return findMatchingDoc(version, doc, prefix, match[1], '');
   }
+}
+
+function findMatchingDoc(version: GlobalVersion, doc: GlobalDoc, prefix: string, suffix: string, fallbackSuffix: string): GlobalDoc | undefined {
+  // Find exact match
+  const exactDocPath = `${prefix}/${suffix}`;
+  if (doc.path === exactDocPath) {
+    return doc;
+  }
+  const exactDoc = version.docs.find((otherDoc) => otherDoc.path === exactDocPath);
+  if (exactDoc) {
+    return exactDoc;
+  }
+  // Find a loose match with fewer path parts
+  const suffixParts = suffix.split('/');
+  suffixParts.pop();
+  while (suffixParts.length > 0) {
+    const looseDocPath = `${prefix}/${suffixParts.join('/')}`;
+    const looseDoc = version.docs.find((otherDoc) => otherDoc.path === looseDocPath);
+    if (looseDoc) {
+      return looseDoc;
+    }
+    suffixParts.pop();
+  }
+  // Find fallback page
+  const fallbackDocPath = `${prefix}/${fallbackSuffix}`;
+  return version.docs.find((otherDoc) => otherDoc.path === fallbackDocPath);
 }

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -188,4 +188,21 @@ function findMatchingTheoplayerDoc(version: GlobalVersion, doc: GlobalDoc, platf
     const mainDocPath = `${docPathPrefix}/getting-started`;
     return version.docs.find((otherDoc) => otherDoc.path === mainDocPath);
   }
+  // Connectors
+  const connectorMatch = doc.path.match(/^\/docs\/theoplayer\/connectors\/[a-z\-]+\/(.*)$/);
+  if (connectorMatch) {
+    const docPathPrefix = `/docs/theoplayer/connectors/${platformName}`;
+    // Find exact match
+    const exactDocPath = `${docPathPrefix}/${connectorMatch[1]}`;
+    if (doc.path === exactDocPath) {
+      return doc;
+    }
+    const exactDoc = version.docs.find((otherDoc) => otherDoc.path === exactDocPath);
+    if (exactDoc) {
+      return exactDoc;
+    }
+    // Find index page
+    const indexDocPath = `${docPathPrefix}/`;
+    return version.docs.find((otherDoc) => otherDoc.path === indexDocPath);
+  }
 }

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -161,35 +161,24 @@ export function isDocSharedWithPlatform(docsPluginId: string, doc: GlobalDoc, pl
   return false;
 }
 
-export function getPlatformDoc(
-  docsPluginId: string,
-  version: GlobalVersion,
-  doc: GlobalDoc,
-  platformName: PlatformName,
-  baseUrlUtils: BaseUrlUtils
-): GlobalDoc | undefined {
+export function getPlatformDoc(docsPluginId: string, version: GlobalVersion, doc: GlobalDoc, platformName: PlatformName): GlobalDoc | undefined {
   if (isDocSharedWithPlatform(docsPluginId, doc, platformName)) {
     return doc;
   }
   if (docsPluginId === 'theoplayer') {
-    return findMatchingTheoplayerDoc(version, doc, platformName, baseUrlUtils);
+    return findMatchingTheoplayerDoc(version, doc, platformName);
   } else if (docsPluginId === 'open-video-ui') {
-    return findMatchingOpenVideoUiDoc(version, doc, platformName, baseUrlUtils);
+    return findMatchingOpenVideoUiDoc(version, doc, platformName);
   }
 }
 
-function findMatchingTheoplayerDoc(
-  version: GlobalVersion,
-  doc: GlobalDoc,
-  platformName: PlatformName,
-  baseUrlUtils: BaseUrlUtils
-): GlobalDoc | undefined {
-  const docPath = doc.path.replace(baseUrlUtils.withBaseUrl('/'), '/');
+function findMatchingTheoplayerDoc(version: GlobalVersion, doc: GlobalDoc, platformName: PlatformName): GlobalDoc | undefined {
+  const docPath = doc.path.replace(version.path, '');
   // Getting Started
-  const gettingStartedMatch = docPath.match(/^\/theoplayer\/getting-started\/(?:sdks|frameworks)\/[a-z\-]+\/(.*)$/);
+  const gettingStartedMatch = docPath.match(/^\/getting-started\/(?:sdks|frameworks)\/[a-z\-]+\/(.*)$/);
   if (gettingStartedMatch) {
     const isFrameworkPlatform = platformName === 'react-native' || platformName === 'flutter';
-    const docPathPrefix = baseUrlUtils.withBaseUrl(`/theoplayer/getting-started/${isFrameworkPlatform ? 'frameworks' : 'sdks'}/${platformName}`);
+    const docPathPrefix = `${version.path}/getting-started/${isFrameworkPlatform ? 'frameworks' : 'sdks'}/${platformName}`;
     // Find exact match
     const exactDocPath = `${docPathPrefix}/${gettingStartedMatch[1]}`;
     if (doc.path === exactDocPath) {
@@ -204,9 +193,9 @@ function findMatchingTheoplayerDoc(
     return version.docs.find((otherDoc) => otherDoc.path === mainDocPath);
   }
   // Connectors
-  const connectorMatch = docPath.match(/^\/theoplayer\/connectors\/[a-z\-]+\/(.*)$/);
+  const connectorMatch = docPath.match(/^\/connectors\/[a-z\-]+\/(.*)$/);
   if (connectorMatch) {
-    const docPathPrefix = baseUrlUtils.withBaseUrl(`/theoplayer/connectors/${platformName}`);
+    const docPathPrefix = `${version.path}/connectors/${platformName}`;
     // Find exact match
     const exactDocPath = `${docPathPrefix}/${connectorMatch[1]}`;
     if (doc.path === exactDocPath) {
@@ -222,16 +211,11 @@ function findMatchingTheoplayerDoc(
   }
 }
 
-function findMatchingOpenVideoUiDoc(
-  version: GlobalVersion,
-  doc: GlobalDoc,
-  platformName: PlatformName,
-  baseUrlUtils: BaseUrlUtils
-): GlobalDoc | undefined {
-  const docPath = doc.path.replace(baseUrlUtils.withBaseUrl('/'), '/');
-  const match = docPath.match(/^\/open-video-ui\/[a-z\-]+\/(.*)$/);
+function findMatchingOpenVideoUiDoc(version: GlobalVersion, doc: GlobalDoc, platformName: PlatformName): GlobalDoc | undefined {
+  const docPath = doc.path.replace(version.path, '');
+  const match = docPath.match(/^\/[a-z\-]+\/(.*)$/);
   if (match) {
-    const docPathPrefix = baseUrlUtils.withBaseUrl(`open-video-ui/${platformName}`);
+    const docPathPrefix = `${version.path}/${platformName}`;
     // Find exact match
     const exactDocPath = `${docPathPrefix}/${match[1]}`;
     if (doc.path === exactDocPath) {

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -169,7 +169,7 @@ export function getPlatformDoc(
   baseUrlUtils: BaseUrlUtils
 ): GlobalDoc | undefined {
   if (isDocSharedWithPlatform(docsPluginId, doc, platformName)) {
-    return version.docs[doc.id];
+    return doc;
   }
   if (docsPluginId === 'theoplayer') {
     return findMatchingTheoplayerDoc(version, doc, platformName, baseUrlUtils);

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -1,4 +1,5 @@
 import type { GlobalDoc, GlobalVersion } from '@docusaurus/plugin-content-docs/client';
+import useBaseUrl, { BaseUrlUtils } from '@docusaurus/useBaseUrl';
 
 /**
  * The names of SDK platforms.
@@ -160,23 +161,35 @@ export function isDocSharedWithPlatform(docsPluginId: string, doc: GlobalDoc, pl
   return false;
 }
 
-export function getPlatformDoc(docsPluginId: string, version: GlobalVersion, doc: GlobalDoc, platformName: PlatformName): GlobalDoc | undefined {
+export function getPlatformDoc(
+  docsPluginId: string,
+  version: GlobalVersion,
+  doc: GlobalDoc,
+  platformName: PlatformName,
+  baseUrlUtils: BaseUrlUtils
+): GlobalDoc | undefined {
   if (isDocSharedWithPlatform(docsPluginId, doc, platformName)) {
     return version.docs[doc.id];
   }
   if (docsPluginId === 'theoplayer') {
-    return findMatchingTheoplayerDoc(version, doc, platformName);
+    return findMatchingTheoplayerDoc(version, doc, platformName, baseUrlUtils);
   } else if (docsPluginId === 'open-video-ui') {
-    return findMatchingOpenVideoUiDoc(version, doc, platformName);
+    return findMatchingOpenVideoUiDoc(version, doc, platformName, baseUrlUtils);
   }
 }
 
-function findMatchingTheoplayerDoc(version: GlobalVersion, doc: GlobalDoc, platformName: PlatformName): GlobalDoc | undefined {
+function findMatchingTheoplayerDoc(
+  version: GlobalVersion,
+  doc: GlobalDoc,
+  platformName: PlatformName,
+  baseUrlUtils: BaseUrlUtils
+): GlobalDoc | undefined {
+  const docPath = doc.path.replace(baseUrlUtils.withBaseUrl('/'), '/');
   // Getting Started
-  const gettingStartedMatch = doc.path.match(/^\/docs\/theoplayer\/getting-started\/(?:sdks|frameworks)\/[a-z\-]+\/(.*)$/);
+  const gettingStartedMatch = docPath.match(/^\/theoplayer\/getting-started\/(?:sdks|frameworks)\/[a-z\-]+\/(.*)$/);
   if (gettingStartedMatch) {
     const isFrameworkPlatform = platformName === 'react-native' || platformName === 'flutter';
-    const docPathPrefix = `/docs/theoplayer/getting-started/${isFrameworkPlatform ? 'frameworks' : 'sdks'}/${platformName}`;
+    const docPathPrefix = baseUrlUtils.withBaseUrl(`/theoplayer/getting-started/${isFrameworkPlatform ? 'frameworks' : 'sdks'}/${platformName}`);
     // Find exact match
     const exactDocPath = `${docPathPrefix}/${gettingStartedMatch[1]}`;
     if (doc.path === exactDocPath) {
@@ -191,9 +204,9 @@ function findMatchingTheoplayerDoc(version: GlobalVersion, doc: GlobalDoc, platf
     return version.docs.find((otherDoc) => otherDoc.path === mainDocPath);
   }
   // Connectors
-  const connectorMatch = doc.path.match(/^\/docs\/theoplayer\/connectors\/[a-z\-]+\/(.*)$/);
+  const connectorMatch = docPath.match(/^\/theoplayer\/connectors\/[a-z\-]+\/(.*)$/);
   if (connectorMatch) {
-    const docPathPrefix = `/docs/theoplayer/connectors/${platformName}`;
+    const docPathPrefix = baseUrlUtils.withBaseUrl(`/theoplayer/connectors/${platformName}`);
     // Find exact match
     const exactDocPath = `${docPathPrefix}/${connectorMatch[1]}`;
     if (doc.path === exactDocPath) {
@@ -209,10 +222,16 @@ function findMatchingTheoplayerDoc(version: GlobalVersion, doc: GlobalDoc, platf
   }
 }
 
-function findMatchingOpenVideoUiDoc(version: GlobalVersion, doc: GlobalDoc, platformName: PlatformName): GlobalDoc | undefined {
-  const match = doc.path.match(/^\/docs\/open-video-ui\/[a-z\-]+\/(.*)$/);
+function findMatchingOpenVideoUiDoc(
+  version: GlobalVersion,
+  doc: GlobalDoc,
+  platformName: PlatformName,
+  baseUrlUtils: BaseUrlUtils
+): GlobalDoc | undefined {
+  const docPath = doc.path.replace(baseUrlUtils.withBaseUrl('/'), '/');
+  const match = docPath.match(/^\/open-video-ui\/[a-z\-]+\/(.*)$/);
   if (match) {
-    const docPathPrefix = `/docs/open-video-ui/${platformName}`;
+    const docPathPrefix = baseUrlUtils.withBaseUrl(`open-video-ui/${platformName}`);
     // Find exact match
     const exactDocPath = `${docPathPrefix}/${match[1]}`;
     if (doc.path === exactDocPath) {

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -181,6 +181,12 @@ function findMatchingTheoplayerDoc(version: GlobalVersion, doc: GlobalDoc, platf
     const prefix = `${version.path}/getting-started/${isFrameworkPlatform ? 'frameworks' : 'sdks'}/${platformName}`;
     return findMatchingDoc(version, doc, prefix, gettingStartedMatch[2], 'getting-started');
   }
+  // How-to guides
+  const howToGuideMatch = docPath.match(/^\/how-to-guides\/([a-z\-]+)\/(.*)$/);
+  if (howToGuideMatch && isPlatformName(howToGuideMatch[1])) {
+    const prefix = `${version.path}/how-to-guides/${platformName}`;
+    return findMatchingDoc(version, doc, prefix, howToGuideMatch[2], '');
+  }
   // Connectors
   const connectorMatch = docPath.match(/^\/connectors\/([a-z\-]+)\/(.*)$/);
   if (connectorMatch && isPlatformName(connectorMatch[1])) {

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -175,26 +175,26 @@ export function getPlatformDoc(docsPluginId: string, version: GlobalVersion, doc
 function findMatchingTheoplayerDoc(version: GlobalVersion, doc: GlobalDoc, platformName: PlatformName): GlobalDoc | undefined {
   const docPath = doc.path.replace(version.path, '');
   // Getting Started
-  const gettingStartedMatch = docPath.match(/^\/getting-started\/(?:sdks|frameworks)\/[a-z\-]+\/(.*)$/);
-  if (gettingStartedMatch) {
+  const gettingStartedMatch = docPath.match(/^\/getting-started\/(?:sdks|frameworks)\/([a-z\-]+)\/(.*)$/);
+  if (gettingStartedMatch && isPlatformName(gettingStartedMatch[1])) {
     const isFrameworkPlatform = platformName === 'react-native' || platformName === 'flutter';
     const prefix = `${version.path}/getting-started/${isFrameworkPlatform ? 'frameworks' : 'sdks'}/${platformName}`;
-    return findMatchingDoc(version, doc, prefix, gettingStartedMatch[1], 'getting-started');
+    return findMatchingDoc(version, doc, prefix, gettingStartedMatch[2], 'getting-started');
   }
   // Connectors
-  const connectorMatch = docPath.match(/^\/connectors\/[a-z\-]+\/(.*)$/);
-  if (connectorMatch) {
+  const connectorMatch = docPath.match(/^\/connectors\/([a-z\-]+)\/(.*)$/);
+  if (connectorMatch && isPlatformName(connectorMatch[1])) {
     const prefix = `${version.path}/connectors/${platformName}`;
-    return findMatchingDoc(version, doc, prefix, connectorMatch[1], '');
+    return findMatchingDoc(version, doc, prefix, connectorMatch[2], '');
   }
 }
 
 function findMatchingOpenVideoUiDoc(version: GlobalVersion, doc: GlobalDoc, platformName: PlatformName): GlobalDoc | undefined {
   const docPath = doc.path.replace(version.path, '');
-  const match = docPath.match(/^\/[a-z\-]+\/(.*)$/);
-  if (match) {
+  const match = docPath.match(/^\/([a-z\-]+)\/(.*)$/);
+  if (match && isPlatformName(match[1])) {
     const prefix = `${version.path}/${platformName}`;
-    return findMatchingDoc(version, doc, prefix, match[1], '');
+    return findMatchingDoc(version, doc, prefix, match[2], '');
   }
 }
 

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -166,6 +166,8 @@ export function getPlatformDoc(docsPluginId: string, version: GlobalVersion, doc
   }
   if (docsPluginId === 'theoplayer') {
     return findMatchingTheoplayerDoc(version, doc, platformName);
+  } else if (docsPluginId === 'open-video-ui') {
+    return findMatchingOpenVideoUiDoc(version, doc, platformName);
   }
 }
 
@@ -194,6 +196,25 @@ function findMatchingTheoplayerDoc(version: GlobalVersion, doc: GlobalDoc, platf
     const docPathPrefix = `/docs/theoplayer/connectors/${platformName}`;
     // Find exact match
     const exactDocPath = `${docPathPrefix}/${connectorMatch[1]}`;
+    if (doc.path === exactDocPath) {
+      return doc;
+    }
+    const exactDoc = version.docs.find((otherDoc) => otherDoc.path === exactDocPath);
+    if (exactDoc) {
+      return exactDoc;
+    }
+    // Find index page
+    const indexDocPath = `${docPathPrefix}/`;
+    return version.docs.find((otherDoc) => otherDoc.path === indexDocPath);
+  }
+}
+
+function findMatchingOpenVideoUiDoc(version: GlobalVersion, doc: GlobalDoc, platformName: PlatformName): GlobalDoc | undefined {
+  const match = doc.path.match(/^\/docs\/open-video-ui\/[a-z\-]+\/(.*)$/);
+  if (match) {
+    const docPathPrefix = `/docs/open-video-ui/${platformName}`;
+    // Find exact match
+    const exactDocPath = `${docPathPrefix}/${match[1]}`;
     if (doc.path === exactDocPath) {
       return doc;
     }


### PR DESCRIPTION
When using the platform select dropdown, we currently always navigate to the start page of that SDK. This is annoying if you're already on a specific article, since now you have to manually find that same article for the newly selected SDK.

This PR improves this by trying to find a matching article based on the article's URL. We assume that our articles have a predictable URL structure, and that articles with similar URLs have similar content. Some examples:
* `/theoplayer/getting-started/sdks/web/migrating-to-theoplayer-8` matches with `/theoplayer/getting-started/sdks/android/migrating-to-theoplayer-8`
* `/theoplayer/connectors/web/comscore/getting-started` matches with `/theoplayer/connectors/android/comscore/getting-started`
* `/open-video-ui/web/guides/custom-ui` matches with `/open-video-ui/android/guides/custom-ui`

If there's no exact match, we try to match on fewer path parts until we have a match, falling back to the index page if nothing matches. For example:
* `/theoplayer/getting-started/sdks/web/how-can-we-embed-iframe` would switch to `/theoplayer/getting-started/sdks/android/getting-started`
  * There's no equivalent page, and `/android/getting-started` counts as the "index page".
* `/theoplayer/connectors/web/comscore/changelog` would switch to `/theoplayer/connectors/android/comscore`
  * There is an equivalent Android connector, but it doesn't have a changelog page yet.
* `/theoplayer/connectors/web/cmcd/getting-started` would switch to `/theoplayer/connectors/android`
  * There is no equivalent Android connector yet, so we go to the index page.