### PR TITLE
Update Media3 guide for THEOplayer 8.10

### DIFF
--- a/theoplayer/how-to-guides/android/media3/getting-started.mdx
+++ b/theoplayer/how-to-guides/android/media3/getting-started.mdx
@@ -138,7 +138,7 @@ theoplayerView.player.addIntegration(media3PlayerIntegration)
 As this integration is still under development, there are currently some known limitations and features that are still under development and not yet supported:
 
 - The preload, ABR, network, metrics, latency and caching (offline playback) APIs are not yet implemented and return dummy values.
-- Millicast playback is not yet supported, and will fall back to our existing playback pipeline.
+- Millicast playback is not yet supported, and must always be handled by the [Millicast integration](../millicast/getting-started.mdx).
 - `TextTrack.cues`, `TextTrack.activeCues` and cue-related events are not yet supported. Although subtitles do render correctly to the screen, the content of these subtitles is not yet exposed through our API.
 - Certain player and source configuration parameters are not yet handled.
 - Certain player events may not yet be dispatched correctly.

--- a/theoplayer/how-to-guides/android/media3/getting-started.mdx
+++ b/theoplayer/how-to-guides/android/media3/getting-started.mdx
@@ -119,7 +119,7 @@ Once the Media3PlayerIntegration is added to the player, all subsequent sources 
 
 </Tabs>
 
-By default, the `Media3PlayerIntegration` will play all types of sources except HESP and Millicast.
+By default, the `Media3PlayerIntegration` will play all types of sources except Millicast.
 To modify the default behaviour, you can pass a custom `Media3PlayerIntegration.SourceSelectCallback` implementation
 when constructing the integration.
 
@@ -138,7 +138,7 @@ theoplayerView.player.addIntegration(media3PlayerIntegration)
 As this integration is still under development, there are currently some known limitations and features that are still under development and not yet supported:
 
 - The preload, ABR, network, metrics, latency and caching (offline playback) APIs are not yet implemented and return dummy values.
-- HESP/THEOlive and Millicast playback are not yet supported, and will fall back to our existing playback pipeline.
+- Millicast playback is not yet supported, and will fall back to our existing playback pipeline.
 - `TextTrack.cues`, `TextTrack.activeCues` and cue-related events are not yet supported. Although subtitles do render correctly to the screen, the content of these subtitles is not yet exposed through our API.
 - Certain player and source configuration parameters are not yet handled.
 - Certain player events may not yet be dispatched correctly.

--- a/theoplayer/how-to-guides/android/media3/getting-started.mdx
+++ b/theoplayer/how-to-guides/android/media3/getting-started.mdx
@@ -132,7 +132,7 @@ when constructing the integration.
 
 As this integration is still under development, there are currently some known limitations and features that are still under development and not yet supported:
 
-- The preload, ABR, network, metrics and latency APIs are not yet implemented and return dummy values.
+- The ABR, network, metrics and latency APIs are not yet implemented and return dummy values.
 - Millicast playback is not yet supported, and must always be handled by the [Millicast integration](../millicast/getting-started.mdx).
 - Certain player and source configuration parameters are not yet handled.
 - Certain player events may not yet be dispatched correctly.

--- a/theoplayer/how-to-guides/android/media3/getting-started.mdx
+++ b/theoplayer/how-to-guides/android/media3/getting-started.mdx
@@ -57,13 +57,13 @@ Once the Media3PlayerIntegration is added to the player, all subsequent sources 
     <TabItem value="kotlin" label="Kotlin">
         ```kotlin
         val typedSource = TypedSource
-        .Builder("https://cdn.theoplayer.com/video/dash/big_buck_bunny/BigBuckBunny_10s_simple_2014_05_09.mpd")
-        .type(SourceType.DASH)
-        .build()
+            .Builder("https://cdn.theoplayer.com/video/dash/big_buck_bunny/BigBuckBunny_10s_simple_2014_05_09.mpd")
+            .type(SourceType.DASH)
+            .build()
 
         val sourceDescription = SourceDescription
-        .Builder(typedSource)
-        .build()
+            .Builder(typedSource)
+            .build()
 
         theoPlayerView.player.source = sourceDescription
         ```
@@ -71,13 +71,13 @@ Once the Media3PlayerIntegration is added to the player, all subsequent sources 
     <TabItem value="java" label="Java">
         ```java
         TypedSource typedSource = new TypedSource
-        .Builder("https://cdn.theoplayer.com/video/dash/big_buck_bunny/BigBuckBunny_10s_simple_2014_05_09.mpd")
-        .type(SourceType.DASH)
-        .build();
+            .Builder("https://cdn.theoplayer.com/video/dash/big_buck_bunny/BigBuckBunny_10s_simple_2014_05_09.mpd")
+            .type(SourceType.DASH)
+            .build();
 
         SourceDescription sourceDescription = new SourceDescription
-        .Builder(typedSource)
-        .build();
+            .Builder(typedSource)
+            .build();
 
         theoPlayerView.getPlayer().setSource(sourceDescription);
         ```

