### PR TITLE
Token based security for THEOlive on React Native and Roku

### DIFF
--- a/theolive/playback/flutter/_category_.json
+++ b/theolive/playback/flutter/_category_.json
@@ -1,7 +1,7 @@
 {
   "label": "Flutter",
   "description": "Start with THEOlive on cross-platform apps with Flutter.",
-  "position": 2,
+  "position": 3,
   "customProps": {
     "icon": "flutter"
   }

--- a/theolive/playback/ios/00-getting-started.mdx
+++ b/theolive/playback/ios/00-getting-started.mdx
@@ -22,4 +22,4 @@ theoplayer.source = SourceDescription(source: TheoLiveSource(channelId: "3aa5qyl
 
 ## More information
 
-- [API references](/theoplayer/v9/api-reference/ios/)
+- [API references](pathname:///theoplayer/v9/api-reference/ios/)

--- a/theolive/playback/ios/00-getting-started.mdx
+++ b/theolive/playback/ios/00-getting-started.mdx
@@ -1,0 +1,20 @@
+---
+sidebar_position: 1
+sidebar_label: Getting started with iOS
+---
+
+# Getting started with THEOlive on iOS
+
+## Usage
+
+1. Follow [our Getting Started guide](/theoplayer/getting-started/sdks/ios/getting-started)
+   to set up THEOplayer in your iOS app.
+2. Add a THEOlive source to your player's source.
+
+### Add a THEOlive source
+
+TODO
+
+## More information
+
+- [API references](/theoplayer/v9/api-reference/ios/)

--- a/theolive/playback/ios/00-getting-started.mdx
+++ b/theolive/playback/ios/00-getting-started.mdx
@@ -13,7 +13,12 @@ sidebar_label: Getting started with iOS
 
 ### Add a THEOlive source
 
-TODO
+After setting up your THEOplayer in your app, set its source to a `SourceDescription` containing a `TheoLiveSource`.
+You'll need a THEOlive channel ID:
+
+```swift
+theoplayer.source = SourceDescription(source: TheoLiveSource(channelId: "3aa5qylwwk7gijsobayq09yee"))
+```
 
 ## More information
 

--- a/theolive/playback/ios/_category_.json
+++ b/theolive/playback/ios/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "iOS",
+  "description": "Start with THEOlive on iOS/tvOS.",
+  "position": 2,
+  "customProps": {
+    "icon": "🍎"
+  }
+}

--- a/theolive/playback/react-native/00-getting-started.mdx
+++ b/theolive/playback/react-native/00-getting-started.mdx
@@ -13,7 +13,17 @@ sidebar_label: Getting started with React Native
 
 ### Add a THEOlive source
 
-TODO
+After setting up your THEOplayer on your web page, set its source to a `SourceDescription` containing a `THEOliveSource`.
+You'll need a THEOlive channel ID:
+
+```javascript
+player.source = {
+  sources: {
+    type: 'theolive',
+    src: 'your-channel-id',
+  },
+};
+```
 
 ## More information
 

--- a/theolive/playback/react-native/00-getting-started.mdx
+++ b/theolive/playback/react-native/00-getting-started.mdx
@@ -1,0 +1,20 @@
+---
+sidebar_position: 1
+sidebar_label: Getting started with React Native
+---
+
+# Getting started with THEOlive on React Native
+
+## Usage
+
+1. Follow [our Getting Started guide](/theoplayer/getting-started/frameworks/react-native/getting-started/)
+   to set up THEOplayer in your React Native app.
+2. Add a THEOlive source to your player's source.
+
+### Add a THEOlive source
+
+TODO
+
+## More information
+
+- [API references](https://theoplayer.github.io/react-native-theoplayer/api/)

--- a/theolive/playback/react-native/_category_.json
+++ b/theolive/playback/react-native/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "React Native",
+  "description": "Start with THEOlive on React Native.",
+  "position": 3,
+  "customProps": {
+    "icon": "⚛️"
+  }
+}

--- a/theolive/playback/react-native/token-based-security.mdx
+++ b/theolive/playback/react-native/token-based-security.mdx
@@ -1,6 +1,6 @@
 # Token based security
 
-THEOlive offers the option to enable JWT token security on channel alias level. This can be interesting if you only want valid users to access your stream. Read more about the feature and configuring it on your channels on the [token based security guide](/theolive/platform/security/token-based-security).
+THEOlive offers the option to enable JWT token security on channel distribution level. This can be interesting if you only want valid users to access your stream. Read more about the feature and configuring it on your channels on the [token based security guide](/theolive/platform/security/token-based-security).
 
 This page will demonstrate how to configure the React Native Player SDK for playback of channels with token based security enabled.
 

--- a/theolive/playback/react-native/token-based-security.mdx
+++ b/theolive/playback/react-native/token-based-security.mdx
@@ -1,0 +1,143 @@
+# Token based security
+
+THEOlive offers the option to enable JWT token security on channel alias level. This can be interesting if you only want valid users to access your stream. Read more about the feature and configuring it on your channels on the [token based security guide](/theolive/platform/security/token-based-security).
+
+This page will demonstrate how to configure the React Native Player SDK for playback of channels with token based security enabled.
+
+## Setting up the React Native THEOplayer SDK for THEOlive
+
+Refer to the [getting started guide](../getting-started) for the prerequisite steps in getting the React Native SDK up and running for THEOlive playback.
+
+## Configuring THEOplayer to pass the token
+
+The token needs to be passed along with player requests as a Bearer token in the `Authorization` header of the requests. To do so we can make use of the Network API of the player, which on React Native works as follows:
+
+```
+const token = getToken(); // Generate or request your token, for more information check the token based security guide linked above.
+player.network.setHeader('Authorization', `Bearer ${token}`);
+```
+
+This will ensure the player includes your authorization header on all subsequent requests it performs for playback of your THEOlive channel.
+
+## Dealing with token expiry and rotation
+
+If your tokens are short-lived, you want to make sure to update the token being passed to the player and requests before it expires, to allow playback to continue beyond expiry. This can simply be done by updating the header on the player in the same way. For example, one could check on an interval that makes sense for your token lifespan whether the token is about to expire and update when necessary, for example:
+
+```
+let token;
+
+// Helper function to check whether your token will expire within one minute from now
+function tokenWillExpireSoon() {
+  const payload = JSON.parse(atob(token.split('.')[1]));
+  const exp = payload.exp; // in seconds
+  const now = Math.floor(Date.now() / 1000); // current time in seconds
+  return exp - now <= 60;
+}
+
+function maybeUpdateToken() {
+  if (!token || tokenWillExpireSoon(token)) {
+    token = getToken(); // Generate or request your token, for more information check the token based security guide linked above.
+    player.network.setHeader('Authorization', `Bearer ${token}`);
+  }
+}
+
+maybeUpdateToken();
+setInterval(maybeUpdateToken, 30000); // Check every 30 seconds
+```
+
+## Clearing the token
+
+If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-theolive source altogether, the header can be simply removed as follows:
+
+```
+player.network.removeHeader('Authorization');
+```
+
+## Enabling Token Based Security for Safari browsers on iOS \<17
+
+Apple devices running an iOS version lower than 17.1 do not support MSE, therefore there are limitations with what is possible when playing a THEOlive stream. One such limitation is that the above network API approach does not work on those devices. Instead, a service worker needs to be registered to support playback of JWT enabled streams.
+
+The service worker needs to intercept the `fetch` requests originating from the app, to be able to include the `Authorization` header to the requests.
+
+A code snippet for the service worker code is shared below.
+
+:::note
+Service worker registration is only possible in a secure environment (`https://`) or on `localhost`. There can also only be one service worker active, so if your environment or application already has a service worker active, you will need to include the additional functionality in that service worker.
+:::
+
+```javascript title="iOS Safari service worker"
+self.addEventListener('install', () => {
+  console.log('Service worker installed!');
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  console.log('Service Worker activated');
+  // Claim clients so the service worker is in effect immediately
+  event.waitUntil(self.clients.claim());
+});
+
+// Intercept the fetch event and add in your JWT
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    (async function () {
+      try {
+        const url = new URL(event.request.url);
+        if (!url.origin.endsWith('theo.live')) {
+          // Requests not made by the player for playback of the THEOlive channel should not be modified.
+          return fetch(event.request);
+        }
+        const token = getToken(); // Generate or request your token, for more information check the token based security guide linked above.
+        // Clone the request and add the JWT header
+        const modifiedRequest = new Request(event.request, {
+          headers: {
+            ...Object.fromEntries(event.request.headers.entries()),
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        return fetch(modifiedRequest);
+      } catch (error) {
+        console.error('Error in fetch handler:', error);
+        return new Response('Service Worker Error', { status: 500 });
+      }
+    })()
+  );
+});
+```
+
+:::note
+In order for the service worker to be able to intercept requests made from the player library, it's scope must include the player sdk files. That means the player and service worker must be hosted on the same path or the player must be hosted in a subfolder of the path where the service worker is hosted.
+:::
+
+To register this service worker in to your code, you can attach it this way.
+
+```javascript title="Register service worker"
+function registerServiceWorker() {
+  if (!('serviceWorker' in navigator)) {
+    console.error('Service worker not supported!');
+    return;
+  }
+  const serviceWorkerScope = "/service/worker/path" // Replace with your own path to the service worker location.
+  const serviceWorkerPath = "${root}/service-worker.js"; // Replace with the filename of your service worker.
+
+  // We recommend unregistering actively before (re-)registering as we've seen issues where hard reloads could cause issues if the service worker wasn't unregistered.
+  const registration = await navigator.serviceWorker.getRegistration(serviceWorkerPath);
+  await registration?.unregister();
+
+  navigator.serviceWorker
+    .register(serviceWorkerPath, {
+      scope: serviceWorkerScope,
+    })
+    .then((reg) => {
+      if (reg.active) console.log('Service worker registered!');
+    })
+    .catch((err) => {
+      console.error('Could not register service worker!', err);
+    });
+};
+
+// Initialise the service worker some time early in the processs.
+if (!(window.MediaSource || window.ManagedMediaSource)) {
+  registerServiceWorker();
+}
+```

--- a/theolive/playback/react-native/token-based-security.mdx
+++ b/theolive/playback/react-native/token-based-security.mdx
@@ -47,7 +47,7 @@ setInterval(maybeUpdateToken, 30000); // Check every 30 seconds
 
 ## Clearing the token
 
-If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-theolive source altogether, the header can be simply removed as follows:
+If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-THEOlive source altogether, the header can be simply removed as follows:
 
 ```javascript
 player.theoLive.authToken = undefined;

--- a/theolive/playback/react-native/token-based-security.mdx
+++ b/theolive/playback/react-native/token-based-security.mdx
@@ -14,7 +14,7 @@ The THEOlive API provides a simple property to configure your token:
 
 ```javascript
 const token = getToken(); // Generate or request your token, for more information check the token based security guide linked above.
-player.theoLive.authToken = token;
+player.theolive.authToken = token;
 ```
 
 This will ensure the player includes your token in the authorization header on all subsequent requests it performs for playback of your THEOlive channel.
@@ -37,7 +37,7 @@ function tokenWillExpireSoon() {
 function maybeUpdateToken() {
   if (!token || tokenWillExpireSoon(token)) {
     token = getToken(); // Generate or request your token, for more information check the token based security guide linked above.
-    player.theoLive.authToken = token;
+    player.theolive.authToken = token;
   }
 }
 
@@ -50,7 +50,7 @@ setInterval(maybeUpdateToken, 30000); // Check every 30 seconds
 If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-THEOlive source altogether, the header can be simply removed as follows:
 
 ```javascript
-player.theoLive.authToken = undefined;
+player.theolive.authToken = undefined;
 ```
 
 ## Enabling Token Based Security for Safari browsers on iOS \<17

--- a/theolive/playback/react-native/token-based-security.mdx
+++ b/theolive/playback/react-native/token-based-security.mdx
@@ -12,7 +12,7 @@ Refer to the [getting started guide](../getting-started) for the prerequisite st
 
 The token needs to be passed along with player requests as a Bearer token in the `Authorization` header of the requests. To do so we can make use of the Network API of the player, which on React Native works as follows:
 
-```
+```javascript
 const token = getToken(); // Generate or request your token, for more information check the token based security guide linked above.
 player.network.setHeader('Authorization', `Bearer ${token}`);
 ```
@@ -23,7 +23,7 @@ This will ensure the player includes your authorization header on all subsequent
 
 If your tokens are short-lived, you want to make sure to update the token being passed to the player and requests before it expires, to allow playback to continue beyond expiry. This can simply be done by updating the header on the player in the same way. For example, one could check on an interval that makes sense for your token lifespan whether the token is about to expire and update when necessary, for example:
 
-```
+```javascript
 let token;
 
 // Helper function to check whether your token will expire within one minute from now
@@ -49,7 +49,7 @@ setInterval(maybeUpdateToken, 30000); // Check every 30 seconds
 
 If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-theolive source altogether, the header can be simply removed as follows:
 
-```
+```javascript
 player.network.removeHeader('Authorization');
 ```
 

--- a/theolive/playback/react-native/token-based-security.mdx
+++ b/theolive/playback/react-native/token-based-security.mdx
@@ -106,7 +106,7 @@ self.addEventListener('fetch', (event) => {
 ```
 
 :::note
-In order for the service worker to be able to intercept requests made from the player library, it's scope must include the player sdk files. That means the player and service worker must be hosted on the same path or the player must be hosted in a subfolder of the path where the service worker is hosted.
+In order for the service worker to be able to intercept requests made from the player library, its scope must include the player SDK files. That means the player and service worker must be hosted on the same path or the player must be hosted in a subfolder of the path where the service worker is hosted.
 :::
 
 To register this service worker in to your code, you can attach it this way.

--- a/theolive/playback/react-native/token-based-security.mdx
+++ b/theolive/playback/react-native/token-based-security.mdx
@@ -10,14 +10,14 @@ Refer to the [getting started guide](../getting-started) for the prerequisite st
 
 ## Configuring THEOplayer to pass the token
 
-The token needs to be passed along with player requests as a Bearer token in the `Authorization` header of the requests. To do so we can make use of the Network API of the player, which on React Native works as follows:
+The THEOlive API provides a simple property to configure your token:
 
 ```javascript
 const token = getToken(); // Generate or request your token, for more information check the token based security guide linked above.
-player.network.setHeader('Authorization', `Bearer ${token}`);
+player.theoLive.authToken = token;
 ```
 
-This will ensure the player includes your authorization header on all subsequent requests it performs for playback of your THEOlive channel.
+This will ensure the player includes your token in the authorization header on all subsequent requests it performs for playback of your THEOlive channel.
 
 ## Dealing with token expiry and rotation
 
@@ -37,7 +37,7 @@ function tokenWillExpireSoon() {
 function maybeUpdateToken() {
   if (!token || tokenWillExpireSoon(token)) {
     token = getToken(); // Generate or request your token, for more information check the token based security guide linked above.
-    player.network.setHeader('Authorization', `Bearer ${token}`);
+    player.theoLive.authToken = token;
   }
 }
 
@@ -50,7 +50,7 @@ setInterval(maybeUpdateToken, 30000); // Check every 30 seconds
 If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-theolive source altogether, the header can be simply removed as follows:
 
 ```javascript
-player.network.removeHeader('Authorization');
+player.theoLive.authToken = undefined;
 ```
 
 ## Enabling Token Based Security for Safari browsers on iOS \<17

--- a/theolive/playback/roku/_category_.json
+++ b/theolive/playback/roku/_category_.json
@@ -1,7 +1,7 @@
 {
   "label": "Roku",
   "description": "Start with THEOlive on Roku smart TVs.",
-  "position": 3,
+  "position": 4,
   "customProps": {
     "icon": "📺"
   }

--- a/theolive/playback/roku/token-based-security.mdx
+++ b/theolive/playback/roku/token-based-security.mdx
@@ -75,7 +75,7 @@ end function
 
 ## Clearing the token
 
-If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-theolive source altogether, the header can be simply removed as follows:
+If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-THEOlive source altogether, the header can be simply removed as follows:
 
 ```brightscript
 .theolive.authToken = invalid

--- a/theolive/playback/roku/token-based-security.mdx
+++ b/theolive/playback/roku/token-based-security.mdx
@@ -51,7 +51,7 @@ end sub
 sub maybeUpdateToken()
     if m.token = "" or tokenWillExpireSoon(m.token) then
         m.token = getToken() ' Generate or request your token, for more information check the token based security guide linked above.
-        m.player.theolive.authToken = token
+        m.player.theolive.authToken = m.token
     end if
 end sub
 

--- a/theolive/playback/roku/token-based-security.mdx
+++ b/theolive/playback/roku/token-based-security.mdx
@@ -10,14 +10,14 @@ Refer to the [getting started guide](../getting-started) for the prerequisite st
 
 ## Configuring THEOplayer to pass the token
 
-The token needs to be passed along with player requests as a Bearer token in the `Authorization` header of the requests. To do so we can make use of the Network API of the player, which on Roku works as follows:
+The THEOlive API provides a simple property to configure your token:
 
 ```brightscript
 token = getToken() // Generate or request your token, for more information check the token based security guide linked above.
-player.network.callFunc("setHeader", "Authorization", "Bearer " + token)
+player.theolive.authToken = token
 ```
 
-This will ensure the player includes your authorization header on all subsequent requests it performs for playback of your THEOlive channel.
+This will ensure the player includes your token in the authorization header on all subsequent requests it performs for playback of your THEOlive channel.
 
 ## Dealing with token expiry and rotation
 
@@ -51,7 +51,7 @@ end sub
 sub maybeUpdateToken()
     if m.token = "" or tokenWillExpireSoon(m.token) then
         m.token = getToken() ' Generate or request your token, for more information check the token based security guide linked above.
-        m.player.network.callFunc("setHeader", "Authorization", "Bearer " + token)
+        m.player.theolive.authToken = token
     end if
 end sub
 
@@ -78,5 +78,5 @@ end function
 If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-theolive source altogether, the header can be simply removed as follows:
 
 ```brightscript
-player.network.callFunc("removeHeader", "Authorization")
+.theolive.authToken = invalid
 ```

--- a/theolive/playback/roku/token-based-security.mdx
+++ b/theolive/playback/roku/token-based-security.mdx
@@ -78,5 +78,5 @@ end function
 If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-THEOlive source altogether, the header can be simply removed as follows:
 
 ```brightscript
-player.theolive.authToken = invalid
+player.theolive.authToken = ""
 ```

--- a/theolive/playback/roku/token-based-security.mdx
+++ b/theolive/playback/roku/token-based-security.mdx
@@ -64,7 +64,7 @@ function tokenWillExpireSoon(token as String) as Boolean
     ba.FromBase64String(payloadBase64)
     decodedJson = ParseJson(ba.ToAsciiString())
     if decodedJson = invalid then return true
-			
+
     exp = decodedJson.exp
     if exp = invalid then return true
     now = Int(CreateObject("roDateTime").AsSeconds())

--- a/theolive/playback/roku/token-based-security.mdx
+++ b/theolive/playback/roku/token-based-security.mdx
@@ -1,6 +1,6 @@
 # Token based security
 
-THEOlive offers the option to enable JWT token security on channel alias level. This can be interesting if you only want valid users to access your stream. Read more about the feature and configuring it on your channels on the [token based security guide](/theolive/platform/security/token-based-security).
+THEOlive offers the option to enable JWT token security on channel distribution level. This can be interesting if you only want valid users to access your stream. Read more about the feature and configuring it on your channels on the [token based security guide](/theolive/platform/security/token-based-security).
 
 This page will demonstrate how to configure the Roku Player SDK for playback of channels with token based security enabled.
 

--- a/theolive/playback/roku/token-based-security.mdx
+++ b/theolive/playback/roku/token-based-security.mdx
@@ -78,5 +78,5 @@ end function
 If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-THEOlive source altogether, the header can be simply removed as follows:
 
 ```brightscript
-.theolive.authToken = invalid
+player.theolive.authToken = invalid
 ```

--- a/theolive/playback/roku/token-based-security.mdx
+++ b/theolive/playback/roku/token-based-security.mdx
@@ -1,0 +1,82 @@
+# Token based security
+
+THEOlive offers the option to enable JWT token security on channel alias level. This can be interesting if you only want valid users to access your stream. Read more about the feature and configuring it on your channels on the [token based security guide](/theolive/platform/security/token-based-security).
+
+This page will demonstrate how to configure the Roku Player SDK for playback of channels with token based security enabled.
+
+## Setting up the Roku THEOplayer SDK for THEOlive
+
+Refer to the [getting started guide](../getting-started) for the prerequisite steps in getting the Roku SDK up and running for THEOlive playback.
+
+## Configuring THEOplayer to pass the token
+
+The token needs to be passed along with player requests as a Bearer token in the `Authorization` header of the requests. To do so we can make use of the Network API of the player, which on Roku works as follows:
+
+```
+token = getToken() // Generate or request your token, for more information check the token based security guide linked above.
+player.network.callFunc("setHeader", "Authorization", "Bearer " + token)
+```
+
+This will ensure the player includes your authorization header on all subsequent requests it performs for playback of your THEOlive channel.
+
+## Dealing with token expiry and rotation
+
+If your tokens are short-lived, you want to make sure to update the token being passed to the player and requests before it expires, to allow playback to continue beyond expiry. This can simply be done by updating the header on the player in the same way. For example, one could check on an interval that makes sense for your token lifespan whether the token is about to expire and update when necessary, for example:
+
+Add a Timer to your SceneGraph component to check the token at an interval:
+
+```
+...
+  <children>
+    <Timer id="tokenTimer" repeat="true" duration="30" />
+  </children>
+...
+```
+
+And in your Brightscript code:
+
+```
+sub init()
+    ...
+
+    m.token = ""
+    m.player = getPlayer()
+
+    maybeUpdateToken()
+    m.tokenTimer = m.top.findNode("tokenTimer")
+    m.tokenTimer.observeField("fire", "maybeUpdateToken")
+    m.tokenTimer.control = "start"
+end sub
+
+sub maybeUpdateToken()
+    if m.token = "" or tokenWillExpireSoon(m.token) then
+        m.token = getToken() ' Generate or request your token, for more information check the token based security guide linked above.
+        m.player.network.callFunc("setHeader", "Authorization", "Bearer " + token)
+    end if
+end sub
+
+function tokenWillExpireSoon(token as String) as Boolean
+    parts = token.split(".")
+    if parts.count() < 2 then return true
+
+    payloadBase64 = parts[1]
+    ba = CreateObject("roByteArray")
+    ba.FromBase64String(payloadBase64)
+    decodedJson = ParseJson(ba.ToAsciiString())
+    if decodedJson = invalid then return true
+			
+    exp = decodedJson.exp
+    if exp = invalid then return true
+    now = Int(CreateObject("roDateTime").AsSeconds())
+
+    return exp - now <= 60
+end function
+```
+
+## Clearing the token
+
+If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-theolive source altogether, the header can be simply removed as follows:
+
+```
+player.network.callFunc("removeHeader", "Authorization")
+```

--- a/theolive/playback/roku/token-based-security.mdx
+++ b/theolive/playback/roku/token-based-security.mdx
@@ -12,7 +12,7 @@ Refer to the [getting started guide](../getting-started) for the prerequisite st
 
 The token needs to be passed along with player requests as a Bearer token in the `Authorization` header of the requests. To do so we can make use of the Network API of the player, which on Roku works as follows:
 
-```
+```brightscript
 token = getToken() // Generate or request your token, for more information check the token based security guide linked above.
 player.network.callFunc("setHeader", "Authorization", "Bearer " + token)
 ```
@@ -25,7 +25,7 @@ If your tokens are short-lived, you want to make sure to update the token being 
 
 Add a Timer to your SceneGraph component to check the token at an interval:
 
-```
+```brightscript
 ...
   <children>
     <Timer id="tokenTimer" repeat="true" duration="30" />
@@ -35,7 +35,7 @@ Add a Timer to your SceneGraph component to check the token at an interval:
 
 And in your Brightscript code:
 
-```
+```brightscript
 sub init()
     ...
 
@@ -77,6 +77,6 @@ end function
 
 If the token isn't needed anymore, e.g. when switching to an unprotected channel or a non-theolive source altogether, the header can be simply removed as follows:
 
-```
+```brightscript
 player.network.callFunc("removeHeader", "Authorization")
 ```


### PR DESCRIPTION
Adding basic docs for how to configure JWT tokens for secured THEOlive channel playback.

Adding some reviewers here
@turbidwater can you sanity check my Roku guide
@tvanlaerhoven can you sanity check my React Native guide
@cTopher let's look at who can

- Update the main token based security page, cause that still mentions channel aliases etc, and we'll need to remove the player instructions there and link through to these but maybe there's more changes to make backend and channel wise
- Extend the iOS and React Native base getting started's a bit and what we want to include there, I made it very barebones to begin with just so we can have the JWT previews up already for sharing