### PR TITLE
Update 00-getting-started.mdx

### DIFF
--- a/theoplayer/how-to-guides/web/theolive/00-getting-started.mdx
+++ b/theoplayer/how-to-guides/web/theolive/00-getting-started.mdx
@@ -19,7 +19,7 @@ You'll need a THEOlive channel ID:
 const player = new THEOplayer.Player(element, configuration);
 player.source = {
   sources: {
-    type: 'theolive',
+    integration: 'theolive',
     src: 'your-channel-id',
   },
 };


### PR DESCRIPTION
fixed a bug in the docs where `type` was used instead of `integration`