--- a/theoplayer/how-to-guides/android/media3/getting-started.mdx
+++ b/theoplayer/how-to-guides/android/media3/getting-started.mdx
@@ -139,7 +139,6 @@ As this integration is still under development, there are currently some known l
 
 - The preload, ABR, network, metrics, latency and caching (offline playback) APIs are not yet implemented and return dummy values.
 - Millicast playback is not yet supported, and must always be handled by the [Millicast integration](../millicast/getting-started.mdx).
-- `TextTrack.cues`, `TextTrack.activeCues` and cue-related events are not yet supported. Although subtitles do render correctly to the screen, the content of these subtitles is not yet exposed through our API.
 - Certain player and source configuration parameters are not yet handled.
 - Certain player events may not yet be dispatched correctly.
 - There are some known issues with video track and quality switching.

--- a/theoplayer/how-to-guides/android/media3/getting-started.mdx
+++ b/theoplayer/how-to-guides/android/media3/getting-started.mdx
@@ -137,7 +137,7 @@ theoplayerView.player.addIntegration(media3PlayerIntegration)
 
 As this integration is still under development, there are currently some known limitations and features that are still under development and not yet supported:
 
-- The preload, ABR, network, metrics, latency and caching (offline playback) APIs are not yet implemented and return dummy values.
+- The preload, ABR, network, metrics and latency APIs are not yet implemented and return dummy values.
 - Millicast playback is not yet supported, and must always be handled by the [Millicast integration](../millicast/getting-started.mdx).
 - Certain player and source configuration parameters are not yet handled.
 - Certain player events may not yet be dispatched correctly.

--- a/theoplayer/how-to-guides/android/media3/getting-started.mdx
+++ b/theoplayer/how-to-guides/android/media3/getting-started.mdx
@@ -45,10 +45,22 @@ Add the Media3 integration as a dependency in your module-level `build.gradle` f
 
 To make use of the Media3 integration, create and add the `Media3PlayerIntegration` to your `THEOplayerView`:
 
-```kotlin
-val media3PlayerIntegration = Media3PlayerIntegrationFactory.createMedia3PlayerIntegration()
-theoplayerView.player.addIntegration(media3PlayerIntegration)
-```
+<Tabs queryString="lang">
+    <!-- prettier-ignore-start -->
+    <TabItem value="kotlin" label="Kotlin">
+        ```kotlin
+        val media3PlayerIntegration = Media3PlayerIntegrationFactory.createMedia3PlayerIntegration()
+        theoplayerView.player.addIntegration(media3PlayerIntegration)
+        ```
+    </TabItem>
+    <TabItem value="java" label="Java">
+        ```java
+        Media3PlayerIntegration media3PlayerIntegration = Media3PlayerIntegrationFactory.createMedia3PlayerIntegration()
+        theoplayerView.getPlayer().addIntegration(media3PlayerIntegration)
+        ```
+    </TabItem>
+    <!-- prettier-ignore-end -->
+</Tabs>
 
 Once the Media3PlayerIntegration is added to the player, all subsequent sources set on the player will use the Media3 pipeline.
 
