### PR TITLE
Collapse old versions in changelog

### DIFF
--- a/src/theme/Details/index.tsx
+++ b/src/theme/Details/index.tsx
@@ -1,0 +1,14 @@
+import React, { type ReactNode } from 'react';
+import clsx from 'clsx';
+import { Details as DetailsGeneric } from '@docusaurus/theme-common/Details';
+import type { Props } from '@theme/Details';
+
+import styles from './styles.module.css';
+
+// Should we have a custom details/summary comp in Infima instead of reusing
+// alert classes?
+const InfimaClasses = 'alert alert--info';
+
+export default function Details({ ...props }: Props): ReactNode {
+  return <DetailsGeneric {...props} className={clsx(InfimaClasses, styles.details, props.className)} />;
+}

--- a/src/theme/Details/index.tsx
+++ b/src/theme/Details/index.tsx
@@ -1,6 +1,5 @@
 import React, { type ReactNode } from 'react';
 import clsx from 'clsx';
-import { Details as DetailsGeneric } from '@docusaurus/theme-common/Details';
 import type { Props } from '@theme/Details';
 
 import styles from './styles.module.css';
@@ -9,6 +8,13 @@ import styles from './styles.module.css';
 // alert classes?
 const InfimaClasses = 'alert alert--info';
 
