### PR TITLE
Add headings to supported platforms page for better ToC

### DIFF
--- a/theoplayer/faq/81-supported-platforms.md
+++ b/theoplayer/faq/81-supported-platforms.md
@@ -12,7 +12,7 @@ description: List of supported platforms for the different THEOplayer SDKs
       <th></th>
       <th colspan="2">HLS</th>
       <th colspan="2">MPEG-DASH</th>
-      <th colspan="2">HESP [^hesp] [^protocols]</th>
+      <th colspan="2">HESP [^hesp]</th>
     </tr>
     <tr>
       <th></th>

--- a/theoplayer/faq/81-supported-platforms.md
+++ b/theoplayer/faq/81-supported-platforms.md
@@ -26,7 +26,9 @@ description: List of supported platforms for the different THEOplayer SDKs
         <td>Content Protection & DRM</td>
       </tr>
       <tr>
-        <th colspan="7">Desktop Browser Platforms</th>
+        <th colspan="7">
+        ### Desktop Browser Platforms
+        </th>
       </tr>
       <tr>
         <th>Chrome (and Chromium based)</th>
@@ -131,7 +133,9 @@ description: List of supported platforms for the different THEOplayer SDKs
         <td>Fairplay DRM</td>
       </tr>
       <tr>
-        <th colspan="7">Mobile Browser Platforms</th>
+        <th colspan="7">
+        ### Mobile Browser Platforms
+        </th>
       </tr>
       <tr>
         <th>Chrome for Android</th>
@@ -200,7 +204,9 @@ description: List of supported platforms for the different THEOplayer SDKs
         <td>Fairplay DRM</td>
       </tr>
       <tr>
-        <th colspan="7">Connected devices and smart TV platforms</th>
+        <th colspan="7">
+        ### Connected devices and smart TV platforms
+        </th>
       </tr>
       <tr>
         <th>Samsung Tizen</th>
@@ -559,7 +565,9 @@ description: List of supported platforms for the different THEOplayer SDKs
         <td><a href="https://optiview.dolby.com/contact/">Contact us</a></td>
       </tr>
       <tr>
-        <th colspan="7">Casting</th>
+        <th colspan="7">
+        ### Casting
+        </th>
       </tr>
       <tr>
         <th>Apple Airplay</th>
@@ -626,7 +634,9 @@ description: List of supported platforms for the different THEOplayer SDKs
         <td>Content Protection & DRM</td>
       </tr>
       <tr>
-        <th colspan="7">Desktop Browser Platforms</th>
+        <th colspan="7">
+        ### Desktop Browser Platforms
+        </th>
       </tr>
       <tr>
         <th>Chrome (and Chromium based)</th>
@@ -731,7 +741,9 @@ description: List of supported platforms for the different THEOplayer SDKs
         <td>Fairplay DRM</td>
       </tr>
       <tr>
-        <th colspan="7">Mobile Browser Platforms</th>
+        <th colspan="7">
+        ### Mobile Browser Platforms
+        </th>
       </tr>
       <tr>
         <th>Chrome for Android</th>
@@ -800,7 +812,9 @@ description: List of supported platforms for the different THEOplayer SDKs
         <td>Fairplay DRM</td>
       </tr>
       <tr>
-        <th colspan="7">Connected devices and smart TV platforms</th>
+        <th colspan="7">
+        ### Connected devices and smart TV platforms
+        </th>
       </tr>
       <tr>
         <th>Samsung Tizen</th>
@@ -870,7 +884,9 @@ description: List of supported platforms for the different THEOplayer SDKs
         <td><a href="https://optiview.dolby.com/contact/">Contact us</a></td>
       </tr>
       <tr>
-        <th colspan="7">Native Apps</th>
+        <th colspan="7">
+        ### Native Apps
+        </th>
       </tr>
       <tr>
         <th>iOS</th>
@@ -984,7 +1000,9 @@ description: List of supported platforms for the different THEOplayer SDKs
         <td><a href="https://optiview.dolby.com/contact/">Contact us</a></td>
       </tr>
       <tr>
-        <th colspan="7">Casting</th>
+        <th colspan="7">
+        ### Casting
+        </th>
       </tr>
       <tr>
         <th>Apple Airplay</th>
@@ -1051,7 +1069,9 @@ description: List of supported platforms for the different THEOplayer SDKs
         <td>Content Protection & DRM</td>
       </tr>
       <tr>
