### PR TITLE
Use app token for deploying PR previews

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -11,9 +11,16 @@ jobs:
   pr-preview:
     runs-on: ubuntu-latest
     steps:
+      - name: Create app token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.THEOPLAYER_BOT_APP_ID }}
+          private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
           submodules: true
       # Build the website
@@ -42,6 +49,7 @@ jobs:
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           source-dir: ./build/
           preview-branch: gh-pages
           umbrella-dir: pr-preview


### PR DESCRIPTION
When deploying a pull request preview for a PR from an external contributor (such as #164), [the deploy job failed](https://github.com/THEOplayer/documentation/actions/runs/11974630234/job/33462866909) with the following error:
```
Pushing changes… (attempt 1 of 3)
/usr/bin/git push --porcelain ***github.com/THEOplayer/documentation.git github-pages-deploy-action/5p62z7u4e:gh-pages
remote: Permission to THEOplayer/documentation.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/THEOplayer/documentation.git/': The requested URL returned error: 403
```
I *think* this is an issue with the permissions of the default `GITHUB_TOKEN`? Let's see if it works better with an app token from our own friendly THEOplayer bot.