@@ -83,22 +95,38 @@ Once the Media3PlayerIntegration is added to the player, all subsequent sources 
         ```
     </TabItem>
     <!-- prettier-ignore-end -->
-
 </Tabs>
 
 By default, the `Media3PlayerIntegration` will play all types of sources except Millicast.
 To modify the default behaviour, you can pass a custom `Media3PlayerIntegration.SourceSelectCallback` implementation
 when constructing the integration.
 
-```kotlin
-val media3PlayerIntegration = createMedia3PlayerIntegration(Media3PlayerIntegration.SourceSelectCallback { selectedSource, source ->
-    // selectedSource -> represents the TypedSource the player picked to play.
-    // source -> represents the SourceDescription passed to the player.
-    // return true -> the Media3 integration pipeline will be used to play the selected source.
-    // return false -> the default pipeline will be used to play the selected source.
-})
-theoplayerView.player.addIntegration(media3PlayerIntegration)
-```
+<Tabs queryString="lang">
+    <!-- prettier-ignore-start -->
+    <TabItem value="kotlin" label="Kotlin">
+        ```kotlin
+        val media3PlayerIntegration = createMedia3PlayerIntegration(Media3PlayerIntegration.SourceSelectCallback { selectedSource, source ->
+            // selectedSource -> represents the TypedSource the player picked to play.
+            // source -> represents the SourceDescription passed to the player.
+            // return true -> the Media3 integration pipeline will be used to play the selected source.
+            // return false -> the default pipeline will be used to play the selected source.
+        })
+        theoplayerView.player.addIntegration(media3PlayerIntegration)
+        ```
+    </TabItem>
+    <TabItem value="java" label="Java">
+        ```java
+        Media3PlayerIntegration media3PlayerIntegration = Media3PlayerIntegrationFactory.createMedia3PlayerIntegration((selectedSource, source) -> {
+            // selectedSource -> represents the TypedSource the player picked to play.
+            // source -> represents the SourceDescription passed to the player.
+            // return true; -> the Media3 integration pipeline will be used to play the selected source.
+            // return false; -> the default pipeline will be used to play the selected source.
+        });
+        theoplayerView.getPlayer().addIntegration(media3PlayerIntegration);
+        ```
+    </TabItem>
+    <!-- prettier-ignore-end -->
+</Tabs>
 
 ## Known limitations
 

--- a/theoplayer/how-to-guides/android/media3/getting-started.mdx
+++ b/theoplayer/how-to-guides/android/media3/getting-started.mdx
@@ -16,39 +16,6 @@ Note that the integration is still under active development, see [the Known limi
 
 ### Add the Media3 integration dependency
 
-Given that the Media3 integration is under active development, it is currently still published to our `snapshots` repository, so add the THEOplayer `snapshots` Maven repository in your **top-level** (project) `settings.gradle.kts` file.
-
-<Tabs queryString="lang">
-    <!-- prettier-ignore-start -->
-    <TabItem value="groovy" label="Groovy">
-        ```groovy
-        dependencyResolutionManagement {
-            repositories {
-                google()
-                mavenCentral()
-                maven { url "https://maven.theoplayer.com/releases" }
-                // highlight-next-line
-                maven { url "https://maven.theoplayer.com/snapshots" }
-            }
-        }
-        ```
-    </TabItem>
-    <TabItem value="kotlin" label="Kotlin">
-        ```kotlin
-        dependencyResolutionManagement {
-            repositories {
-                google()
-                mavenCentral()
-                maven { url = uri("https://maven.theoplayer.com/releases") }
-                // highlight-next-line
-                maven { url = uri("https://maven.theoplayer.com/snapshots") }
-            }
-        }
-        ```
-    </TabItem>
-    <!-- prettier-ignore-end -->
-</Tabs>
-
 Add the Media3 integration as a dependency in your module-level `build.gradle` file:
 
 <Tabs queryString="lang">

--- a/theoplayer/how-to-guides/android/media3/getting-started.mdx
+++ b/theoplayer/how-to-guides/android/media3/getting-started.mdx
@@ -95,6 +95,7 @@ Once the Media3PlayerIntegration is added to the player, all subsequent sources 
         ```
     </TabItem>
     <!-- prettier-ignore-end -->
+
 </Tabs>
 
 By default, the `Media3PlayerIntegration` will play all types of sources except Millicast.

--- a/theoplayer/how-to-guides/android/media3/getting-started.mdx
+++ b/theoplayer/how-to-guides/android/media3/getting-started.mdx
@@ -133,7 +133,7 @@ when constructing the integration.
 
 As this integration is still under development, there are currently some known limitations and features that are still under development and not yet supported:
 
-- The ABR, network and metrics APIs are not yet implemented and return dummy values.
+- The ABR, network, metrics and caching (offline playback) APIs are not yet implemented and return dummy values.
 - The latency API is currently only supported for HESP/THEOlive streams.
 - Millicast playback is not yet supported, and must always be handled by the [Millicast integration](../millicast/getting-started.mdx).
 - Certain player and source configuration parameters are not yet handled.

--- a/theoplayer/how-to-guides/android/media3/getting-started.mdx
+++ b/theoplayer/how-to-guides/android/media3/getting-started.mdx
@@ -132,7 +132,8 @@ when constructing the integration.
 
 As this integration is still under development, there are currently some known limitations and features that are still under development and not yet supported:
 
-- The ABR, network, metrics and latency APIs are not yet implemented and return dummy values.
+- The ABR, network and metrics APIs are not yet implemented and return dummy values.
+- The latency API is currently only supported for HESP/THEOlive streams.
 - Millicast playback is not yet supported, and must always be handled by the [Millicast integration](../millicast/getting-started.mdx).
 - Certain player and source configuration parameters are not yet handled.
 - Certain player events may not yet be dispatched correctly.


### PR DESCRIPTION
* We're now publishing the Media3 integration to releases, so we don't need to talk about the snapshots repository anymore.
* A lot of previously known limitations have now been partially or fully fixed.