-export default function Details({ ...props }: Props): ReactNode {
-  return <DetailsGeneric {...props} className={clsx(InfimaClasses, styles.details, props.className)} />;
+export default function Details({ summary, className, children, ...props }: Props): ReactNode {
+  const summaryElement = React.isValidElement(summary) ? summary : <summary>{summary ?? 'Details'}</summary>;
+
+  return (
+    <details {...props} className={clsx(InfimaClasses, styles.details, className)}>
+      {summaryElement}
+      <div className={styles.collapsibleContent}>{children}</div>
+    </details>
+  );
 }

--- a/src/theme/Details/index.tsx
+++ b/src/theme/Details/index.tsx
@@ -1,18 +1,58 @@
-import React, { type ReactNode } from 'react';
+import React, { type ReactNode, useRef, useState } from 'react';
 import clsx from 'clsx';
 import type { Props } from '@theme/Details';
-
 import styles from './styles.module.css';
+
+function isInSummary(node: HTMLElement | null): boolean {
+  if (!node) {
+    return false;
+  }
+  return node.tagName === 'SUMMARY' || isInSummary(node.parentElement);
+}
+
+function hasParent(node: HTMLElement | null, parent: HTMLElement): boolean {
+  if (!node) {
+    return false;
+  }
+  return node === parent || hasParent(node.parentElement, parent);
+}
 
 // Should we have a custom details/summary comp in Infima instead of reusing
 // alert classes?
 const InfimaClasses = 'alert alert--info';
 
 export default function Details({ summary, className, children, ...props }: Props): ReactNode {
+  const detailsRef = useRef<HTMLDetailsElement>(null);
   const summaryElement = React.isValidElement(summary) ? summary : <summary>{summary ?? 'Details'}</summary>;
+  const [open, setOpen] = useState(props.open);
 
   return (
-    <details {...props} className={clsx(InfimaClasses, styles.details, className)}>
+    <details
+      {...props}
+      ref={detailsRef}
+      open={open}
+      className={clsx(InfimaClasses, styles.details, className)}
+      onMouseDown={(e) => {
+        const target = e.target as HTMLElement;
+        // Prevent a double-click to highlight summary text
+        if (isInSummary(target) && e.detail > 1) {
+          e.preventDefault();
+        }
+      }}
+      onClick={(e) => {
+        e.stopPropagation(); // For isolation of multiple nested details/summary
+        const target = e.target as HTMLElement;
+        const shouldToggle = isInSummary(target) && hasParent(target, detailsRef.current!);
+        if (!shouldToggle) {
+          return;
+        }
+        e.preventDefault();
+        setOpen(!open);
+      }}
+      onToggle={() => {
+        setOpen(detailsRef.current!.open);
+      }}
+    >
       {summaryElement}
       <div className={styles.collapsibleContent}>{children}</div>
     </details>

--- a/src/theme/Details/styles.module.css
+++ b/src/theme/Details/styles.module.css
@@ -1,0 +1,6 @@
+.details {
+  --docusaurus-details-decoration-color: var(--ifm-alert-border-color);
+  --docusaurus-details-transition: transform var(--ifm-transition-fast) ease;
+  margin: 0 0 var(--ifm-spacing-vertical);
+  border: 1px solid var(--ifm-alert-border-color);
+}

--- a/src/theme/Details/styles.module.css
+++ b/src/theme/Details/styles.module.css
@@ -1,6 +1,55 @@
 .details {
-  --docusaurus-details-decoration-color: var(--ifm-alert-border-color);
-  --docusaurus-details-transition: transform var(--ifm-transition-fast) ease;
+  --docusaurus-details-summary-arrow-size: 0.38rem;
+  --docusaurus-details-decoration-color: var(--ifm-alert-border-color, grey);
+  --docusaurus-details-transition: transform var(--ifm-transition-fast, 200ms) ease;
   margin: 0 0 var(--ifm-spacing-vertical);
   border: 1px solid var(--ifm-alert-border-color);
+}
+
+.details > summary {
+  position: relative;
+  cursor: pointer;
+  list-style: none;
+  padding-left: 1rem;
+}
+
+/* TODO: deprecation, need to remove this after Safari will support `::marker` */
+.details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.details > summary::before {
+  position: absolute;
+  top: 0.45rem;
+  left: 0;
+
+  /* CSS-only Arrow */
+  content: '';
+  border-width: var(--docusaurus-details-summary-arrow-size);
+  border-style: solid;
+  border-color: transparent transparent transparent var(--docusaurus-details-decoration-color);
+
+  /* Arrow rotation anim */
+  transform: rotate(0deg);
+  transition: var(--docusaurus-details-transition);
+  transform-origin: calc(var(--docusaurus-details-summary-arrow-size) / 2) 50%;
+}
+
+/* Use the open property for arrow animation */
+.details[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.collapsibleContent {
+  margin-top: 1rem;
+  border-top: 1px solid var(--docusaurus-details-decoration-color);
+  padding-top: 1rem;
+}
+
+.collapsibleContent p:last-child {
+  margin-bottom: 0;
+}
+
+.details > summary > p:last-child {
+  margin-bottom: 0;
 }

--- a/src/theme/Details/styles.module.css
+++ b/src/theme/Details/styles.module.css
@@ -1,7 +1,8 @@
 .details {
   --docusaurus-details-summary-arrow-size: 0.38rem;
   --docusaurus-details-decoration-color: var(--ifm-alert-border-color, grey);
-  --docusaurus-details-transition: transform var(--ifm-transition-fast, 200ms) ease;
+  --docusaurus-details-transition-duration: var(--ifm-transition-fast, 200ms);
+  --docusaurus-details-transition: transform var(--docusaurus-details-transition-duration) ease;
   margin: 0 0 var(--ifm-spacing-vertical);
   border: 1px solid var(--ifm-alert-border-color);
 }
@@ -52,4 +53,26 @@
 
 .details > summary > p:last-child {
   margin-bottom: 0;
+}
+
+/* https://nerdy.dev/open-and-close-transitions-for-the-details-element */
+@media (prefers-reduced-motion: no-preference) {
+  .details {
+    interpolate-size: allow-keywords;
+  }
+}
+
+.details::details-content {
+  opacity: 0;
+  height: 0;
+  overflow-y: clip;
+  transition:
+    content-visibility var(--docusaurus-details-transition-duration) allow-discrete,
+    opacity var(--docusaurus-details-transition-duration),
+    height var(--docusaurus-details-transition-duration);
+}
+
+.details[open]::details-content {
+  opacity: 1;
+  height: auto;
 }

--- a/theoplayer/changelog.md
+++ b/theoplayer/changelog.md
@@ -499,7 +499,7 @@ For more info on navigating our breaking changes, take a look at our migration g
 - Fixed an issue where license checks would not properly display error messages for different issues with licenses.
 - Fixed an issue where app crashes could occur due to lingering listeners after destroying the player instance.
 
-<details name="major-version">
+<details>
 <summary>Version 8</summary>
 
 ## 🚀 8.14.0 (2025/03/26)
@@ -1518,7 +1518,7 @@ For more info on navigating our breaking changes, take a look at our migration g
 - Deprecating all THEOplayer Objective-C API support. Existing APIs will still continue to work until next major release, but additional support for new APIs will discontinue. When it was introduced, the goal of the Objective-C APIs was to provide bindings to bridge our native SDK to React Native. Over time that became unneeded as Swift became capable of accomplishing the goal. Please contact us for support in case your codebase relies on the Objective-C APIs.
 
 </details>
-<details name="major-version">
+<details>
 <summary>Version 7</summary>
 
 ## 🚀 7.12.0 (2024/09/05)
@@ -2134,7 +2134,7 @@ THEOplayer 7.0 is **backwards compatible for most features but includes some bre
 - Removed deprecated `MenuItem` and `MenuLayoutConfigurator` types.
 
 </details>
-<details name="major-version">
+<details>
 <summary>Version 6</summary>
 
 ## 🚀 6.13.0 (2024/03/28)
@@ -2883,7 +2883,7 @@ THEOplayer 6.0 is **backwards compatible for most features but includes some bre
 - Deprecated `THEOplayer.requestSeekable` in favor of `THEOplayer.seekable`.
 
 </details>
-<details name="major-version">
+<details>
 <summary>Version 5</summary>
 
 ## 🚀 5.11.0 (2023/09/11)
@@ -3633,7 +3633,7 @@ THEOplayer 5.0 is **backwards compatible for most features but includes some bre
 - Added `THEOplayer.developerSettings` API to host developer-friendly settings and experimental features
 
 </details>
-<details name="major-version">
+<details>
 <summary>Version 4</summary>
 
 ## 🚀 4.12.9 (2024/05/13)
@@ -4681,7 +4681,7 @@ Introducing a major version bump to THEOplayer 4.0. This version officially rele
 - Please start migrating your projects to be compatible with the Swift 5.5 compiler (Xcode 13) or later. Starting from THEOplayerSDK 5.0.0 we will only support Swift 5.5 or higher.
 
 </details>
-<details name="major-version">
+<details>
 <summary>Version 3</summary>
 
 ## 🚀 3.7.0 (2022/08/01)
@@ -5290,7 +5290,7 @@ Some features are not yet supported, therefore, only the above-mentioned feature
 - Fix an issue where fullscreen device orientation was broken when using fullscreenOrientationCoupling.
 
 </details>
-<details name="major-version">
+<details>
 <summary>Version 2</summary>
 
 ## 🚀 2.92.0 (2021/12/17)

--- a/theoplayer/changelog.md
+++ b/theoplayer/changelog.md
@@ -499,6 +499,9 @@ For more info on navigating our breaking changes, take a look at our migration g
 - Fixed an issue where license checks would not properly display error messages for different issues with licenses.
 - Fixed an issue where app crashes could occur due to lingering listeners after destroying the player instance.
 
+<details name="major-version">
+<summary>Version 8</summary>
+
 ## 🚀 8.14.0 (2025/03/26)
 
 ### Web
@@ -1514,6 +1517,10 @@ For more info on navigating our breaking changes, take a look at our migration g
 
 - Deprecating all THEOplayer Objective-C API support. Existing APIs will still continue to work until next major release, but additional support for new APIs will discontinue. When it was introduced, the goal of the Objective-C APIs was to provide bindings to bridge our native SDK to React Native. Over time that became unneeded as Swift became capable of accomplishing the goal. Please contact us for support in case your codebase relies on the Objective-C APIs.
 
+</details>
+<details name="major-version">
+<summary>Version 7</summary>
+
 ## 🚀 7.12.0 (2024/09/05)
 
 ### General
@@ -2125,6 +2132,10 @@ THEOplayer 7.0 is **backwards compatible for most features but includes some bre
 
 - Removed deprecated tvOS specific `THEOplayer` initializers.
 - Removed deprecated `MenuItem` and `MenuLayoutConfigurator` types.
+
+</details>
+<details name="major-version">
+<summary>Version 6</summary>
 
 ## 🚀 6.13.0 (2024/03/28)
 
@@ -2871,6 +2882,10 @@ THEOplayer 6.0 is **backwards compatible for most features but includes some bre
 - Deprecated `THEOplayer.requestMetrics` in favor of `THEOplayer.metrics`.
 - Deprecated `THEOplayer.requestSeekable` in favor of `THEOplayer.seekable`.
 
+</details>
+<details name="major-version">
+<summary>Version 5</summary>
+
 ## 🚀 5.11.0 (2023/09/11)
 
 ### General
@@ -3616,6 +3631,10 @@ THEOplayer 5.0 is **backwards compatible for most features but includes some bre
 - Added integration support via `THEOplayer.addIntegration()` API
 - Added TextTrack styling support via `THEOplayer.textTrackStyle` API
 - Added `THEOplayer.developerSettings` API to host developer-friendly settings and experimental features
+
+</details>
+<details name="major-version">
+<summary>Version 4</summary>
 
 ## 🚀 4.12.9 (2024/05/13)
 
@@ -4661,6 +4680,10 @@ Introducing a major version bump to THEOplayer 4.0. This version officially rele
 - Swift 5.3 (XCode 12.4) is deprecated.
 - Please start migrating your projects to be compatible with the Swift 5.5 compiler (Xcode 13) or later. Starting from THEOplayerSDK 5.0.0 we will only support Swift 5.5 or higher.
 
+</details>
+<details name="major-version">
+<summary>Version 3</summary>
+
 ## 🚀 3.7.0 (2022/08/01)
 
 ### General
@@ -5265,6 +5288,10 @@ Some features are not yet supported, therefore, only the above-mentioned feature
 #### 🐛 Issues
 
 - Fix an issue where fullscreen device orientation was broken when using fullscreenOrientationCoupling.
+
+</details>
+<details name="major-version">
+<summary>Version 2</summary>
 
 ## 🚀 2.92.0 (2021/12/17)
 
@@ -9865,3 +9892,5 @@ Some features are not yet supported, therefore, only the above-mentioned feature
 - When present, PSSH headers now get read from the manifest in order to kick start the DRM flow
 - Support for the presentationTimeOffset MPEG-DASH MPD attribute has been added to the player
 - Various small improvements in the flow and stability of the player
+
+</details>


### PR DESCRIPTION
The THEOplayer changelog is getting very long, which means the page is taking long to render as well. In order to optimize this, I had the idea of grouping the older versions into a `<details>` element for each major version. That way, initially you will only see versions of the latest major, and you can expand an older major at the bottom if you're looking for an older version.

I had to swizzle Docusaurus' `<Details>` component to not use `<Collapsible>`, because we don't want the inner content to have `display: none` and thus be unavailable for Ctrl+F search and anchor links. Moreover, we want anchor links to auto-expand the details element, e.g. navigating to `/theoplayer/changelog/#-800-20240909` should expand the "version 8" group. This is based largely on ideas from https://github.com/facebook/docusaurus/issues/10055#issuecomment-2064108252 and https://github.com/facebook/docusaurus/issues/10055#issuecomment-2383713345.

To do:
* Auto-expand on anchor links seems to only work in Chrome. We might need to add a bit of JavaScript to do that in other browsers?
* Clicking any anchor link on the changelog page is still very slow... It looks like the whole page is being re-rendered on every click for some reason? I might have to raise an issue upstream...