### PR TITLE
Update feeds-webhooks.md add priority and reverting sourceId/simulcastId in feed:hooks

### DIFF
--- a/millicast/webhooks/feeds-webhooks.md
+++ b/millicast/webhooks/feeds-webhooks.md
@@ -28,12 +28,11 @@ The `data` payload will contain the following details:
 - **streamId** is the combination of account and stream name to identify the playback url.
 - **started** is the epoch time for when the stream was started.
 - **active** is a boolean flag indicating if the feed is still currently active when the hook fired.
-- **sourceId** is the unique identifier for the feed that was specified as a parameter in the publish url.
 
 Optionally the webhook may include:
 
 - **ended** is an epoch time for when the publishing feed was ended (only included when the stream has ended).
-- **simulcastId** is the identifier that associates this feed with a simulcast layer (only included when specified in the publish url).
+- **priority** if specified identifies the priority of a redundant ingest.
 
 ## Examples
 

--- a/millicast/webhooks/feeds-webhooks.md
+++ b/millicast/webhooks/feeds-webhooks.md
@@ -32,7 +32,7 @@ The `data` payload will contain the following details:
 Optionally the webhook may include:
 
 - **ended** is an epoch time for when the publishing feed was ended (only included when the stream has ended).
-- **priority** if specified identifies the priority of a redundant ingest.
+- **priority** is a numeric value identifying the priority of an ingest when using [redundant streams](/millicast/broadcast/redundant-ingest/index.mdx).
 
 ## Examples
 


### PR DESCRIPTION
We needed to revert the sourceId/simulcastId changes for 3.0.0 and will release them not long away in 3.0.1 

For now I am reverting the changes made for them in the docs, but we also forgot to add the priority optional field which I have added in this doc update.