-        <th colspan="7">Desktop Browser Platforms</th>
+        <th colspan="7">
+        ### Desktop Browser Platforms
+        </th>
       </tr>
       <tr>
         <th>Chrome (and Chromium based)</th>
@@ -1156,7 +1176,9 @@ description: List of supported platforms for the different THEOplayer SDKs
         <td>Fairplay DRM</td>
       </tr>
       <tr>
-        <th colspan="7">Mobile Browser Platforms</th>
+        <th colspan="7">
+        ### Mobile Browser Platforms
+        </th>
       </tr>
       <tr>
         <th>Chrome for Android</th>
@@ -1225,7 +1247,9 @@ description: List of supported platforms for the different THEOplayer SDKs
         <td>Fairplay DRM</td>
       </tr>
       <tr>
-        <th colspan="7">Native Apps</th>
+        <th colspan="7">
+        ### Native Apps
+        </th>
       </tr>
       <tr>
         <th>iOS</th>

--- a/theoplayer/faq/81-supported-platforms.md
+++ b/theoplayer/faq/81-supported-platforms.md
@@ -14,17 +14,17 @@ description: List of supported platforms for the different THEOplayer SDKs
       <th colspan="2">MPEG-DASH</th>
       <th colspan="2">HESP [^hesp] [^protocols]</th>
     </tr>
+    <tr>
+      <th></th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+    </tr>
   </thead>
   <tbody>
-      <tr>
-        <td></td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-      </tr>
       <tr>
         <th colspan="7">
         ### Desktop Browser Platforms
@@ -377,17 +377,17 @@ description: List of supported platforms for the different THEOplayer SDKs
       <th colspan="2">MPEG-DASH</th>
       <th colspan="2">HESP (*)</th>
     </tr>
+    <tr>
+      <th></th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+    </tr>
   </thead>
   <tbody>
-      <tr>
-        <td></td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-      </tr>
       <tr>
         <th>iOS</th>
         <td>13+</td>
@@ -440,17 +440,17 @@ description: List of supported platforms for the different THEOplayer SDKs
       <th colspan="2">MPEG-DASH</th>
       <th colspan="2">HESP (*)</th>
     </tr>
+    <tr>
+      <th></th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+    </tr>
   </thead>
   <tbody>
-      <tr>
-        <td></td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-      </tr>
       <tr>
         <th>Android</th>
         <td>5.0+</td>
@@ -529,17 +529,17 @@ description: List of supported platforms for the different THEOplayer SDKs
       <th colspan="2">MPEG-DASH</th>
       <th colspan="2">HESP (*)</th>
     </tr>
+    <tr>
+      <th></th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+    </tr>
   </thead>
   <tbody>
-      <tr>
-        <td></td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-      </tr>
       <tr>
         <th>Roku OS</th>
         <td>
@@ -622,17 +622,17 @@ description: List of supported platforms for the different THEOplayer SDKs
       <th colspan="2">MPEG-DASH</th>
       <th colspan="2">HESP (*)</th>
     </tr>
+    <tr>
+      <th></th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+    </tr>
   </thead>
   <tbody>
-      <tr>
-        <td></td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-      </tr>
       <tr>
         <th colspan="7">
         ### Desktop Browser Platforms
@@ -1057,17 +1057,17 @@ description: List of supported platforms for the different THEOplayer SDKs
       <th colspan="2">MPEG-DASH</th>
       <th colspan="2">HESP (*)</th>
     </tr>
+    <tr>
+      <th></th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+      <th>Version</th>
+      <th>Content Protection & DRM</th>
+    </tr>
   </thead>
   <tbody>
-      <tr>
-        <td></td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-        <td>Version</td>
-        <td>Content Protection & DRM</td>
-      </tr>
       <tr>
         <th colspan="7">
         ### Desktop Browser Platforms


### PR DESCRIPTION
Apparently HTML headings don't show up in the table of contents, so you *have* to use Markdown headings [(see docs)](https://docusaurus.io/docs/markdown-features/toc#customizing-table-of-contents-generation). It's always a bit awkward to mix HTML and Markdown, but at least it works. 😛

I also moved "version" and "DRM" into the `<thead>`. (Yes, you're allowed to have two `<tr>`s inside a single `<thead>`. 😉)