### PR TITLE
Index THEOlive docs

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -204,11 +204,6 @@ const config: Config = {
         path: 'theolive',
         routeBasePath: '/theolive',
         sidebarPath: './sidebarsTheolive.ts',
-        versions: {
-          current: {
-            noIndex: true,
-          },
-        },
       },
     ],
     [


### PR DESCRIPTION
It looks like this configuration was copied over from our "contributing" section, which we don't want to index. However, THEOlive docs *should* be indexed.