### PR TITLE
Fix duplicate code fragment in MediaTailor guide

### DIFF
--- a/theoplayer/how-to-guides/01-ads/12-mediatailor.md
+++ b/theoplayer/how-to-guides/01-ads/12-mediatailor.md
@@ -96,10 +96,6 @@ val mediaTailorSource = MediaTailorSource
 theoplayerView.player.source = SourceDescription
     .Builder(mediaTailorSource)
     .build()
-
-theoplayerView.player.source = SourceDescription
-    .Builder(mediaTailorSource)
-    .build()
 ```
 
 Optionally, you can pass parameters regarding e.g. session data and device type by using the `adsParams` property, as


### PR DESCRIPTION
Something weird happened in #369, see [diff](https://github.com/THEOplayer/documentation/pull/369/files#diff-418c1b2a898922ead5526c6b5676109794f767f6861facfa8850bd6a4ab1efe5). Reverting that.