### PR TITLE
Fix version dropdown

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -166,10 +166,12 @@ const config: Config = {
           },
           v9: {
             label: fs.readFileSync(path.join(__dirname, 'theoplayer_versioned_docs/version-v9/version.txt'), 'utf8').trim(),
+            banner: 'none',
+            noIndex: true,
           },
           v8: {
             label: fs.readFileSync(path.join(__dirname, 'theoplayer_versioned_docs/version-v8/version.txt'), 'utf8').trim(),
-            banner: 'none',
+            banner: 'unmaintained',
             noIndex: true,
           },
           v7: {


### PR DESCRIPTION
THEOplayer 10.0.0 was showing as "next" in the version dropdown, this fixes that.

Also mark v8 as unmaintained now.