### PR TITLE
Invalidate everything on CloudFront

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,4 +41,4 @@ jobs:
           aws s3 sync --delete ./build s3://docs-staging-optiview-dolby-com-0-20250610142618642800000001/docs/
       - name: Invalidate CloudFront
         run: |
-          aws cloudfront create-invalidation --distribution-id E15SU691K20UEP --paths '/docs/*'
+          aws cloudfront create-invalidation --distribution-id E15SU691K20UEP --paths '/*'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,4 +44,4 @@ jobs:
           aws s3 sync --delete ./build s3://docs-optiview-dolby-com-0-20250401191057436800000003/docs/
       - name: Invalidate CloudFront
         run: |
-          aws cloudfront create-invalidation --distribution-id EKPRWRE0B1EQ4 --paths '/docs/*'
+          aws cloudfront create-invalidation --distribution-id EKPRWRE0B1EQ4 --paths '/*'


### PR DESCRIPTION
Apparently this is needed? It doesn't make much of a difference, since the S3 bucket should *only* contain the docs. 🤷‍♂️