### PR TITLE
Add separate workflow to build PRs from forks

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,29 @@
+name: Build pull request
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+concurrency: build-${{ github.ref }}
+jobs:
+  pr-preview:
+    runs-on: ubuntu-latest
+    # Run only on PRs from forks.
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: true
+      # Build the website
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Build
+        run: |
+          npm ci
+          npm run build

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -7,7 +7,7 @@ on:
       - synchronize
 concurrency: build-${{ github.ref }}
 jobs:
-  pr-preview:
+  build:
     runs-on: ubuntu-latest
     # Run only on PRs from forks.
     if: ${{ github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,6 +10,8 @@ concurrency: preview-${{ github.ref }}
 jobs:
   pr-preview:
     runs-on: ubuntu-latest
+    # Do not run on PRs from forks, since they don't have the permissions to deploy to our GitHub pages branch.
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
       - name: Create app token
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
At the moment, we can't deploy pull request previews for forks [due to a limitation of rossjrw/pr-preview-action](https://github.com/rossjrw/pr-preview-action/pull/6) (and also because of security considerations). However, we still want to run *some* checks on such PRs, so we can detect common problems like Markdown errors or broken links.

This adds a separate workflow specific for PRs from forks, which only builds the website without deploying it. The deploy preview workflow is now limited to run only on our own non-fork PRs.