### PR TITLE
Rebranding and language updates

### DIFF
--- a/ads/callouts/_rebranding_notice.md
+++ b/ads/callouts/_rebranding_notice.md
@@ -1,0 +1,5 @@
+:::info OptiView Rebranding
+
+OptiView Ads is the new name for THEOads as part of the OptiView product suite. During the transition, you may still see references to THEOads. OptiView Ads and THEOads refer to the same product.
+
+:::

--- a/ads/getting-started/android.mdx
+++ b/ads/getting-started/android.mdx
@@ -15,7 +15,7 @@ import TabItem from '@theme/TabItem';
 
 1. You need to have an OptiView Player license which is compatible with OptiView Ads. This can be done through the [player portal](https://portal.theoplayer.com).
 2. You need a correctly deployed [OptiView Ads signaling service](signaling-service.mdx).
-3. Add the OptiView Player Android SDK to your project by following our [Getting started](/theoplayer/getting-started/sdks/android/getting-started) guide. Make sure to [set up a OptiView Ads-compatible license](/theoplayer/getting-started/sdks/android/getting-started/#setting-up-the-license) in your app.
+3. Add the OptiView Player Android SDK to your project by following our [Getting started](/theoplayer/getting-started/sdks/android/getting-started) guide. Make sure to [set up an OptiView Ads-compatible license](/theoplayer/getting-started/sdks/android/getting-started/#setting-up-the-license) in your app.
 4. Add the OptiView Ads integration as a dependency in your module-level `build.gradle` file:
    <Tabs queryString="lang">
       <!-- prettier-ignore-start -->
@@ -92,7 +92,7 @@ theoPlayerView.player.source = SourceDescription.Builder(
 
 ## Integrating with Open Video UI
 
-When using the [Open Video UI for Android](/open-video-ui/android/), you need to create and add the `TheoAdsIntegration` before creating your `DefaultUI` or `UIController`. You can then create a OptiView Ads-enabled source and set it as `player.source`:
+When using the [Open Video UI for Android](/open-video-ui/android/), you need to create and add the `TheoAdsIntegration` before creating your `DefaultUI` or `UIController`. You can then create an OptiView Ads-enabled source and set it as `player.source`:
 
 ```kotlin
 import androidx.activity.compose.setContent

--- a/ads/getting-started/android.mdx
+++ b/ads/getting-started/android.mdx
@@ -6,16 +6,16 @@ sidebar_custom_props: { 'icon': 'android' }
 
 # Getting started with OptiView Ads on Android
 
-This guide will get you started to integrate OptiView Ads in your THEOplayer Android SDK: configure the license, update dependencies and set the source description.
+This guide will get you started to integrate OptiView Ads in your OptiView Player Android SDK: configure the license, update dependencies and set the source description.
 
 ## Prerequisites
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-1. You need to have a THEOplayer license which is compatible with OptiView Ads. This can be done through the [player portal](https://portal.theoplayer.com).
+1. You need to have an OptiView Player license which is compatible with OptiView Ads. This can be done through the [player portal](https://portal.theoplayer.com).
 2. You need a correctly deployed [OptiView Ads signaling service](signaling-service.mdx).
-3. Add the THEOplayer Android SDK to your project by following our [Getting started](/theoplayer/getting-started/sdks/android/getting-started) guide. Make sure to [set up a OptiView Ads-compatible license](/theoplayer/getting-started/sdks/android/getting-started/#setting-up-the-license) in your app.
+3. Add the OptiView Player Android SDK to your project by following our [Getting started](/theoplayer/getting-started/sdks/android/getting-started) guide. Make sure to [set up a OptiView Ads-compatible license](/theoplayer/getting-started/sdks/android/getting-started/#setting-up-the-license) in your app.
 4. Add the OptiView Ads integration as a dependency in your module-level `build.gradle` file:
    <Tabs queryString="lang">
       <!-- prettier-ignore-start -->

--- a/ads/getting-started/chromecast.mdx
+++ b/ads/getting-started/chromecast.mdx
@@ -6,16 +6,16 @@ sidebar_custom_props: { 'icon': 'web' }
 
 # Getting started with OptiView Ads on Chromecast CAF
 
-This guide will get you started with OptiView Ads using the THEOplayer Chromecast CAF SDK.
+This guide will get you started with OptiView Ads using the OptiView Player Chromecast CAF SDK.
 ! NOTE: Currently the Chromecast CAF SDK only supports image overlays from OptiView Ads.
 
 ## Prerequisites
 
-1. You need to have a THEOplayer license which is compatible with OptiView Ads. This can be done through the [player portal](https://portal.theoplayer.com).
+1. You need to have an OptiView Player license which is compatible with OptiView Ads. This can be done through the [player portal](https://portal.theoplayer.com).
 2. You need a correctly deployed [OptiView Ads signaling service](signaling-service.mdx).
 3. Your THEOplayer SDK needs to have the `theoads` feature enabled.
 
-   As of THEOplayer version 8.2.0, this feature is enabled by default in the main `theoplayer` package so we recommend to use at least this version, preferable the latest available version.
+   As of OptiView Player version 8.2.0, this feature is enabled by default in the main `theoplayer` package so we recommend to use at least this version, preferable the latest available version.
    You can install this package with the following command:
 
    ```bash
@@ -29,7 +29,7 @@ This guide will get you started with OptiView Ads using the THEOplayer Chromecas
 ### Configuring the Chromecast receiver
 
 OptiView Ads is supported using the default Chromecast Shaka player for HLS on Chromecast CAF. To enable this, before starting the Chromecast application, configure it to use Shaka.
-Also, you need to load the THEOplayer Chromecast CAF SDK.
+Also, you need to load the OptiView Player Chromecast CAF SDK.
 
 Here is an example of a bare-bones CAF receiver app you can use as a starting point for basic playback without any custom UI:
 

--- a/ads/getting-started/chromecast.mdx
+++ b/ads/getting-started/chromecast.mdx
@@ -15,7 +15,7 @@ This guide will get you started with OptiView Ads using the OptiView Player Chro
 2. You need a correctly deployed [OptiView Ads signaling service](signaling-service.mdx).
 3. Your THEOplayer SDK needs to have the `theoads` feature enabled.
 
-   As of OptiView Player version 8.2.0, this feature is enabled by default in the main `theoplayer` package so we recommend to use at least this version, preferable the latest available version.
+   As of OptiView Player version 8.2.0, this feature is enabled by default in the main `theoplayer` package so we recommend to use at least this version, preferably the latest available version.
    You can install this package with the following command:
 
    ```bash

--- a/ads/getting-started/index.mdx
+++ b/ads/getting-started/index.mdx
@@ -5,7 +5,11 @@ sidebar_label: Getting Started
 
 # Getting started with OptiView Ads
 
-These guides provide the steps required to get started with OptiView Ads (SGAI). They cover the deployment and API integration of the Signaling Service into your existing workflow, as well as the integration of OptiView Ads into your application using various OptiView Player SDKs.
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
+
+<RebrandingNotice />
+
+These guides provide the steps required to get started with OptiView Ads. They cover the deployment and API integration of the Signaling Service into your existing workflow, as well as the integration of OptiView Ads into your application using various OptiView Player SDKs.
 
 import DocCardList from '@theme/DocCardList';
 

--- a/ads/getting-started/ios.mdx
+++ b/ads/getting-started/ios.mdx
@@ -6,16 +6,16 @@ sidebar_custom_props: { 'icon': 'apple' }
 
 # Getting started with OptiView Ads on iOS
 
-This guide will get you started to integrate OptiView Ads in your THEOplayer iOS SDK: configure the license, update dependencies and set the source description.
+This guide will get you started to integrate OptiView Ads in your OptiView Player iOS SDK: configure the license, update dependencies and set the source description.
 
 ## Prerequisites
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-1.  You need to have a THEOplayer license which is compatible with OptiView Ads. This can be done through the [player portal](https://portal.theoplayer.com).
+1.  You need to have an OptiView Player license which is compatible with OptiView Ads. This can be done through the [player portal](https://portal.theoplayer.com).
 2.  You need a correctly deployed [OptiView Ads signaling service](signaling-service.mdx).
-3.  Add the THEOplayer iOS SDK to your project by following our [Getting started](/theoplayer/getting-started/sdks/ios/getting-started) guide. Make sure to [set up a OptiView Ads-compatible license](/theoplayer/getting-started/sdks/ios/getting-started/#theoplayer-license) in your app.
+3.  Add the OptiView Player iOS SDK to your project by following our [Getting started](/theoplayer/getting-started/sdks/ios/getting-started) guide. Make sure to [set up a OptiView Ads-compatible license](/theoplayer/getting-started/sdks/ios/getting-started/#theoplayer-license) in your app.
 4.  Add the OptiView Ads integration as a dependency to your project:
     <Tabs queryString="lang">
     <!-- prettier-ignore-start -->

--- a/ads/getting-started/ios.mdx
+++ b/ads/getting-started/ios.mdx
@@ -15,7 +15,7 @@ import TabItem from '@theme/TabItem';
 
 1.  You need to have an OptiView Player license which is compatible with OptiView Ads. This can be done through the [player portal](https://portal.theoplayer.com).
 2.  You need a correctly deployed [OptiView Ads signaling service](signaling-service.mdx).
-3.  Add the OptiView Player iOS SDK to your project by following our [Getting started](/theoplayer/getting-started/sdks/ios/getting-started) guide. Make sure to [set up a OptiView Ads-compatible license](/theoplayer/getting-started/sdks/ios/getting-started/#theoplayer-license) in your app.
+3.  Add the OptiView Player iOS SDK to your project by following our [Getting started](/theoplayer/getting-started/sdks/ios/getting-started) guide. Make sure to [set up an OptiView Ads-compatible license](/theoplayer/getting-started/sdks/ios/getting-started/#theoplayer-license) in your app.
 4.  Add the OptiView Ads integration as a dependency to your project:
     <Tabs queryString="lang">
     <!-- prettier-ignore-start -->

--- a/ads/getting-started/react-native.mdx
+++ b/ads/getting-started/react-native.mdx
@@ -6,14 +6,14 @@ sidebar_custom_props: { 'icon': 'react' }
 
 # Getting started with OptiView Ads on React Native
 
-This guide will get you started with OptiView Ads in your THEOplayer React Native SDK: configure the license, update dependencies and set the source description.
+This guide will get you started with OptiView Ads in your OptiView Player React Native SDK: configure the license, update dependencies and set the source description.
 
 ## Prerequisites
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-1.  You need to have a THEOplayer license which is compatible with OptiView Ads. This can be done through the [player portal](https://portal.theoplayer.com).
+1.  You need to have an OptiView Player license which is compatible with OptiView Ads. This can be done through the [player portal](https://portal.theoplayer.com).
 2.  You need a correctly deployed [OptiView Ads signaling service](signaling-service.mdx).
 3.  Enable the OptiView Ads integration based on the target platform:
     <Tabs queryString="platform">
@@ -46,7 +46,7 @@ import TabItem from '@theme/TabItem';
 
 ## Integration
 
-This guide assumes you know how to set up React Native with THEOplayer.
+This guide assumes you know how to set up React Native with OptiView Player.
 For more information regarding this check out the [THEOplayer getting started](/theoplayer/getting-started/frameworks/react-native/getting-started/).
 
 ### Player configuration

--- a/ads/getting-started/react-native.mdx
+++ b/ads/getting-started/react-native.mdx
@@ -29,7 +29,7 @@ import TabItem from '@theme/TabItem';
             To enable OptiView Ads you can add the "THEOADS" feature flag to react-native-theoplayer.json (or theoplayer-config.json)
         </TabItem>
         <TabItem value="web" label="Web">
-            Add a dependency to a OptiView ads-enabled THEOplayer package:
+            Add a dependency to an OptiView Ads-enabled THEOplayer package:
             ```bash
             $ npm i theoplayer@npm:@theoplayer/theoads
             ```
@@ -47,7 +47,7 @@ import TabItem from '@theme/TabItem';
 ## Integration
 
 This guide assumes you know how to set up React Native with OptiView Player.
-For more information regarding this check out the [THEOplayer getting started](/theoplayer/getting-started/frameworks/react-native/getting-started/).
+For more information regarding this check out the [OptiView Player getting started](/theoplayer/getting-started/frameworks/react-native/getting-started/).
 
 ### Player configuration
 

--- a/ads/getting-started/web.mdx
+++ b/ads/getting-started/web.mdx
@@ -14,7 +14,7 @@ This guide will get you started with OptiView Ads in your OptiView Player Web SD
 2. You need a correctly deployed [OptiView Ads signaling service](signaling-service.mdx).
 3. Your THEOplayer SDK needs to have the `theoads` feature enabled.
 
-   As of OptiView Player version 8.2.0, this feature is enabled by default in the main `theoplayer` package so we recommend to use at least this version, preferable the latest available version.
+   As of OptiView Player version 8.2.0, this feature is enabled by default in the main `theoplayer` package so we recommend to use at least this version, preferably the latest available version.
    You can install this package with the following command:
 
    ```bash
@@ -23,7 +23,7 @@ This guide will get you started with OptiView Ads in your OptiView Player Web SD
 
 ## Integration
 
-This guide assumes you know how to set up OptiView Player. For more information regarding this, check out the [THEOplayer getting started](/theoplayer/getting-started/sdks/web/getting-started/).
+This guide assumes you know how to set up OptiView Player. For more information regarding this, check out the [OptiView Player getting started](/theoplayer/getting-started/sdks/web/getting-started/).
 
 ### Google DAI library
 
@@ -104,7 +104,7 @@ OptiView Ads works seamlessly together with [Open Video UI for Web](/open-video-
 
 It should look something like this:
 
-![Screenshot of Open Video UI playing a OptiView Ads stream](../assets/img/web-ui.png)
+![Screenshot of Open Video UI playing an OptiView Ads stream](../assets/img/web-ui.png)
 
 ## More information
 

--- a/ads/getting-started/web.mdx
+++ b/ads/getting-started/web.mdx
@@ -6,15 +6,15 @@ sidebar_custom_props: { 'icon': 'web' }
 
 # Getting started with OptiView Ads on Web
 
-This guide will get you started with OptiView Ads in your THEOplayer Web SDK: configure the license, update dependencies and set the source description.
+This guide will get you started with OptiView Ads in your OptiView Player Web SDK: configure the license, update dependencies and set the source description.
 
 ## Prerequisites
 
-1. You need to have a THEOplayer license which is compatible with OptiView Ads. This can be done through the [player portal](https://portal.theoplayer.com).
+1. You need to have an OptiView Player license which is compatible with OptiView Ads. This can be done through the [player portal](https://portal.theoplayer.com).
 2. You need a correctly deployed [OptiView Ads signaling service](signaling-service.mdx).
 3. Your THEOplayer SDK needs to have the `theoads` feature enabled.
 
-   As of THEOplayer version 8.2.0, this feature is enabled by default in the main `theoplayer` package so we recommend to use at least this version, preferable the latest available version.
+   As of OptiView Player version 8.2.0, this feature is enabled by default in the main `theoplayer` package so we recommend to use at least this version, preferable the latest available version.
    You can install this package with the following command:
 
    ```bash
@@ -23,7 +23,7 @@ This guide will get you started with OptiView Ads in your THEOplayer Web SDK: co
 
 ## Integration
 
-This guide assumes you know how to set up THEOplayer. For more information regarding this, check out the [THEOplayer getting started](/theoplayer/getting-started/sdks/web/getting-started/).
+This guide assumes you know how to set up OptiView Player. For more information regarding this, check out the [THEOplayer getting started](/theoplayer/getting-started/sdks/web/getting-started/).
 
 ### Google DAI library
 

--- a/ads/how-to-guides/ad-impressions.md
+++ b/ads/how-to-guides/ad-impressions.md
@@ -12,11 +12,11 @@ The ad impression is beaconed simultaneously with the firing of the player's `ad
 
 ## Information tracked
 
-The information passed only contains an identifier of the THEOplayer license build so the impressions are linked to the customer. It also includes the ad experience type.
+The information passed only contains an identifier of the OptiView Player license build so the impressions are linked to the customer. It also includes the ad experience type.
 No information about the viewers is passed along.
 
 ## View my impression usage
 
-You can view your ad impressions on the portal dashboard underneath the THEOplayer license impressions.
+You can view your ad impressions on the portal dashboard underneath the OptiView Player license impressions.
 
 ![Portal dashboard](../assets/img/impressions.png)

--- a/ads/index.mdx
+++ b/ads/index.mdx
@@ -39,7 +39,7 @@ To ensure high availability, we recommend maintaining the original origin stream
 
 OptiView Ads is tightly integrated with [Google Ad Manager](https://developers.google.com/ad-manager/dynamic-ad-insertion 'Google DAI') for ad decisioning, transcoding, and serving, ensuring a streamlined process for ad delivery and management.
 
-OptiView Ads enables innovative ad formats through THEOplayer, providing new ways to monetize content in a less intrusive manner. The out-of-the-box formats include, but are not limited to:
+OptiView Ads enables innovative ad formats through OptiView Player, providing new ways to monetize content in a less intrusive manner. The out-of-the-box formats include, but are not limited to:
 
 - **Default Full Screen Ad Insertion**: Replaces the content with an advertisement.
 - **Double Box**: Allows content to continue playing side-by-side with an advertisement and its companion background.

--- a/ads/index.mdx
+++ b/ads/index.mdx
@@ -50,6 +50,6 @@ OptiView Ads enables innovative ad formats through OptiView Player, providing ne
 
 ![OptiView Ads experiences](./assets/img/ads_formats.svg)
 
-**Note**: Every OptiView Player comes with the functionality to enable OptiView Ads by default. However, a OptiView ads-enabled OptiView Player license is required to activate this functionality.
+**Note**: Every OptiView Player comes with the functionality to enable OptiView Ads by default. However, an OptiView Ads-enabled OptiView Player license is required to activate this functionality.
 
 <SidebarDocCardList />

--- a/ads/index.mdx
+++ b/ads/index.mdx
@@ -6,8 +6,11 @@ sidebar_label: Introduction
 # Dolby OptiView Ads Introduction
 
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+import RebrandingNotice from './callouts/_rebranding_notice.md';
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+
+<RebrandingNotice />
 
 OptiView Ads is an ad insertion service for LIVE content (VoD support coming soon), utilizing Server-Guided Ad Insertion (SGAI). On these pages, you'll learn how to get started with OptiView Ads, how to configure the player and integrate the signaling service APIs.
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -490,7 +490,7 @@ const config: Config = {
           if (docPluginId === 'open-video-ui') {
             frontMatter.description = "Find out what's new in Open Video UI.";
           } else if (docPluginId === 'theoplayer' && !docPath.includes('connector')) {
-            frontMatter.description = "Find out what's new in THEOplayer.";
+            frontMatter.description = "Find out what's new in the OptiView Player.";
           } else {
             frontMatter.description = "Find out what's new.";
           }
@@ -510,7 +510,7 @@ const config: Config = {
           } else if (docPath.includes('connector')) {
             frontMatter.description = 'Set up your connector in just a few minutes!';
           } else {
-            frontMatter.description = 'Set up your first THEOplayer in just a few minutes!';
+            frontMatter.description = 'Set up your first OptiView Player in just a few minutes!';
           }
         }
         frontMatter.sidebar_custom_props ??= { icon: '🚀 ' };
@@ -552,7 +552,7 @@ const config: Config = {
             {
               type: 'custom-platformSidebar',
               docsPluginId: 'theoplayer',
-              label: 'THEOplayer',
+              label: 'OptiView Player',
               href: '/theoplayer',
               activeBasePath: '/theoplayer',
             } satisfies PlatformSidebarNavbarItemProps,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -524,6 +524,18 @@ const config: Config = {
   themeConfig: {
     // TODO OpenGraph image for OptiView?
     // image: 'img/opengraph.png',
+
+    // announcement bar for PR preview only
+    announcementBar: process.env.DOCUSAURUS_PR_NUMBER
+      ? {
+          id: 'pr_preview',
+          content: `This is a preview of the documentation website from <a target="_blank" rel="noopener noreferrer" href="${process.env.DOCUSAURUS_PR_URL}">pull request #${process.env.DOCUSAURUS_PR_NUMBER}</a>.`,
+          backgroundColor: '#9cb9c9',
+          textColor: '#344a5e',
+          isCloseable: false,
+        }
+      : null, // don't use announce bar in production
+    
     navbar: {
       title: null,
       logo: {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -96,8 +96,7 @@ function removeDocIndexItems(items) {
 
 const config: Config = {
   title: 'Dolby OptiView Documentation',
-  tagline:
-    'Discover the latest developer documentation and samples for OptiView products',
+  tagline: 'Discover the latest developer documentation and samples for OptiView products',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -97,7 +97,7 @@ function removeDocIndexItems(items) {
 const config: Config = {
   title: 'Dolby OptiView Documentation',
   tagline:
-    'Discover the latest developer documentation and samples for OptiView products including: Player, Streaming, Ads, Ad Engine, and Open Video UI',
+    'Discover the latest developer documentation and samples for OptiView products',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
@@ -584,14 +584,14 @@ const config: Config = {
               type: 'docSidebar',
               docsPluginId: 'theolive',
               sidebarId: 'theolive',
-              label: 'Live (THEOlive)',
+              label: 'Live',
               activeBasePath: '/theolive',
             },
             {
               type: 'docSidebar',
               docsPluginId: 'millicast',
               sidebarId: 'millicast',
-              label: 'Real-time (Millicast)',
+              label: 'Real-time',
               activeBasePath: '/millicast',
             },
           ],

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -535,7 +535,7 @@ const config: Config = {
           isCloseable: false,
         }
       : undefined,
-    
+
     navbar: {
       title: null,
       logo: {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -525,22 +525,6 @@ const config: Config = {
   themeConfig: {
     // TODO OpenGraph image for OptiView?
     // image: 'img/opengraph.png',
-    announcementBar: process.env.DOCUSAURUS_PR_NUMBER
-      ? {
-          id: 'pr_preview',
-          content: `This is a preview of the documentation website from <a target="_blank" rel="noopener noreferrer" href="${process.env.DOCUSAURUS_PR_URL}">pull request #${process.env.DOCUSAURUS_PR_NUMBER}</a>.`,
-          backgroundColor: '#9cb9c9',
-          textColor: '#344a5e',
-          isCloseable: false,
-        }
-      : {
-          id: 'dolby_optiview_new_name',
-          content:
-            'Dolby OptiView is the new home for everything Dolby.io and THEOplayer. <a target="_blank" rel="noopener" href="https://dolby.io/blog/introducing-dolby-optiview-redefining-immersive-streaming-experiences/">Learn more.</a>',
-          backgroundColor: '#4800c4',
-          textColor: '#fff',
-          isCloseable: true,
-        },
     navbar: {
       title: null,
       logo: {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -534,7 +534,7 @@ const config: Config = {
           textColor: '#344a5e',
           isCloseable: false,
         }
-      : null, // don't use announce bar in production
+      : undefined,
     
     navbar: {
       title: null,

--- a/millicast/analytics/index.md
+++ b/millicast/analytics/index.md
@@ -3,7 +3,7 @@ title: Analytics APIs
 slug: /analytics-api
 ---
 
-The Analytics APIs allow you to query your usage independent of the Dolby.io dashboard and get details of how your users are consuming your streams.
+The Analytics APIs allow you to query your usage independent of the OptiView Streaming Dashboard and get details of how your users are consuming your streams.
 
 To access the analytics APIs you must have an API token. To learn more on how to get your API token, please read the following article [Acquiring Your API Token](/millicast/streaming-dashboard/token-api.mdx).
 
@@ -19,11 +19,11 @@ A breakdown of per-stream data is also only available within a 7 day window. Thi
 
 To query for a particular month’s data, the API requires the date range to be from **day 1** of the month in question to **day 1** of the next month. An example of the query would look like this: startDate=2021-**01-01**&stopDate=2021-**02-01**&resolution=**Month**. This query would return the total bandwidth usage for the month of January 2021.
 
-It is advised that you save your Daily and Hourly data if you feel that you would need it beyond the 365 and 7 day retention provided by Dolby.io Real-time Streaming.
+It is advised that you save your Daily and Hourly data if you feel that you would need it beyond the 365 and 7 day retention provided by OptiView Real-time Streaming.
 
 Wildcards
 
-The Dolby.io Real-time Streaming publisher token provides a Wildcard option which allows you to use an arbitrary stream name on-the-fly, rather than specifying the stream name in advance. This is beneficial if you are dynamically generating streams and are not sure how many streams you will need to generate or which names you will need to use. Because queries for stream analytics require a stream name, it is important for you to keep track of which stream names are being used if you would later like to query the analytics data for these individual streams.
+The OptiView Real-time Streaming publisher token provides a Wildcard option which allows you to use an arbitrary stream name on-the-fly, rather than specifying the stream name in advance. This is beneficial if you are dynamically generating streams and are not sure how many streams you will need to generate or which names you will need to use. Because queries for stream analytics require a stream name, it is important for you to keep track of which stream names are being used if you would later like to query the analytics data for these individual streams.
 
 ## Basic call structure
 
@@ -33,11 +33,11 @@ In this example we want to query the API to get usage information for our entire
 
 ## Example tutorial: JS / Nodejs
 
-In the following example, we will use the Analytics APIs to query a Dolby.io Real-time Streaming account for a date range of usage and display it in a graph using Google Charts (see: https://developers.google.com/chart/interactive/docs/gallery/areachart)
+In the following example, we will use the Analytics APIs to query an OptiView Real-time Streaming account for a date range of usage and display it in a graph using Google Charts (see: https://developers.google.com/chart/interactive/docs/gallery/areachart)
 
 Before proceeding we assume you are familiar with Nodejs and have some familiarity with Google Charts. For this example we used a Nodejs server version 12.19 (the latest stable version as of February 2021).
 
-As with all API calls to our platform you must have your API token ready, you can find this in your Dolby.io dashboard.
+As with all API calls to our platform you must have your API token ready, you can find this in your OptiView Streaming Dashboard.
 
 Let's start by creating a new Nodejs project:
 
@@ -57,7 +57,7 @@ const startUTC = '2020-08-01'; // UTC year-month-day
 const stopUTC = '2021-01-01';
 const token = '__TOKEN__';
 
-// Dolby.io Real-time Streaming request details
+// OptiView Real-time Streaming request details
 const options = {
   hostname: 'api.millicast.com',
   path: '/api/analytics/account/series?startDate=' + startUTC + '&stopDate=' + stopUTC + '&resolution=Month',
@@ -105,7 +105,7 @@ https.createServer({ key: fs.readFileSync('ssl/key.pem'), cert: fs.readFileSync(
 console.log('running! see port https://localhost:' + port + '/usage');
 ```
 
-In this example we use the standard Express module along with the built in HTTPS module to handle secure requests coming from the client HTML side and for calls going out to the Dolby.io Real-time Streaming from the server. This example uses openssl self-signed certificates to satisfy the key and conf requirement in the HTTPS module on Nodejs. We are testing locally so we run a simple local web server from the Visual Studio Code editor to do the calls over HTTPS locally (https://localhost:8443/). In this case, you would only need to bypass the browser warning that comes up to access your HTML file.
+In this example we use the standard Express module along with the built in HTTPS module to handle secure requests coming from the client HTML side and for calls going out to the OptiView Real-time Streaming from the server. This example uses openssl self-signed certificates to satisfy the key and conf requirement in the HTTPS module on Nodejs. We are testing locally so we run a simple local web server from the Visual Studio Code editor to do the calls over HTTPS locally (https://localhost:8443/). In this case, you would only need to bypass the browser warning that comes up to access your HTML file.
 
 The express **"get"** method handles the request call to the API when the HTML user makes calls via the "/usage" path specified in the method. The path here is an arbitrary label, feel free to use whatever path name you prefer, just remember the call on the HTML counterpart has to match the path.
 
@@ -189,7 +189,7 @@ First open your editor and create a blank html file, save it as index.html. In y
                         let data = google.visualization.arrayToDataTable(o);
 
                         let opt = {
-                                title: 'Dolby.io Real-time Streaming Usage',
+                                title: 'OptiView Real-time Streaming Usage',
                                 hAxis: {title: 'Month', titleTextStyle: {color: '#333'}},
                                 vAxis: {minValue: 0}
                         };
@@ -496,7 +496,7 @@ Notice, the data sent to the server is in the same format that is expected on th
 
 ## Viewers per stream
 
-Calculating the viewers per stream (daily or hourly), which region they viewed from, and how much bandwidth they consumed is a straightforward process. Navigate to the Dolby.io API reference and select the [Analytics Streams Geo Series API](/millicast/api/analytics-streams-geo-series). Add your startDate, stopDate, resolution, and streamName. Additionally, in the top right corner, add your API Secret key found in the [Settings Tab](../streaming-dashboard/index.mdx#settings) of the dashboard. Once all the fields have correct values click the `Try It!` button to get your data.
+Calculating the viewers per stream (daily or hourly), which region they viewed from, and how much bandwidth they consumed is a straightforward process. Navigate to the OptiView API reference and select the [Analytics Streams Geo Series API](/millicast/api/analytics-streams-geo-series). Add your startDate, stopDate, resolution, and streamName. Additionally, in the top right corner, add your API Secret key found in the [Settings Tab](../streaming-dashboard/index.mdx#settings) of the dashboard. Once all the fields have correct values click the `Try It!` button to get your data.
 
 > 🚧 Get your data before it expires!
 >

--- a/millicast/analytics/index.md
+++ b/millicast/analytics/index.md
@@ -3,7 +3,7 @@ title: Analytics APIs
 slug: /analytics-api
 ---
 
-The Analytics APIs allow you to query your usage independent of the OptiView Streaming Dashboard and get details of how your users are consuming your streams.
+The Analytics APIs allow you to query your usage independent of the OptiView Real-time Streaming Dashboard and get details of how your users are consuming your streams.
 
 To access the analytics APIs you must have an API token. To learn more on how to get your API token, please read the following article [Acquiring Your API Token](/millicast/streaming-dashboard/token-api.mdx).
 
@@ -37,7 +37,7 @@ In the following example, we will use the Analytics APIs to query an OptiView Re
 
 Before proceeding we assume you are familiar with Nodejs and have some familiarity with Google Charts. For this example we used a Nodejs server version 12.19 (the latest stable version as of February 2021).
 
-As with all API calls to our platform you must have your API token ready, you can find this in your OptiView Streaming Dashboard.
+As with all API calls to our platform you must have your API token ready, you can find this in your OptiView Real-time Streaming Dashboard.
 
 Let's start by creating a new Nodejs project:
 

--- a/millicast/broadcast/hardware-encoders/elgato.mdx
+++ b/millicast/broadcast/hardware-encoders/elgato.mdx
@@ -92,7 +92,7 @@ import Elgato7 from '../../assets/img/hardware-encoders/elgato_7.png';
   <img src={Elgato7} width="600" />
 </div>
 
-Concurrently, the actions can be seen through Dolby.io Streaming dashboard\*. Visit the stream token, and under the Publishing tab, copy in a new tab the Hosted Player Path URL\*\*.
+Concurrently, the actions can be seen through OptiView Real-time Streaming dashboard\*. Visit the stream token, and under the Publishing tab, copy in a new tab the Hosted Player Path URL\*\*.
 
 \*Note: OBS needs to have the stream token configured for this step to be possible. Visit the [dedicated OBS guide](/millicast/broadcast/software-encoders/obs/index.mdx) on how to set up a WebRTC stream.
 

--- a/millicast/broadcast/hardware-encoders/haivision.mdx
+++ b/millicast/broadcast/hardware-encoders/haivision.mdx
@@ -14,7 +14,7 @@ See the official [Haivision](https://www.haivision.com/) site for documentation,
 
 ### How to use Haivision Makito X4 encoder with SRT
 
-To get started, log into your [Dolby.io Streaming Account](https://dashboard.dolby.io/signin).
+To get started, log into your [OptiView Real-time Streaming Account](https://dashboard.dolby.io/signin).
 
 1. Select **Live Broadcast** from the left menu.
 
@@ -45,7 +45,7 @@ To get started, log into your [Dolby.io Streaming Account](https://dashboard.dol
 If you haven't already, begin by following the [Getting Started](/millicast/getting-started/index.mdx) tutorial to start your first broadcast. You'll need your _RTMP publish path_ and _RTMP publish stream name_ for the steps described below.
 :::
 
-To get started, log into your [Dolby.io Streaming Account](https://dashboard.dolby.io/signin). Enter your KB web interface, switch views to the Channel Control Center, and create a new channel.
+To get started, log into your [OptiView Real-time Streaming Account](https://dashboard.dolby.io/signin). Enter your KB web interface, switch views to the Channel Control Center, and create a new channel.
 
 Follow the Create Channel Wizard prompts to create a channel as normal:
 
@@ -53,7 +53,7 @@ Follow the Create Channel Wizard prompts to create a channel as normal:
 2. Identify your live source for the channel input.
 3. Choose RTMP for the channel output and copy the RTMP publish path from the _Publishing_ tab of the stream token.  
    RTMP URL: `rtmp://rtmp-auto.millicast.com:1935/v2/pub`
-4. Enter the RTMP publish stream name from your Dolby.io Streaming Dashboard.  
+4. Enter the RTMP publish stream name from your OptiView Real-time Streaming Dashboard.  
    Stream Name: `myStreamName?token=3bc330607a15a0ecebebd8c9ee2a559fd143c937174bd276e213a96425bb107e`
 
 With the broadcast credentials set up, the stream is ready to go live. To view the stream, navigate back to your newly created token and switch to the _Playback_ tab. From the Playback tab, copy the _Hosted Player path_ URL and open it in your browser.

--- a/millicast/broadcast/hardware-encoders/haivision.mdx
+++ b/millicast/broadcast/hardware-encoders/haivision.mdx
@@ -14,7 +14,7 @@ See the official [Haivision](https://www.haivision.com/) site for documentation,
 
 ### How to use Haivision Makito X4 encoder with SRT
 
-To get started, log into your [OptiView Real-time Streaming Account](https://dashboard.dolby.io/signin).
+To get started, log into your [OptiView Real-time Streaming Account](https://streaming.dolby.io/signin).
 
 1. Select **Live Broadcast** from the left menu.
 
@@ -45,7 +45,7 @@ To get started, log into your [OptiView Real-time Streaming Account](https://das
 If you haven't already, begin by following the [Getting Started](/millicast/getting-started/index.mdx) tutorial to start your first broadcast. You'll need your _RTMP publish path_ and _RTMP publish stream name_ for the steps described below.
 :::
 
-To get started, log into your [OptiView Real-time Streaming Account](https://dashboard.dolby.io/signin). Enter your KB web interface, switch views to the Channel Control Center, and create a new channel.
+To get started, log into your [OptiView Real-time Streaming Account](https://streaming.dolby.io/signin). Enter your KB web interface, switch views to the Channel Control Center, and create a new channel.
 
 Follow the Create Channel Wizard prompts to create a channel as normal:
 

--- a/millicast/broadcast/hardware-encoders/index.mdx
+++ b/millicast/broadcast/hardware-encoders/index.mdx
@@ -6,7 +6,7 @@ slug: /hardware-encoders
 
 import DocCardList from '@theme/DocCardList';
 
-In today's digital landscape, the demand for real-time streaming content has skyrocketed, prompting broadcasters and video creators to prioritize the efficient delivery of high-quality video and audio streams. Hardware-based encoders play a crucial role in this process with their offerings of superior encoding capabilities and seamless transmission. Needless to say, workflows don't have to be interrupted in order to better a stream. Using the Dolby.io Streaming API protocols like [SRT](/millicast/broadcast/srt.mdx), [NDI](/millicast/broadcast/ndi.md), and [WHIP](/millicast/broadcast/webrtc-and-whip.mdx) can be ingested directly from the encoders like [Teradek](teradek.mdx), [Osprey](osprey.mdx), and [Videon](videon.mdx) and distributed in WebRTC.
+In today's digital landscape, the demand for real-time streaming content has skyrocketed, prompting broadcasters and video creators to prioritize the efficient delivery of high-quality video and audio streams. Hardware-based encoders play a crucial role in this process with their offerings of superior encoding capabilities and seamless transmission. Needless to say, workflows don't have to be interrupted in order to better a stream. Using the OptiView Real-time Streaming API protocols like [SRT](/millicast/broadcast/srt.mdx), [NDI](/millicast/broadcast/ndi.md), and [WHIP](/millicast/broadcast/webrtc-and-whip.mdx) can be ingested directly from the encoders like [Teradek](teradek.mdx), [Osprey](osprey.mdx), and [Videon](videon.mdx) and distributed in WebRTC.
 
 ## Integration guides
 

--- a/millicast/broadcast/hardware-encoders/magewell.mdx
+++ b/millicast/broadcast/hardware-encoders/magewell.mdx
@@ -23,7 +23,7 @@ import RtmpMagewell from '../../assets/img/hardware-encoders/rmtp-magewell.png';
   <img src={RtmpMagewell} width="600" />
 </div>
 
-Next, navigate to your [OptiView Streaming Dashboard](https://dashboard.dolby.io/signin) and [gather your RTMP token credentials](/millicast/broadcast/rtmp-and-rtmps.mdx#how-to-find-your-rtmp-publish-url). Add the `RTMP publish path` from your OptiView Streaming Dashboard to the `URL`, and add your `RTMP Publish Stream Name`, also from the OptiView Streaming Dashboard, to the `Stream key`.
+Next, navigate to your [OptiView Real-time Streaming Dashboard](https://dashboard.dolby.io/signin) and [gather your RTMP token credentials](/millicast/broadcast/rtmp-and-rtmps.mdx#how-to-find-your-rtmp-publish-url). Add the `RTMP publish path` from your OptiView Real-time Streaming Dashboard to the `URL`, and add your `RTMP Publish Stream Name`, also from the OptiView Real-time Streaming Dashboard, to the `Stream key`.
 
 Finally, select which network you'd like the encoder to use to connect, and save the settings.
 
@@ -61,7 +61,7 @@ import SrtCaller from '../../assets/img/hardware-encoders/srt-caller.png';
   <img src={SrtCaller} width="600" />
 </div>
 
-Next, navigate to your [OptiView Streaming Dashboard](https://dashboard.dolby.io/signin) and [gather your SRT token credentials](/millicast/broadcast/srt.mdx). Add the `SRT publish path` from your OptiView Streaming Dashboard to the `Address`, set the `Port` to `10000`, and add your `SRT Stream ID`, also from the OptiView Streaming Dashboard, to the `Stream ID`.
+Next, navigate to your [OptiView Real-time Streaming Dashboard](https://dashboard.dolby.io/signin) and [gather your SRT token credentials](/millicast/broadcast/srt.mdx). Add the `SRT publish path` from your OptiView Real-time Streaming Dashboard to the `Address`, set the `Port` to `10000`, and add your `SRT Stream ID`, also from the OptiView Real-time Streaming Dashboard, to the `Stream ID`.
 
 import SrtSetup from '../../assets/img/hardware-encoders/srt-setup.png';
 
@@ -69,7 +69,7 @@ import SrtSetup from '../../assets/img/hardware-encoders/srt-setup.png';
   <img src={SrtSetup} width="600" />
 </div>
 
-Additionally, if you have `Passphrase encryption` enabled on the OptiView Streaming Dashboard, you can enable it on the encoder side by setting `Encryption` to `AES-128`.
+Additionally, if you have `Passphrase encryption` enabled on the OptiView Real-time Streaming Dashboard, you can enable it on the encoder side by setting `Encryption` to `AES-128`.
 
 Once saved, make sure the stream is activated by toggling the server switch on the `Streaming Server` page.
 

--- a/millicast/broadcast/hardware-encoders/magewell.mdx
+++ b/millicast/broadcast/hardware-encoders/magewell.mdx
@@ -3,7 +3,7 @@ title: Magewell
 slug: /hardware-encoders/magewell
 ---
 
-[Magewell](https://www.magewell.com/) is a leading encoder manufacturer that supports connecting to the Dolby.io Real-time Streaming Service for broadcasting real-time streams. This guide outlines a number of different options for broadcasting streams from a Magewell device to the Dolby.io servers.
+[Magewell](https://www.magewell.com/) is a leading encoder manufacturer that supports connecting to the OptiView Real-time Streaming Service for broadcasting real-time streams. This guide outlines a number of different options for broadcasting streams from a Magewell device to the OptiView Real-time servers.
 
 :::tip Getting Started
 If you haven't already, begin by following the [Getting Started](/millicast/getting-started/index.mdx) tutorial to start your first broadcast. You'll need your _RTMP publish path_ and _RTMP publish stream name_ for the steps described below.
@@ -13,7 +13,7 @@ See the official [Magewell site](https://www.magewell.com/support-contacts) for 
 
 ## Using the Ultra Encode to broadcast RTMP
 
-The [Magewell Ultra Encode](https://www.magewell.com/ultra-encode) supports broadcasting RTMP streams, which can be ingested by the Dolby.io Real-time Streaming service.
+The [Magewell Ultra Encode](https://www.magewell.com/ultra-encode) supports broadcasting RTMP streams, which can be ingested by the OptiView Real-time Streaming service.
 
 To begin, first power on your Ultra Encode, connect it to the internet (Ethernet or WiFi), and connect your video capture device. Once connected, [log in](https://www.magewell.com/files/documents/User_Manual/ultra_encode_user_manual_en.pdf) to the Ultra Encode dashboard and navigate to the `Streaming Server` tab on the left side panel. Inside of `Streaming Server` click the `+ Add Server` button and select `RTMP`.
 
@@ -23,7 +23,7 @@ import RtmpMagewell from '../../assets/img/hardware-encoders/rmtp-magewell.png';
   <img src={RtmpMagewell} width="600" />
 </div>
 
-Next, navigate to your [Dolby.io Dashboard](https://dashboard.dolby.io/signin) and [gather your RTMP token credentials](/millicast/broadcast/rtmp-and-rtmps.mdx#how-to-find-your-rtmp-publish-url). Add the `RTMP publish path` from your Dolby.io Dashboard to the `URL`, and add your `RTMP Publish Stream Name`, also from the Dolby.io dashboard, to the `Stream key`.
+Next, navigate to your [OptiView Streaming Dashboard](https://dashboard.dolby.io/signin) and [gather your RTMP token credentials](/millicast/broadcast/rtmp-and-rtmps.mdx#how-to-find-your-rtmp-publish-url). Add the `RTMP publish path` from your OptiView Streaming Dashboard to the `URL`, and add your `RTMP Publish Stream Name`, also from the OptiView Streaming Dashboard, to the `Stream key`.
 
 Finally, select which network you'd like the encoder to use to connect, and save the settings.
 
@@ -51,7 +51,7 @@ import ConnectMagewellStream from '../../assets/img/hardware-encoders/connect-ma
 
 ## Using the Ultra Encode to broadcast SRT
 
-The [Magewell Ultra Encode](https://www.magewell.com/ultra-encode) supports broadcasting SRT streams, which can be ingested by the Dolby.io Real-time Streaming service.
+The [Magewell Ultra Encode](https://www.magewell.com/ultra-encode) supports broadcasting SRT streams, which can be ingested by the OptiView Real-time Streaming service.
 
 To begin, first power on your Ultra Encode, connect it to the internet (Ethernet or WiFi), and connect your video capture device. Once connected, [log in](https://www.magewell.com/files/documents/User_Manual/ultra_encode_user_manual_en.pdf) to the Ultra Encode dashboard and navigate to the `Streaming Server` tab on the left side panel. Inside of `Streaming Server` click the `+ Add Server` button and select `SRT Caller`.
 
@@ -61,7 +61,7 @@ import SrtCaller from '../../assets/img/hardware-encoders/srt-caller.png';
   <img src={SrtCaller} width="600" />
 </div>
 
-Next, navigate to your [Dolby.io Dashboard](https://dashboard.dolby.io/signin) and [gather your SRT token credentials](/millicast/broadcast/srt.mdx). Add the `SRT publish path` from your Dolby.io Dashboard to the `Address`, set the `Port` to `10000`, and add your `SRT Stream ID`, also from the Dolby.io dashboard, to the `Stream ID`.
+Next, navigate to your [OptiView Streaming Dashboard](https://dashboard.dolby.io/signin) and [gather your SRT token credentials](/millicast/broadcast/srt.mdx). Add the `SRT publish path` from your OptiView Streaming Dashboard to the `Address`, set the `Port` to `10000`, and add your `SRT Stream ID`, also from the OptiView Streaming Dashboard, to the `Stream ID`.
 
 import SrtSetup from '../../assets/img/hardware-encoders/srt-setup.png';
 
@@ -69,7 +69,7 @@ import SrtSetup from '../../assets/img/hardware-encoders/srt-setup.png';
   <img src={SrtSetup} width="600" />
 </div>
 
-Additionally, if you have `Passphrase encryption` enabled on the Dolby.io Dashboard, you can enable it on the encoder side by setting `Encryption` to `AES-128`.
+Additionally, if you have `Passphrase encryption` enabled on the OptiView Streaming Dashboard, you can enable it on the encoder side by setting `Encryption` to `AES-128`.
 
 Once saved, make sure the stream is activated by toggling the server switch on the `Streaming Server` page.
 

--- a/millicast/broadcast/hardware-encoders/magewell.mdx
+++ b/millicast/broadcast/hardware-encoders/magewell.mdx
@@ -23,7 +23,7 @@ import RtmpMagewell from '../../assets/img/hardware-encoders/rmtp-magewell.png';
   <img src={RtmpMagewell} width="600" />
 </div>
 
-Next, navigate to your [OptiView Real-time Streaming Dashboard](https://dashboard.dolby.io/signin) and [gather your RTMP token credentials](/millicast/broadcast/rtmp-and-rtmps.mdx#how-to-find-your-rtmp-publish-url). Add the `RTMP publish path` from your OptiView Real-time Streaming Dashboard to the `URL`, and add your `RTMP Publish Stream Name`, also from the OptiView Real-time Streaming Dashboard, to the `Stream key`.
+Next, navigate to your [OptiView Real-time Streaming Dashboard](https://streaming.dolby.io/signin) and [gather your RTMP token credentials](/millicast/broadcast/rtmp-and-rtmps.mdx#how-to-find-your-rtmp-publish-url). Add the `RTMP publish path` from your OptiView Real-time Streaming Dashboard to the `URL`, and add your `RTMP Publish Stream Name`, also from the OptiView Real-time Streaming Dashboard, to the `Stream key`.
 
 Finally, select which network you'd like the encoder to use to connect, and save the settings.
 
@@ -61,7 +61,7 @@ import SrtCaller from '../../assets/img/hardware-encoders/srt-caller.png';
   <img src={SrtCaller} width="600" />
 </div>
 
-Next, navigate to your [OptiView Real-time Streaming Dashboard](https://dashboard.dolby.io/signin) and [gather your SRT token credentials](/millicast/broadcast/srt.mdx). Add the `SRT publish path` from your OptiView Real-time Streaming Dashboard to the `Address`, set the `Port` to `10000`, and add your `SRT Stream ID`, also from the OptiView Real-time Streaming Dashboard, to the `Stream ID`.
+Next, navigate to your [OptiView Real-time Streaming Dashboard](https://streaming.dolby.io/signin) and [gather your SRT token credentials](/millicast/broadcast/srt.mdx). Add the `SRT publish path` from your OptiView Real-time Streaming Dashboard to the `Address`, set the `Port` to `10000`, and add your `SRT Stream ID`, also from the OptiView Real-time Streaming Dashboard, to the `Stream ID`.
 
 import SrtSetup from '../../assets/img/hardware-encoders/srt-setup.png';
 

--- a/millicast/broadcast/hardware-encoders/osprey.mdx
+++ b/millicast/broadcast/hardware-encoders/osprey.mdx
@@ -43,7 +43,7 @@ import OspreyTalon3 from '../../assets/img/hardware-encoders/osprey_login.jpeg';
 
 ### How-to use Osprey Talon with WHIP
 
-To get started, you'll have to [login](https://streaming.dolby.io) to a OptiView Real-time account. Within the account, you'll need the _Stream Name_ and _Publishing Token_.
+To get started, you'll have to [login](https://streaming.dolby.io) to an OptiView Real-time account. Within the account, you'll need the _Stream Name_ and _Publishing Token_.
 
 Inside the encoder UI, click on the _Channels_ tab. From the Channels tab, set the protocol to OptiView (WebRTC). Enter your Stream Name and Publishing Token in the corresponding fields.
 
@@ -61,11 +61,11 @@ import OspreyBroadcast from '../../assets/img/hardware-encoders/osprey_broadcast
   <img src={OspreyBroadcast} width="600" />
 </div>
 
-The stream is now live. To view the stream, navigate back to your newly created token on the OptiView Streaming Dashboard and switch to the _Playback_ tab. From the Playback tab, copy the _Hosted Player Path_ URL and open it in your browser.
+The stream is now live. To view the stream, navigate back to your newly created token on the OptiView Real-time Streaming Dashboard and switch to the _Playback_ tab. From the Playback tab, copy the _Hosted Player Path_ URL and open it in your browser.
 
 ### How-to use Osprey Talon with SRT
 
-To get started, you'll have to [login](https://streaming.dolby.io) to a OptiView Real-time account. Within the account, you'll need the _SRT stream ID_ and _SRT publish path_.
+To get started, you'll have to [login](https://streaming.dolby.io) to an OptiView Real-time account. Within the account, you'll need the _SRT stream ID_ and _SRT publish path_.
 
 Inside the encoder UI, click on the _Channels_ tab. From the Channels tab, set the protocol to **TS over SRT**.
 
@@ -82,7 +82,7 @@ Once configured, you can press start and the encoder will begin streaming conten
 
 #### Turn on SRT encryption
 
-To enable SRT encryption for the SRT feed, in the OptiView Streaming Dashboard for your stream token, enable **Passphrase encryption** and copy the **SRT passphrase**.
+To enable SRT encryption for the SRT feed, in the OptiView Real-time Streaming Dashboard for your stream token, enable **Passphrase encryption** and copy the **SRT passphrase**.
 
 import StrPassphrase from '../../assets/img/hardware-encoders/osprey_srt_passphrase.png';
 
@@ -102,7 +102,7 @@ Once configured, you can press start and the encoder will begin streaming conten
 
 ### How-to use Osprey Talon with RTMP
 
-To get started, you'll have to [login](https://streaming.dolby.io) to a OptiView Real-time account. Within the account, you'll need the _RTMP publish path_ and _RTMP publish stream name_.
+To get started, you'll have to [login](https://streaming.dolby.io) to an OptiView Real-time account. Within the account, you'll need the _RTMP publish path_ and _RTMP publish stream name_.
 
 Inside the encoder UI, click on the _Channels_ tab. From the Channels tab, set the protocol to **RTMP/RTMPS**.
 

--- a/millicast/broadcast/hardware-encoders/osprey.mdx
+++ b/millicast/broadcast/hardware-encoders/osprey.mdx
@@ -43,9 +43,9 @@ import OspreyTalon3 from '../../assets/img/hardware-encoders/osprey_login.jpeg';
 
 ### How-to use Osprey Talon with WHIP
 
-To get started, you'll have to [login](https://streaming.dolby.io) to a Dolby.io account. Within the account, you'll need the _Stream Name_ and _Publishing Token_.
+To get started, you'll have to [login](https://streaming.dolby.io) to a OptiView Real-time account. Within the account, you'll need the _Stream Name_ and _Publishing Token_.
 
-Inside the encoder UI, click on the _Channels_ tab. From the Channels tab, set the protocol to Dolby.io (WebRTC). Enter your Stream Name and Publishing Token in the corresponding fields.
+Inside the encoder UI, click on the _Channels_ tab. From the Channels tab, set the protocol to OptiView (WebRTC). Enter your Stream Name and Publishing Token in the corresponding fields.
 
 import WhipOsprey from '../../assets/img/hardware-encoders/osprey_talon_whip.png';
 
@@ -61,11 +61,11 @@ import OspreyBroadcast from '../../assets/img/hardware-encoders/osprey_broadcast
   <img src={OspreyBroadcast} width="600" />
 </div>
 
-The stream is now live. To view the stream, navigate back to your newly created token on the Dolby.io Dashboard and switch to the _Playback_ tab. From the Playback tab, copy the _Hosted Player Path_ URL and open it in your browser.
+The stream is now live. To view the stream, navigate back to your newly created token on the OptiView Streaming Dashboard and switch to the _Playback_ tab. From the Playback tab, copy the _Hosted Player Path_ URL and open it in your browser.
 
 ### How-to use Osprey Talon with SRT
 
-To get started, you'll have to [login](https://streaming.dolby.io) to a Dolby.io account. Within the account, you'll need the _SRT stream ID_ and _SRT publish path_.
+To get started, you'll have to [login](https://streaming.dolby.io) to a OptiView Real-time account. Within the account, you'll need the _SRT stream ID_ and _SRT publish path_.
 
 Inside the encoder UI, click on the _Channels_ tab. From the Channels tab, set the protocol to **TS over SRT**.
 
@@ -82,7 +82,7 @@ Once configured, you can press start and the encoder will begin streaming conten
 
 #### Turn on SRT encryption
 
-To enable SRT encryption for the SRT feed, in the Dolby.io dashboard for your stream token, enable **Passphrase encryption** and copy the **SRT passphrase**.
+To enable SRT encryption for the SRT feed, in the OptiView Streaming Dashboard for your stream token, enable **Passphrase encryption** and copy the **SRT passphrase**.
 
 import StrPassphrase from '../../assets/img/hardware-encoders/osprey_srt_passphrase.png';
 
@@ -102,7 +102,7 @@ Once configured, you can press start and the encoder will begin streaming conten
 
 ### How-to use Osprey Talon with RTMP
 
-To get started, you'll have to [login](https://streaming.dolby.io) to a Dolby.io account. Within the account, you'll need the _RTMP publish path_ and _RTMP publish stream name_.
+To get started, you'll have to [login](https://streaming.dolby.io) to a OptiView Real-time account. Within the account, you'll need the _RTMP publish path_ and _RTMP publish stream name_.
 
 Inside the encoder UI, click on the _Channels_ tab. From the Channels tab, set the protocol to **RTMP/RTMPS**.
 

--- a/millicast/broadcast/hardware-encoders/teradek.mdx
+++ b/millicast/broadcast/hardware-encoders/teradek.mdx
@@ -3,7 +3,7 @@ title: Teradek
 slug: /hardware-encoders/teradek
 ---
 
-**Teradek** is a designer and manufacturer of professional high-end video equipment and solutions for creating and sharing content. Teradek offers a range of support for different broadcast standards and protocols, including support for [RTMP, RTMPS](/millicast/broadcast/rtmp-and-rtmps.mdx), [SRT](/millicast/broadcast/srt.mdx), and [NDI](/millicast/broadcast/ndi.md), all of which can be distributed via the Dolby.io real-time streaming CDN.
+**Teradek** is a designer and manufacturer of professional high-end video equipment and solutions for creating and sharing content. Teradek offers a range of support for different broadcast standards and protocols, including support for [RTMP, RTMPS](/millicast/broadcast/rtmp-and-rtmps.mdx), [SRT](/millicast/broadcast/srt.mdx), and [NDI](/millicast/broadcast/ndi.md), all of which can be distributed via the OptiView Real-time CDN.
 
 :::tip Getting Started
 If you haven't already, begin by following the [Getting Started](/millicast/getting-started/index.mdx) tutorial to start your first broadcast. You'll need your _RTMP publish path_ and _RTMP publish stream name_ for the steps described below.
@@ -15,7 +15,7 @@ See the official [Teradek](https://teradek.com/) site for documentation, install
 
 ### How-to setup the VidiU for RTMP streaming
 
-To get started, you'll have to [login](https://streaming.dolby.io) to a Dolby.io account. Within the account, you'll need to create a token and copy RTMP publishing paths. You'll also have to download the [Vidiu or Teradek app](https://teradek.com/pages/vidiu-x) for your mobile device.
+To get started, you'll have to [login](https://streaming.dolby.io) to a OptiView Real-time account. Within the account, you'll need to create a token and copy RTMP publishing paths. You'll also have to download the [Vidiu or Teradek app](https://teradek.com/pages/vidiu-x) for your mobile device.
 
 From your VidiU app on your mobile device, select `Device > Settings > Broadcast > Platform`. After Platform, select `RTMP(S)` at the bottom of the menu.
 
@@ -33,7 +33,7 @@ import Vidiu2 from '../../assets/img/hardware-encoders/teradek-vidiu2.png';
   <img src={Vidiu2} width="400" />
 </div>
 
-Enter your Dolby.io Real-time Streaming RTMP or RTMPS path, and your RTMP publish stream name:
+Enter your OptiView Real-time Streaming RTMP or RTMPS path, and your RTMP publish stream name:
 
 - For example, RTMP would look similar to:  
   `rtmp://rtmp-auto.millicast.com:1935/v2/pub`
@@ -54,7 +54,7 @@ To view the stream, navigate back to your newly created token and switch to the 
 
 ### How-to setup the Teradek Wave for RTMP streaming
 
-To get started, you'll have to [login](https://streaming.dolby.io) to a Dolby.io account. Within the account, you'll need to create a token and copy RTMP publishing paths. You'll also have to have your Teradek Wave in hand, ready to use.
+To get started, you'll have to [login](https://streaming.dolby.io) to a OptiView Real-time account. Within the account, you'll need to create a token and copy RTMP publishing paths. You'll also have to have your Teradek Wave in hand, ready to use.
 
 - From your Teradek Wave, start by selecting `Create event > Device > Configure your event`and setting your Channel Name.
 - Set the Server URL for RTMP as your RTMP publish path. For example:  
@@ -79,4 +79,4 @@ You can also adjust the additional settings on the Teredak Wave, such as:
 
 To view the stream, navigate back to your newly created token and switch to the _Playback_ tab. From the Playback tab, copy the _Hosted Player Path_ URL and open it in your browser.
 
-Teredak products that use [RTMP, RTMPS](/millicast/broadcast/rtmp-and-rtmps.mdx), [SRT](/millicast/broadcast/srt.mdx), and [NDI](/millicast/broadcast/ndi.md) can all be used with Dolby.io Real-time Streaming for low-latency streams with global delivery.
+Teredak products that use [RTMP, RTMPS](/millicast/broadcast/rtmp-and-rtmps.mdx), [SRT](/millicast/broadcast/srt.mdx), and [NDI](/millicast/broadcast/ndi.md) can all be used with OptiView Real-time Streaming for low-latency streams with global delivery.

--- a/millicast/broadcast/hardware-encoders/teradek.mdx
+++ b/millicast/broadcast/hardware-encoders/teradek.mdx
@@ -15,7 +15,7 @@ See the official [Teradek](https://teradek.com/) site for documentation, install
 
 ### How-to setup the VidiU for RTMP streaming
 
-To get started, you'll have to [login](https://streaming.dolby.io) to a OptiView Real-time account. Within the account, you'll need to create a token and copy RTMP publishing paths. You'll also have to download the [Vidiu or Teradek app](https://teradek.com/pages/vidiu-x) for your mobile device.
+To get started, you'll have to [login](https://streaming.dolby.io) to an OptiView Real-time account. Within the account, you'll need to create a token and copy RTMP publishing paths. You'll also have to download the [Vidiu or Teradek app](https://teradek.com/pages/vidiu-x) for your mobile device.
 
 From your VidiU app on your mobile device, select `Device > Settings > Broadcast > Platform`. After Platform, select `RTMP(S)` at the bottom of the menu.
 
@@ -54,7 +54,7 @@ To view the stream, navigate back to your newly created token and switch to the 
 
 ### How-to setup the Teradek Wave for RTMP streaming
 
-To get started, you'll have to [login](https://streaming.dolby.io) to a OptiView Real-time account. Within the account, you'll need to create a token and copy RTMP publishing paths. You'll also have to have your Teradek Wave in hand, ready to use.
+To get started, you'll have to [login](https://streaming.dolby.io) to an OptiView Real-time account. Within the account, you'll need to create a token and copy RTMP publishing paths. You'll also have to have your Teradek Wave in hand, ready to use.
 
 - From your Teradek Wave, start by selecting `Create event > Device > Configure your event`and setting your Channel Name.
 - Set the Server URL for RTMP as your RTMP publish path. For example:  

--- a/millicast/broadcast/hardware-encoders/videon.mdx
+++ b/millicast/broadcast/hardware-encoders/videon.mdx
@@ -57,7 +57,7 @@ import AudioProfiles from '../../assets/img/hardware-encoders/videon_audio_profi
 
 #### Using RTMP
 
-Open your OptiView Streaming Dashboard and copy the [**RTMP publishing paths**](/millicast/broadcast/rtmp-and-rtmps.mdx). Additionally, enable the** RTMP multi-bitrate** toggle. You can also use the [Multi-Source builder](/millicast/streaming-dashboard/multi-source-builder.mdx) to generate those URLs.
+Open your OptiView Real-time Streaming Dashboard and copy the [**RTMP publishing paths**](/millicast/broadcast/rtmp-and-rtmps.mdx). Additionally, enable the** RTMP multi-bitrate** toggle. You can also use the [Multi-Source builder](/millicast/streaming-dashboard/multi-source-builder.mdx) to generate those URLs.
 
 Under **Outputs**, for each **RTMP**, select **Video Source** corresponding to the RTMP profile (1080p for the highest profile and 360p for the lowest profile). Make sure to set **Streaming Providers** to _Generic RTMP_ and paste the **Stream URL** from the OptiView RTMP dashboard.
 
@@ -85,7 +85,7 @@ import VideonRtmp from '../../assets/img/hardware-encoders/videon-rtmp.png';
 
 #### Using SRT
 
-Under **Outputs**, for each **SRT**, select **Video Source** corresponding to the SRT profile (1080p for the highest profile and 360p for the lowest profile). For the **URL**, select the _srt://_ protocol, enter the URL of the **SRT publish path** from the OptiView Streaming Dashboard, and enter port 10000. For the **Stream ID**, use the **SRT stream ID** from the dashboard and append **&simulcastId** for the first layer, **&sourceId=1&simulcastId&videoOnly** for the second layer, and **&sourceId=2&simulcastId&videoOnly** for the third layer. You can also use the [Multi-Source builder](/millicast/streaming-dashboard/multi-source-builder.mdx) to generate those URLs.
+Under **Outputs**, for each **SRT**, select **Video Source** corresponding to the SRT profile (1080p for the highest profile and 360p for the lowest profile). For the **URL**, select the _srt://_ protocol, enter the URL of the **SRT publish path** from the OptiView Real-time Streaming Dashboard, and enter port 10000. For the **Stream ID**, use the **SRT stream ID** from the dashboard and append **&simulcastId** for the first layer, **&sourceId=1&simulcastId&videoOnly** for the second layer, and **&sourceId=2&simulcastId&videoOnly** for the third layer. You can also use the [Multi-Source builder](/millicast/streaming-dashboard/multi-source-builder.mdx) to generate those URLs.
 
 Example:
 

--- a/millicast/broadcast/hardware-encoders/videon.mdx
+++ b/millicast/broadcast/hardware-encoders/videon.mdx
@@ -57,9 +57,9 @@ import AudioProfiles from '../../assets/img/hardware-encoders/videon_audio_profi
 
 #### Using RTMP
 
-Open your Dolby.io dashboard and copy the [**RTMP publishing paths**](/millicast/broadcast/rtmp-and-rtmps.mdx). Additionally, enable the** RTMP multi-bitrate** toggle. You can also use the [Multi-Source builder](/millicast/streaming-dashboard/multi-source-builder.mdx) to generate those URLs.
+Open your OptiView Streaming Dashboard and copy the [**RTMP publishing paths**](/millicast/broadcast/rtmp-and-rtmps.mdx). Additionally, enable the** RTMP multi-bitrate** toggle. You can also use the [Multi-Source builder](/millicast/streaming-dashboard/multi-source-builder.mdx) to generate those URLs.
 
-Under **Outputs**, for each **RTMP**, select **Video Source** corresponding to the RTMP profile (1080p for the highest profile and 360p for the lowest profile). Make sure to set **Streaming Providers** to _Generic RTMP_ and paste the **Stream URL** from the Dolby.io RTMP dashboard.
+Under **Outputs**, for each **RTMP**, select **Video Source** corresponding to the RTMP profile (1080p for the highest profile and 360p for the lowest profile). Make sure to set **Streaming Providers** to _Generic RTMP_ and paste the **Stream URL** from the OptiView RTMP dashboard.
 
 import OutputsImg from '../../assets/img/hardware-encoders/videon_outputs.png';
 
@@ -85,7 +85,7 @@ import VideonRtmp from '../../assets/img/hardware-encoders/videon-rtmp.png';
 
 #### Using SRT
 
-Under **Outputs**, for each **SRT**, select **Video Source** corresponding to the SRT profile (1080p for the highest profile and 360p for the lowest profile). For the **URL**, select the _srt://_ protocol, enter the URL of the **SRT publish path** from the Dolby.io dashboard, and enter port 10000. For the **Stream ID**, use the **SRT stream ID** from the dashboard and append **&simulcastId** for the first layer, **&sourceId=1&simulcastId&videoOnly** for the second layer, and **&sourceId=2&simulcastId&videoOnly** for the third layer. You can also use the [Multi-Source builder](/millicast/streaming-dashboard/multi-source-builder.mdx) to generate those URLs.
+Under **Outputs**, for each **SRT**, select **Video Source** corresponding to the SRT profile (1080p for the highest profile and 360p for the lowest profile). For the **URL**, select the _srt://_ protocol, enter the URL of the **SRT publish path** from the OptiView Streaming Dashboard, and enter port 10000. For the **Stream ID**, use the **SRT stream ID** from the dashboard and append **&simulcastId** for the first layer, **&sourceId=1&simulcastId&videoOnly** for the second layer, and **&sourceId=2&simulcastId&videoOnly** for the third layer. You can also use the [Multi-Source builder](/millicast/streaming-dashboard/multi-source-builder.mdx) to generate those URLs.
 
 Example:
 

--- a/millicast/broadcast/index.mdx
+++ b/millicast/broadcast/index.mdx
@@ -106,7 +106,7 @@ To learn how to create a stream from OBS using WebRTC, see the following video:
 The **Secure Reliable Transport ([SRT](/millicast/broadcast/srt.mdx))** is an open-source protocol that uses an intelligent packet retransmission mechanism on otp of a UDP data flow along with AES-128 and 256-bit encryption. Dolby is part of the _SRT Alliance_, an organization to promote the technology for optimizing streaming performance.
 
 [How-to setup an OptiView Real-time SRT Stream](/millicast/broadcast/srt.mdx)<br/>
-The OptiView Streaming Dashboard is used to configure the publish path and stream id for an incoming SRT media stream.
+The OptiView Real-time Streaming Dashboard is used to configure the publish path and stream id for an incoming SRT media stream.
 
 [How-to use OBS with SRT](/millicast/broadcast/software-encoders/obs/index.mdx)<br/>
 **Open Broadcaster Software (OBS)** is free and open source software is popular for cross-platform streaming. You will need to download a recent version of OBS that has been extended to provide SRT support.
@@ -130,7 +130,7 @@ To learn how to create a stream from OBS using SRT, see the following video:
 **Real-time Messaging Protocol ([RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx))** is well-established in many hardware and software applications. With many years of use, RTMP is a good option for compatibility while sacrificing some latency in order to handle transmuxing the incoming stream to WebRTC.
 
 [How-to setup an OptiView Real-time RTMP Stream](/millicast/broadcast/rtmp-and-rtmps.mdx)<br/>
-The OptiView Streaming Dashboard is used to configure the publish path and stream id for an incoming RTMP or RTMPs media stream.
+The OptiView Real-time Streaming Dashboard is used to configure the publish path and stream id for an incoming RTMP or RTMPs media stream.
 
 [How-to use FFmpeg with RTMP](/millicast/broadcast/software-encoders/ffmpeg.mdx)<br/>
 **FFmpeg** is a free and open-source software project that is commonly used in legacy media workflows. It is a command-line tool that is capable of outputting streaming content via RTMP, RTMPS, and RTSP.
@@ -153,7 +153,7 @@ Publish parameters allow modifying broadcasting preferences to customize streami
 
 Web and mobile browsers are widely available and have wide encoding support, whether broadcasting from Chrome, Safari, Firefox, or Edge. To start broadcasting, see the [Getting Started with Broadcasting](/millicast/getting-started/index.mdx) guide.
 
-You can also start broadcasting directly from the OptiView Streaming Dashboard. For more information, see the following video:
+You can also start broadcasting directly from the OptiView Real-time Streaming Dashboard. For more information, see the following video:
 
 <div className="youtube-container">
   <iframe

--- a/millicast/broadcast/index.mdx
+++ b/millicast/broadcast/index.mdx
@@ -6,13 +6,13 @@ slug: /broadcast
 
 import DocCardList from '@theme/DocCardList';
 
-Broadcasting content requires access to the public internet and encoding, which can be accomplished in a browser, software, hardware, or with the Dolby.io Client-side broadcaster SDKs.
+Broadcasting content requires access to the public internet and encoding, which can be accomplished in a browser, software, hardware, or with the OptiView Real-time client-side broadcaster SDKs.
 
-The Dolby.io CDN can ingest streams encoded in a few main formats:
+The OptiView Real-time CDN can ingest streams encoded in a few main formats:
 
 - [WebRTC](/millicast/broadcast/webrtc-and-whip.mdx), an internet transfer protocol that supports video codecs H.264, H.265, VP8, VP9, AV1, and the Opus audio codec. Broad support is made possible through implementations of **WebRTC HTTP Ingest Protocol (WHIP)**.
-- [SRT](/millicast/broadcast/srt.mdx), a video transfer protocol that can be transmuxed to WebRTC via the Dolby.io CDN and supports H.264 video and AAC audio.
-- [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) **and RTMPS**, internet transfer protocols that can be transmuxed to WebRTC via the Dolby.io CDN that supports only the H.264 video codec.
+- [SRT](/millicast/broadcast/srt.mdx), a video transfer protocol that can be transmuxed to WebRTC via the OptiView Real-time CDN and supports H.264 video and AAC audio.
+- [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) **and RTMPS**, internet transfer protocols that can be transmuxed to WebRTC via the OptiView Real-time CDN that supports only the H.264 video codec.
 
 _SRT and RTMP will automatically have AAC audio converted to Opus via the CDN_
 
@@ -76,16 +76,16 @@ The **WebRTC-HTTP Ingestion Protocol ([WHIP](/millicast/broadcast/webrtc-and-whi
 WHIP acts like a signaler, handling the creation and deletion of endpoints needed during transport while maintaining the benefits of WebRTC, such as end-to-end encryption and ultra-low latency.
 
 [How-to use GStreamer with WHIP](/millicast/broadcast/software-encoders/gstreamer.mdx)<br/>
-**GStreamer** is a popular pipeline-based media framework that links together multiple nodes into a media processing workflow. Using WHIP, you can encode an output node to broadcast streaming content through Dolby.io.
+**GStreamer** is a popular pipeline-based media framework that links together multiple nodes into a media processing workflow. Using WHIP, you can encode an output node to broadcast streaming content through OptiView Real-time Streaming.
 
 [How-to use FlowCaster with WHIP](/millicast/broadcast/software-encoders/flowcaster.mdx)<br/>
 **FlowCaster** software provides a secure connection to provide IP streaming for editors and remote collaboration.
 
 [How-to use LiveU Studio with WHIP](/millicast/broadcast/software-encoders/liveu-studio.mdx)<br/>
-**LiveU Studio** is a cloud-based SaaS solution for live video production. By supporting WHIP, media streams ingested from LiveU Studio and can be broadcast by Dolby.io.
+**LiveU Studio** is a cloud-based SaaS solution for live video production. By supporting WHIP, media streams ingested from LiveU Studio can be broadcast by OptiView Real-time Streaming.
 
 [How-to Setup an Osprey Talon for WHIP](/millicast/broadcast/hardware-encoders/osprey.mdx)<br/>
-The **Osprey Talon** provides exceptional quality with 4k resolution and a plug-and-play interface. There are some recommended settings to enable broadcasting to the Dolby.io platform by using this encoder in the pipeline.
+The **Osprey Talon** provides exceptional quality with 4k resolution and a plug-and-play interface. There are some recommended settings to enable broadcasting to the OptiView Real-time platform by using this encoder in the pipeline.
 
 To learn how to create a stream from OBS using WebRTC, see the following video:
 
@@ -105,8 +105,8 @@ To learn how to create a stream from OBS using WebRTC, see the following video:
 
 The **Secure Reliable Transport ([SRT](/millicast/broadcast/srt.mdx))** is an open-source protocol that uses an intelligent packet retransmission mechanism on otp of a UDP data flow along with AES-128 and 256-bit encryption. Dolby is part of the _SRT Alliance_, an organization to promote the technology for optimizing streaming performance.
 
-[How-to setup a Dolby.io SRT Stream](/millicast/broadcast/srt.mdx)<br/>
-The Dolby.io dashboard is used to configure the publish path and stream id for an incoming SRT media stream.
+[How-to setup an OptiView Real-time SRT Stream](/millicast/broadcast/srt.mdx)<br/>
+The OptiView Streaming Dashboard is used to configure the publish path and stream id for an incoming SRT media stream.
 
 [How-to use OBS with SRT](/millicast/broadcast/software-encoders/obs/index.mdx)<br/>
 **Open Broadcaster Software (OBS)** is free and open source software is popular for cross-platform streaming. You will need to download a recent version of OBS that has been extended to provide SRT support.
@@ -129,20 +129,20 @@ To learn how to create a stream from OBS using SRT, see the following video:
 
 **Real-time Messaging Protocol ([RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx))** is well-established in many hardware and software applications. With many years of use, RTMP is a good option for compatibility while sacrificing some latency in order to handle transmuxing the incoming stream to WebRTC.
 
-[How-to setup a Dolby.io RTMP Stream](/millicast/broadcast/rtmp-and-rtmps.mdx)<br/>
-The Dolby.io dashboard is used to configure the publish path and stream id for an incoming RTMP or RTMPs media stream.
+[How-to setup an OptiView Real-time RTMP Stream](/millicast/broadcast/rtmp-and-rtmps.mdx)<br/>
+The OptiView Streaming Dashboard is used to configure the publish path and stream id for an incoming RTMP or RTMPs media stream.
 
 [How-to use FFmpeg with RTMP](/millicast/broadcast/software-encoders/ffmpeg.mdx)<br/>
 **FFmpeg** is a free and open-source software project that is commonly used in legacy media workflows. It is a command-line tool that is capable of outputting streaming content via RTMP, RTMPS, and RTSP.
 
 [How-to use vMix with RTMP](/millicast/broadcast/software-encoders/vmix.mdx)<br/>
-**vMix** is a software vision mixer available for Windows. It is useful for certain live video production workflows and supports RTMP output that can be broadcast by Dolby.io.
+**vMix** is a software vision mixer available for Windows. It is useful for certain live video production workflows and supports RTMP output that can be broadcast by OptiView Real-time Streaming.
 
 [How-to Setup a Haivision KB encoder for RTMP](/millicast/broadcast/hardware-encoders/haivision.mdx)<br/>
 The **Haivision KB** series of media encoders deliver high-quality video streaming with 4k resolution and a plug-and-play interface with a small rack-mountable form factor. There are some recommended encoding sessions to optimize this encoder in the broadcast pipeline.
 
 [How-to Setup a Teradek VidiU Go for RTMP](/millicast/broadcast/hardware-encoders/teradek.mdx)<br/>
-The **Teradek VidiU Go** is a hardware encoder is capable of broadcast quality video that can be sent over RTMP for compatibility with Dolby.io broadcast workflows.
+The **Teradek VidiU Go** is a hardware encoder is capable of broadcast quality video that can be sent over RTMP for compatibility with OptiView Real-time broadcast workflows.
 
 ### Publish parameters
 
@@ -153,7 +153,7 @@ Publish parameters allow modifying broadcasting preferences to customize streami
 
 Web and mobile browsers are widely available and have wide encoding support, whether broadcasting from Chrome, Safari, Firefox, or Edge. To start broadcasting, see the [Getting Started with Broadcasting](/millicast/getting-started/index.mdx) guide.
 
-You can also start broadcasting directly from the Dolby.io dashboard. For more information, see the following video:
+You can also start broadcasting directly from the OptiView Streaming Dashboard. For more information, see the following video:
 
 <div className="youtube-container">
   <iframe

--- a/millicast/broadcast/multi-source-broadcasting.mdx
+++ b/millicast/broadcast/multi-source-broadcasting.mdx
@@ -3,7 +3,7 @@ title: Multi-Source Broadcasting
 sidebar_position: 9
 ---
 
-**Multi-source Broadcasting** allows you to ingest and send additional capture sources, such as different camera angles, to the Dolby.io Real-time Streaming platform where they will be logically grouped into an optimized multi-view experience over a single WebRTC connection.
+**Multi-source Broadcasting** allows you to ingest and send additional capture sources, such as different camera angles, to the OptiView Real-time Streaming platform where they will be logically grouped into an optimized multi-view experience over a single WebRTC connection.
 
 There are two main use cases where broadcasting multiple video and audio feeds to a stream is useful:
 

--- a/millicast/broadcast/ndi.md
+++ b/millicast/broadcast/ndi.md
@@ -22,7 +22,7 @@ Install the [NDI tools](https://ndi.video/type/ndi-tools/) on your computer. If 
 
 ### How-to publish NDI with OptiView Real-time Streaming Dashboard broadcaster
 
-Sign in to your [OptiView Real-time Streaming dashboard](https://dashboard.dolby.io/) and create a stream token. Press the broadcast button, and inside the Broadcaster, select the camera icon on the bottom left. Here you will see a list of possible camera selections. If you have an NDI camera like NewTek, Angekis, or AIDA, it will show up in the dropdown, and you are ready to go.
+Sign in to your [OptiView Real-time Streaming dashboard](https://streaming.dolby.io/) and create a stream token. Press the broadcast button, and inside the Broadcaster, select the camera icon on the bottom left. Here you will see a list of possible camera selections. If you have an NDI camera like NewTek, Angekis, or AIDA, it will show up in the dropdown, and you are ready to go.
 
 import CaptureScreen1 from '../assets/img/Capture_decran_2023-07-07_a_12.10.26_PM.png';
 

--- a/millicast/broadcast/ndi.md
+++ b/millicast/broadcast/ndi.md
@@ -7,7 +7,7 @@ sidebar_position: 5
 
 This guide will outline four options for NDI delivery:
 
-1. [How-to Publish NDI with OptiView Streaming Dashboard Broadcaster](#how-to-publish-ndi-with-optiview-streaming-dashboard-broadcaster)
+1. [How-to Publish NDI with OptiView Real-time Streaming Dashboard Broadcaster](#how-to-publish-ndi-with-optiview-real-time-streaming-dashboard-broadcaster)
 2. [How-to Publish NDI with OBS-WebRTC](#how-to-publish-ndi-with-obs-webrtc)
 3. [How-to Publish Video Editor with NDI](#how-to-publish-video-editor-with-ndi)
 4. [How-to Publish NDI with vMix](#how-to-publish-ndi-with-vmix)
@@ -15,12 +15,12 @@ This guide will outline four options for NDI delivery:
 ## NDI publishing
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You'll need your _publish token_ and _stream name_ for the steps described below.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast. You'll need your _publish token_ and _stream name_ for the steps described below.
 :::
 
 Install the [NDI tools](https://ndi.video/type/ndi-tools/) on your computer. If you do not have a NDI camera, you can download NDI HX Camera or similar to test the below workflows on you mobile device.
 
-### How-to publish NDI with OptiView Streaming Dashboard broadcaster
+### How-to publish NDI with OptiView Real-time Streaming Dashboard broadcaster
 
 Sign in to your [OptiView Real-time Streaming dashboard](https://dashboard.dolby.io/) and create a stream token. Press the broadcast button, and inside the Broadcaster, select the camera icon on the bottom left. Here you will see a list of possible camera selections. If you have an NDI camera like NewTek, Angekis, or AIDA, it will show up in the dropdown, and you are ready to go.
 

--- a/millicast/broadcast/ndi.md
+++ b/millicast/broadcast/ndi.md
@@ -3,11 +3,11 @@ title: NDI
 sidebar_position: 5
 ---
 
-**NDI**® Tools is a free suite of applications designed to introduce you to the world of IP. NDI makes it possible to connect to any device, in any location, anywhere in the world – and transmit live video to wherever you are. NDI systems and sources on your network. Combine NDI with Dolby.io Real-time Streaming to deliver real-time video for remote or interactive experiences.
+**NDI**® Tools is a free suite of applications designed to introduce you to the world of IP. NDI makes it possible to connect to any device, in any location, anywhere in the world – and transmit live video to wherever you are. NDI systems and sources on your network. Combine NDI with OptiView Real-time Streaming to deliver real-time video for remote or interactive experiences.
 
 This guide will outline four options for NDI delivery:
 
-1. [How-to Publish NDI with Dolby.io Dashboard Broadcaster](#how-to-publish-ndi-with-dolbyio-dashboard-broadcaster)
+1. [How-to Publish NDI with OptiView Streaming Dashboard Broadcaster](#how-to-publish-ndi-with-dolbyio-dashboard-broadcaster)
 2. [How-to Publish NDI with OBS-WebRTC](#how-to-publish-ndi-with-obs-webrtc)
 3. [How-to Publish Video Editor with NDI](#how-to-publish-video-editor-with-ndi)
 4. [How-to Publish NDI with vMix](#how-to-publish-ndi-with-vmix)
@@ -15,14 +15,14 @@ This guide will outline four options for NDI delivery:
 ## NDI publishing
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast. You'll need your _publish token_ and _stream name_ for the steps described below.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You'll need your _publish token_ and _stream name_ for the steps described below.
 :::
 
 Install the [NDI tools](https://ndi.video/type/ndi-tools/) on your computer. If you do not have a NDI camera, you can download NDI HX Camera or similar to test the below workflows on you mobile device.
 
-### How-to publish NDI with Dolby.io dashboard broadcaster
+### How-to publish NDI with OptiView Streaming Dashboard broadcaster
 
-Sign in to your [Dolby.io Real-Time Streaming dashboard](https://dashboard.dolby.io/) and create a stream token. Press the broadcast button, and inside the Broadcaster, select the camera icon on the bottom left. Here you will see a list of possible camera selections. If you have an NDI camera like NewTek, Angekis, or AIDA, it will show up in the dropdown, and you are ready to go.
+Sign in to your [OptiView Real-time Streaming dashboard](https://dashboard.dolby.io/) and create a stream token. Press the broadcast button, and inside the Broadcaster, select the camera icon on the bottom left. Here you will see a list of possible camera selections. If you have an NDI camera like NewTek, Angekis, or AIDA, it will show up in the dropdown, and you are ready to go.
 
 import CaptureScreen1 from '../assets/img/Capture_decran_2023-07-07_a_12.10.26_PM.png';
 
@@ -54,7 +54,7 @@ import CaptureScreen3 from '../assets/img/Capture_decran_2023-07-07_a_12.07.13_P
     <img src={CaptureScreen3} width="600" />
 </div>
 
-Go back into Dolby.io Broadcaster and select NDI Video from the video devices option in the camera icon. Now, point your mobile device anywhere, and you will see the stream coming in.
+Go back into OptiView Broadcaster and select NDI Video from the video devices option in the camera icon. Now, point your mobile device anywhere, and you will see the stream coming in.
 
 import CaptureScreen4 from '../assets/img/Capture_decran_2023-07-07_a_12.11.03_PM.png';
 
@@ -62,7 +62,7 @@ import CaptureScreen4 from '../assets/img/Capture_decran_2023-07-07_a_12.11.03_P
     <img src={CaptureScreen4} width="600" />
 </div>
 
-From here click the "Start" button to begin broadcasting the camera feed globally in real-time with Dolby.io.
+From here click the "Start" button to begin broadcasting the camera feed globally in real-time with OptiView Real-time Streaming.
 
 ### How-to publish NDI with OBS-WebRTC
 
@@ -92,7 +92,7 @@ import CaptureScreen7 from '../assets/img/Capture_decran_2023-07-07_a_12.21.16_P
     <img src={CaptureScreen7} width="600" />
 </div>
 
-After that, OBS needs to connect to our Dolby.io account. Go to Settings and click on the Stream button to add our stream token information.
+After that, OBS needs to connect to our OptiView Real-time account. Go to Settings and click on the Stream button to add our stream token information.
 
 import CaptureScreen8 from '../assets/img/Capture_decran_2023-07-07_a_12.36.26_PM.png';
 
@@ -136,7 +136,7 @@ import CaptureScreen12 from '../assets/img/Capture_decran_2023-07-07_a_12.56.47_
     <img src={CaptureScreen12} width="600" />
 </div>
 
-Inside Dolby.io's Broadcaster, select the camera option to be the NDI video, and you should see the playback before going live on your stream. Afterward, share the viewer link by pressing on the bottom right corner of the Broadcaster. These same steps can be repeated with Adobe After Effect.
+Inside OptiView's Broadcaster, select the camera option to be the NDI video, and you should see the playback before going live on your stream. Afterward, share the viewer link by pressing on the bottom right corner of the Broadcaster. These same steps can be repeated with Adobe After Effect.
 
 import CaptureScreen13 from '../assets/img/Capture_decran_2023-07-07_a_1.03.28_PM.png';
 
@@ -154,7 +154,7 @@ import CaptureScreen15 from '../assets/img/Capture_decran_2023-07-07_a_1.12.41_P
     <img src={CaptureScreen15} width="600" />
 </div>
 
-Open up a new Final Cut Pro project with it matching your NDI configuration and enable A/V Output in the Window menu. Check that your NDI Virtual Input is selected as Final Cut Pro, and the NDI Video is checked off in the Dolby.io Broadcaster to see the playback on the stream.
+Open up a new Final Cut Pro project with it matching your NDI configuration and enable A/V Output in the Window menu. Check that your NDI Virtual Input is selected as Final Cut Pro, and the NDI Video is checked off in the OptiView Broadcaster to see the playback on the stream.
 
 import CaptureScreen16 from '../assets/img/Capture_decran_2023-07-07_a_1.15.00_PM.png';
 
@@ -164,7 +164,7 @@ import CaptureScreen16 from '../assets/img/Capture_decran_2023-07-07_a_1.15.00_P
 
 ### How-to publish NDI with vMix
 
-You can also use [vMix as NDI](/millicast/broadcast/software-encoders/vmix.mdx) source if you do not wish to purchase the NDI HDX. This allows will allow vMix to be used as your switcher or remote source and flexibility with Dolby.io Real-time Streaming codecs with real-time publishing.
+You can also use [vMix as NDI](/millicast/broadcast/software-encoders/vmix.mdx) source if you do not wish to purchase the NDI HDX. This allows will allow vMix to be used as your switcher or remote source and flexibility with OptiView Real-time Streaming codecs with real-time publishing.
 
 ## Learn more
 

--- a/millicast/broadcast/ndi.md
+++ b/millicast/broadcast/ndi.md
@@ -7,7 +7,7 @@ sidebar_position: 5
 
 This guide will outline four options for NDI delivery:
 
-1. [How-to Publish NDI with OptiView Streaming Dashboard Broadcaster](#how-to-publish-ndi-with-dolbyio-dashboard-broadcaster)
+1. [How-to Publish NDI with OptiView Streaming Dashboard Broadcaster](#how-to-publish-ndi-with-optiview-streaming-dashboard-broadcaster)
 2. [How-to Publish NDI with OBS-WebRTC](#how-to-publish-ndi-with-obs-webrtc)
 3. [How-to Publish Video Editor with NDI](#how-to-publish-video-editor-with-ndi)
 4. [How-to Publish NDI with vMix](#how-to-publish-ndi-with-vmix)

--- a/millicast/broadcast/publishing-parameters.md
+++ b/millicast/broadcast/publishing-parameters.md
@@ -33,7 +33,7 @@ Any parameters that are boolean type can be used without a value. For example, t
 
 ## Available Parameters
 
-The Dolby.io Streaming APIs platform provides the following parameters:
+The OptiView Real-time Streaming APIs platform provides the following parameters:
 
 | Parameter name      | Type    | Description                                                                                                                                                                                                                                                                                                                                                                              |
 | :------------------ | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/millicast/broadcast/redundant-ingest/index.mdx
+++ b/millicast/broadcast/redundant-ingest/index.mdx
@@ -3,13 +3,13 @@ title: Redundant Ingest
 sidebar_position: 10
 ---
 
-To provide a resilient and reliable streaming experience, the Dolby.io Streaming platform allows broadcasting multiple redundant contribution streams. This solution ensures seamless content delivery to viewers, even in the case of unexpected technical issues.
+To provide a resilient and reliable streaming experience, the OptiView Real-time Streaming platform allows broadcasting multiple redundant contribution streams. This solution ensures seamless content delivery to viewers, even in the case of unexpected technical issues.
 
 ## Recovery mechanism
 
-To ensure that streamed content will be delivered to viewers, you have to consider the potential problems that may affect broadcasting, such as equipment malfunctions or service interruptions caused by technical glitches or network failures. To avoid such problems during an important event, consider using multiple layers of redundancy including encoders, internet service providers (ISPs), and publishing regions offered by Streaming APIs. Using Dolby.io Streaming, you can publish additional redundant streams, which will be automatically delivered to viewers in the case of a problem with the original stream. For example, in the case of a malfunctioning encoder in the primary broadcast, the platform can seamlessly continue the broadcast as long as there is another live contribution stream that uses a different encoder.
+To ensure that streamed content will be delivered to viewers, you have to consider the potential problems that may affect broadcasting, such as equipment malfunctions or service interruptions caused by technical glitches or network failures. To avoid such problems during an important event, consider using multiple layers of redundancy including encoders, internet service providers (ISPs), and publishing regions offered by Streaming APIs. Using OptiView Real-time Streaming, you can publish additional redundant streams, which will be automatically delivered to viewers in the case of a problem with the original stream. For example, in the case of a malfunctioning encoder in the primary broadcast, the platform can seamlessly continue the broadcast as long as there is another live contribution stream that uses a different encoder.
 
-When publishing multiple backup feeds, you can establish an order in which the streams should fail over. The Dolby.io Streaming platform provides the **priority** parameter that lets you set the priority of each contribution stream. In the case of any problem with the primary stream, viewers receive the available stream that has the _highest_ priority. Not setting any `priority` is equivalent setting the lowest priority to that stream.
+When publishing multiple backup feeds, you can establish an order in which the streams should fail over. The OptiView Real-time Streaming platform provides the **priority** parameter that lets you set the priority of each contribution stream. In the case of any problem with the primary stream, viewers receive the available stream that has the _highest_ priority. Not setting any `priority` is equivalent setting the lowest priority to that stream.
 
 The following instructions explain how to publish redundant streams using Streaming APIs.
 

--- a/millicast/broadcast/rtmp-and-rtmps.mdx
+++ b/millicast/broadcast/rtmp-and-rtmps.mdx
@@ -3,16 +3,16 @@ title: RTMP | RTMPS
 sidebar_position: 2
 ---
 
-**Real-Time Messaging Protocol (RTMP)** has been well supported by popular hardware and software applications for many years. In addition to WebRTC, Dolby.io Real-time Streaming allows you to broadcast and distribute content from an RTMP or secure RTMPS source.
+**Real-Time Messaging Protocol (RTMP)** has been well supported by popular hardware and software applications for many years. In addition to WebRTC, OptiView Real-time Streaming allows you to broadcast and distribute content from an RTMP or secure RTMPS source.
 
-Dolby.io Real-time streaming also supports the ability to live stream multiple bitrates from professional RTMP encoders and deliver WebRTC Simulcast. For more information, see [Simulcast](/millicast/distribution/using-webrtc-simulcast#how-to-enable-simulcast-from-an-encoder).
+OptiView Real-time Streaming also supports the ability to live stream multiple bitrates from professional RTMP encoders and deliver WebRTC Simulcast. For more information, see [Simulcast](/millicast/distribution/using-webrtc-simulcast#how-to-enable-simulcast-from-an-encoder).
 
-This document will outline how to set up and broadcast low-latency RTMP streams via the Dolby.io CDN.
+This document will outline how to set up and broadcast low-latency RTMP streams via the OptiView Real-time CDN.
 
 ## RTMP publishing
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast. You will need to create a publish token to generate the necessary RTMP details.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast. You will need to create a publish token to generate the necessary RTMP details.
 :::
 
 Select the publish token that you want to use for your RTMP streaming application.
@@ -39,7 +39,7 @@ Depending on the particular RTMP integration you may need to specify these detai
 
 > **RTMP Publish URL** = **RTMP publish path** + `/` + **RTMP publish stream name**
 
-This information will authenticate you as a publisher on Dolby.io Real-time Streaming and allow you to successfully broadcast a live feed using your account. Typically the URL will look something similar to:
+This information will authenticate you as a publisher on OptiView Real-time Streaming and allow you to successfully broadcast a live feed using your account. Typically the URL will look something similar to:
 
 ```
 rtmp://rtmp-auto.millicast.com:1935/v2/pub/myStreamName?token=5c7a1529...bdc8&priority=1&sourceId=YourId

--- a/millicast/broadcast/rtsp.mdx
+++ b/millicast/broadcast/rtsp.mdx
@@ -3,11 +3,11 @@ title: RTSP
 sidebar_position: 3
 ---
 
-**Real-Time Streaming Protocol (RTSP)**, is a network control protocol used for controlling the delivery of multimedia data, such as video and audio files, over IP networks. Dolby.io supports RTSP to facilitate seamless integration with existing infrastructure and workflows that rely on this protocol for streaming IP camera feeds.
+**Real-Time Streaming Protocol (RTSP)**, is a network control protocol used for controlling the delivery of multimedia data, such as video and audio files, over IP networks. OptiView Real-time Streaming supports RTSP to facilitate seamless integration with existing infrastructure and workflows that rely on this protocol for streaming IP camera feeds.
 
 ## WebRTC support with RTSP
 
-With Dolby.io's support for RTSP, developers can leverage the use of the widely used protocol for controlling the quality and monitoring streaming multimedia content. One of the key features of RTSP is its ability to handle both live streaming and stored media, allowing users to access pre-recorded content as well as real-time broadcast. It also supports various codecs and media formats, providing flexibility in the types of media that can be streamed. Dolby.io includes guides supporting RTSP for the following:
+With OptiView Real-time Streaming's support for RTSP, developers can leverage the use of the widely used protocol for controlling the quality and monitoring streaming multimedia content. One of the key features of RTSP is its ability to handle both live streaming and stored media, allowing users to access pre-recorded content as well as real-time broadcast. It also supports various codecs and media formats, providing flexibility in the types of media that can be streamed. OptiView Real-time Streaming includes guides supporting RTSP for the following:
 
 import { IconGrid, IconGridButton } from '@site/src/components/IconGrid';
 
@@ -43,13 +43,13 @@ Unselect* Local File* on Input shows. Enter on _Input_ the URL. Here is an examp
 
 Add your admin and password, followed by the IP address and the port or location of the video stream: `rtsp://[IP address of RTSP server]:[port]/live`
 
-Afterward, start up the stream, and you should see live streaming the Hosted Player Path URL. For more information on how to stream from OBS to the Dolby.io CDNs, follow the dedicated [OBS guide](/millicast/broadcast/software-encoders/obs/index.mdx).
+Afterward, start up the stream, and you should see live streaming the Hosted Player Path URL. For more information on how to stream from OBS to the OptiView Real-time CDNs, follow the dedicated [OBS guide](/millicast/broadcast/software-encoders/obs/index.mdx).
 
 ## How-to support RTSP using NDI on Windows
 
-If you haven't already, begin by following the [NDI Getting Started](/millicast/broadcast/ndi.md) tutorial to start your first broadcast with a NDI virtual picker. You'll need a familiarity with the Dolby.io Streaming Dashboard for the steps described below.
+If you haven't already, begin by following the [NDI Getting Started](/millicast/broadcast/ndi.md) tutorial to start your first broadcast with a NDI virtual picker. You'll need a familiarity with the OptiView Real-time Streaming Dashboard for the steps described below.
 
-You can also use [NDI tools](https://ndi.video/tools/ndi-core-suite/) with a VLC plugin. The [VLC plugin](https://ndi.video/tools/vlc-plugin/) is available for Windows and allows you to set an RTSP IP camera as an NDI source. Once configured, you can use the Dolby.io Streaming Broadcaster and select the NDI source. This allows you to also publish using the AV1 codec.
+You can also use [NDI tools](https://ndi.video/tools/ndi-core-suite/) with a VLC plugin. The [VLC plugin](https://ndi.video/tools/vlc-plugin/) is available for Windows and allows you to set an RTSP IP camera as an NDI source. Once configured, you can use the OptiView Real-time Streaming Broadcaster and select the NDI source. This allows you to also publish using the AV1 codec.
 
 ## Learn more
 

--- a/millicast/broadcast/software-encoders/flowcaster.mdx
+++ b/millicast/broadcast/software-encoders/flowcaster.mdx
@@ -5,9 +5,9 @@ slug: /software-encoders/flowcaster
 
 # Drastic Technologies
 
-Drastic Technologies' **FlowCaster** is a tool that enables cloud-based media workflows. FlowCaster makes it simple to use Dolby.io Real-time Streaming and the [WHIP (WebRTC HTTP Ingest Protocol)](/millicast/broadcast/webrtc-and-whip.mdx) with no additional software or hardware requirements.
+Drastic Technologies' **FlowCaster** is a tool that enables cloud-based media workflows. FlowCaster makes it simple to use OptiView Real-time Streaming and the [WHIP (WebRTC HTTP Ingest Protocol)](/millicast/broadcast/webrtc-and-whip.mdx) with no additional software or hardware requirements.
 
-The WebRTC-HTTP ingest protocol (WHIP) uses an HTTP POST request to perform a single shot SDP offer/answer so an ICE/DTLS session can be established between the Flowcaster encoder/media producer (WHIP client) and the Dolby.io Real-time Streaming broadcasting ingestion endpoint (media server).
+The WebRTC-HTTP ingest protocol (WHIP) uses an HTTP POST request to perform a single shot SDP offer/answer so an ICE/DTLS session can be established between the Flowcaster encoder/media producer (WHIP client) and the OptiView Real-time Streaming broadcasting ingestion endpoint (media server).
 
 See the official [FlowCaster](https://www.drastic.tv/productsmenu-56/networkstreaminglist/flowcaster) site for documentation, installation instructions, and additional support.
 
@@ -15,7 +15,7 @@ See the official [FlowCaster](https://www.drastic.tv/productsmenu-56/networkstre
 
 ### How-to use FlowCaster with WHIP
 
-To start off, download the [latest version of FlowCaster](https://www.drastic.tv/productsmenu-56/networkstreaminglist/flowcaster). If you haven't done it yet, [create a Dolby.io account](https://streaming.dolby.io) in order to access the stream token information needed.
+To start off, download the [latest version of FlowCaster](https://www.drastic.tv/productsmenu-56/networkstreaminglist/flowcaster). If you haven't done it yet, [create a OptiView Real-time account](https://streaming.dolby.io) in order to access the stream token information needed.
 
 import FlowcasterMillicast1 from '../../assets/img/a51bd5e-Flowcaster-Millicast.png';
 
@@ -23,7 +23,7 @@ import FlowcasterMillicast1 from '../../assets/img/a51bd5e-Flowcaster-Millicast.
   <img src={FlowcasterMillicast1} width="600" />
 </div>
 
-Once inside the streaming dashboard,[create a token](/millicast/streaming-dashboard/managing-your-tokens.mdx) in your Dolby.io dashboard. You will need the stream name and token for the stream label.
+Once inside the streaming dashboard,[create a token](/millicast/streaming-dashboard/managing-your-tokens.mdx) in your OptiView Streaming Dashboard. You will need the stream name and token for the stream label.
 
 import FlowcasterWhipToken from '../../assets/img/flowcaster-whip-token.png';
 
@@ -69,12 +69,12 @@ FlowCaster is a perfect tool for video and audio professionals to use with their
 [FlowCaster with Adobe (Premiere, After Effects)](https://www.drastic.tv/support-59/supporttipstechnical/100-using-flowcaster-with-adobe-premiere-after-effects)
 
 :::caution FlowCaster's Mac Version
-The newest version of the MacOS doesn't support H264/AV1C, therefore, implementing WHIP as the transmit type is not possible. However, it is possible to broadcast low-delay [SRT](/millicast/broadcast/srt.mdx) or [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) streams which are also supported by Dolby.io.
+The newest version of the MacOS doesn't support H264/AV1C, therefore, implementing WHIP as the transmit type is not possible. However, it is possible to broadcast low-delay [SRT](/millicast/broadcast/srt.mdx) or [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) streams which are also supported by OptiView Real-time Streaming.
 :::
 
 ### Demonstration video
 
-Below is a video showing the complete workflow to connect Flowcaster to the Dolby.io Real-time Streaming service using WebRTC and WHIP:
+Below is a video showing the complete workflow to connect Flowcaster to the OptiView Real-time Streaming service using WebRTC and WHIP:
 
 <div className="youtube-container">
   <iframe

--- a/millicast/broadcast/software-encoders/flowcaster.mdx
+++ b/millicast/broadcast/software-encoders/flowcaster.mdx
@@ -15,7 +15,7 @@ See the official [FlowCaster](https://www.drastic.tv/productsmenu-56/networkstre
 
 ### How-to use FlowCaster with WHIP
 
-To start off, download the [latest version of FlowCaster](https://www.drastic.tv/productsmenu-56/networkstreaminglist/flowcaster). If you haven't done it yet, [create a OptiView Real-time account](https://streaming.dolby.io) in order to access the stream token information needed.
+To start off, download the [latest version of FlowCaster](https://www.drastic.tv/productsmenu-56/networkstreaminglist/flowcaster). If you haven't done it yet, [create an OptiView Real-time account](https://streaming.dolby.io) in order to access the stream token information needed.
 
 import FlowcasterMillicast1 from '../../assets/img/a51bd5e-Flowcaster-Millicast.png';
 
@@ -23,7 +23,7 @@ import FlowcasterMillicast1 from '../../assets/img/a51bd5e-Flowcaster-Millicast.
   <img src={FlowcasterMillicast1} width="600" />
 </div>
 
-Once inside the streaming dashboard,[create a token](/millicast/streaming-dashboard/managing-your-tokens.mdx) in your OptiView Streaming Dashboard. You will need the stream name and token for the stream label.
+Once inside the streaming dashboard,[create a token](/millicast/streaming-dashboard/managing-your-tokens.mdx) in your OptiView Real-time Streaming Dashboard. You will need the stream name and token for the stream label.
 
 import FlowcasterWhipToken from '../../assets/img/flowcaster-whip-token.png';
 

--- a/millicast/broadcast/software-encoders/gstreamer.mdx
+++ b/millicast/broadcast/software-encoders/gstreamer.mdx
@@ -19,7 +19,7 @@ See the official [gstreamer.freedesktop.org](https://gstreamer.freedesktop.org/)
 
 ## Get your OptiView WHIP publish URL
 
-You will need a _WHIP endpoint_ and _Bearer token_ in order to broadcast. From the [OptiView Streaming Dashboard](/millicast/streaming-dashboard/index.mdx), navigate to the _Publishing_ tab of your token. Under the _Live broadcast - Publish tokens_ section, retrieve the _WHIP endpoint_ and _Bearer token_.
+You will need a _WHIP endpoint_ and _Bearer token_ in order to broadcast. From the [OptiView Real-time Streaming Dashboard](/millicast/streaming-dashboard/index.mdx), navigate to the _Publishing_ tab of your token. Under the _Live broadcast - Publish tokens_ section, retrieve the _WHIP endpoint_ and _Bearer token_.
 
 See the [WHIP](/millicast/broadcast/webrtc-and-whip.mdx) broadcast guide for more specific instructions on retrieving these values from the [Streaming Dashboard](/millicast/streaming-dashboard/index.mdx).
 
@@ -54,12 +54,12 @@ The [1.22.0 release](https://gstreamer.freedesktop.org/releases/1.22/) of GStrea
 - WebRTC HTTP ingest (WHIP) to a MediaServer (whipsink)
 - WebRTC HTTP egress (WHEP) from a MediaServer (whepsrc)
 
-The [whipsink](https://gstreamer.freedesktop.org/documentation/webrtchttp/whipsink.html) element can be used to **publish** a gstreamer pipeline out to an OptiView real-time stream. The attributes that must be defined:
+The [whipsink](https://gstreamer.freedesktop.org/documentation/webrtchttp/whipsink.html) element can be used to **publish** a gstreamer pipeline out to an OptiView Real-time stream. The attributes that must be defined:
 
 - `auth-token`: should be set with your publishing bearer token
 - `whip-endpoint`: should be set with the OptiView [WHIP](/millicast/api/director/whip-whip-publish.api.mdx) endpoint
 
-The [autovideosink](https://gstreamer.freedesktop.org/documentation/autodetect/autovideosink.html) element can be used to **playback** an OptiView real-time stream being broadcast into a gstreamer pipeline. The attribute that must be defined:
+The [autovideosink](https://gstreamer.freedesktop.org/documentation/autodetect/autovideosink.html) element can be used to **playback** an OptiView Real-time stream being broadcast into a gstreamer pipeline. The attribute that must be defined:
 
 - `whep-endpoint`: should be set with the OptiView [WHEP](/millicast/api/director/whep-whep-subscribe.api.mdx) endpoint
 

--- a/millicast/broadcast/software-encoders/gstreamer.mdx
+++ b/millicast/broadcast/software-encoders/gstreamer.mdx
@@ -17,9 +17,9 @@ This guide includes a number of examples:
 
 See the official [gstreamer.freedesktop.org](https://gstreamer.freedesktop.org/) documentation for installation instructions and additional support.
 
-## Get your Dolby.io WHIP publish URL
+## Get your OptiView WHIP publish URL
 
-You will need a _WHIP endpoint_ and _Bearer token_ in order to broadcast. From the [Dolby.io Dashboard](/millicast/streaming-dashboard/index.mdx), navigate to the _Publishing_ tab of your token. Under the _Live broadcast - Publish tokens_ section, retrieve the _WHIP endpoint_ and _Bearer token_.
+You will need a _WHIP endpoint_ and _Bearer token_ in order to broadcast. From the [OptiView Streaming Dashboard](/millicast/streaming-dashboard/index.mdx), navigate to the _Publishing_ tab of your token. Under the _Live broadcast - Publish tokens_ section, retrieve the _WHIP endpoint_ and _Bearer token_.
 
 See the [WHIP](/millicast/broadcast/webrtc-and-whip.mdx) broadcast guide for more specific instructions on retrieving these values from the [Streaming Dashboard](/millicast/streaming-dashboard/index.mdx).
 
@@ -37,7 +37,7 @@ https://director.millicast.com/api/whip/{Stream Name}?codec=vp8
 
 :::
 
-## Get your Dolby.io WHEP playback URL
+## Get your OptiView WHEP playback URL
 
 The **WHEP endpoint** is available from the _Playback_ tab of your publish token in the [Streaming Dashboard](/millicast/streaming-dashboard/index.mdx).
 
@@ -54,14 +54,14 @@ The [1.22.0 release](https://gstreamer.freedesktop.org/releases/1.22/) of GStrea
 - WebRTC HTTP ingest (WHIP) to a MediaServer (whipsink)
 - WebRTC HTTP egress (WHEP) from a MediaServer (whepsrc)
 
-The [whipsink](https://gstreamer.freedesktop.org/documentation/webrtchttp/whipsink.html) element can be used to **publish** a gstreamer pipeline out to a Dolby.io real-time stream. The attributes that must be defined:
+The [whipsink](https://gstreamer.freedesktop.org/documentation/webrtchttp/whipsink.html) element can be used to **publish** a gstreamer pipeline out to an OptiView real-time stream. The attributes that must be defined:
 
 - `auth-token`: should be set with your publishing bearer token
-- `whip-endpoint`: should be set with the Dolby.io [WHIP](/millicast/api/director/whip-whip-publish.api.mdx) endpoint
+- `whip-endpoint`: should be set with the OptiView [WHIP](/millicast/api/director/whip-whip-publish.api.mdx) endpoint
 
-The [autovideosink](https://gstreamer.freedesktop.org/documentation/autodetect/autovideosink.html) element can be used to **playback** a Dolby.io real-time stream being broadcast into a gstreamer pipeline. The attribute that must be defined:
+The [autovideosink](https://gstreamer.freedesktop.org/documentation/autodetect/autovideosink.html) element can be used to **playback** an OptiView real-time stream being broadcast into a gstreamer pipeline. The attribute that must be defined:
 
-- `whep-endpoint`: should be set with the Dolby.io [WHEP](/millicast/api/director/whep-whep-subscribe.api.mdx) endpoint
+- `whep-endpoint`: should be set with the OptiView [WHEP](/millicast/api/director/whep-whep-subscribe.api.mdx) endpoint
 
 You can use the [Hosted Viewer](/millicast/streaming-dashboard/index.mdx) and [Live Broadcaster](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx) to test your setups.
 
@@ -229,7 +229,7 @@ import ViewerImg from '../../assets/img/viewer.png';
 
 ### Publishing an RTSP video-only source
 
-Now, to connect to an RTSP source like an axis camera, you need to replace the GStreamer pipeline with one that connects to the Camera and passes the video data to Dolby.io Real-time Streaming without transcoding the content.
+Now, to connect to an RTSP source like an axis camera, you need to replace the GStreamer pipeline with one that connects to the Camera and passes the video data to OptiView Real-time Streaming without transcoding the content.
 
 ```shell
 ./whip-client -u https://director.millicast.com/api/whip/kxhqovek \

--- a/millicast/broadcast/software-encoders/index.mdx
+++ b/millicast/broadcast/software-encoders/index.mdx
@@ -5,7 +5,7 @@ slug: /software-encoders
 
 import DocCardList from '@theme/DocCardList';
 
-A software encoder can take raw video frames and convert it into a digital format that is compatible for distribution with Dolby.io. This type of integration can typically be done without additional hardware requirements and eases adoption of real-time streaming workflows.
+A software encoder can take raw video frames and convert it into a digital format that is compatible for distribution with OptiView Real-time Streaming. This type of integration can typically be done without additional hardware requirements and eases adoption of real-time streaming workflows.
 
 ## Integration Guides
 
@@ -68,7 +68,7 @@ import { IconGrid, IconGridButton } from '@site/src/components/IconGrid';
 
 ### Zoom
 
-**Zoom** is a video collaboration platform. The application supports streaming use cases with [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) which allows you to distribute your meeting with Dolby.io Real-time Streaming.
+**Zoom** is a video collaboration platform. The application supports streaming use cases with [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) which allows you to distribute your meeting with OptiView Real-time Streaming.
 
 [How-to integrate with Zoom Meetings](zoom.mdx)
 

--- a/millicast/broadcast/software-encoders/liveu-studio.mdx
+++ b/millicast/broadcast/software-encoders/liveu-studio.mdx
@@ -11,7 +11,7 @@ See the official [LiveU Studio](https://www.liveu.tv/support) site for documenta
 
 ## How-to use LiveU with WHIP
 
-To get started, [create a token](/millicast/streaming-dashboard/managing-your-tokens.mdx) in your OptiView Streaming Dashboard. On the Publishing tab of the newly created token, copy the WHIP endpoint URL and your Publishing token as shown in the [WebRTC | WHIP guide](/millicast/broadcast/webrtc-and-whip.mdx).
+To get started, [create a token](/millicast/streaming-dashboard/managing-your-tokens.mdx) in your OptiView Real-time Streaming Dashboard. On the Publishing tab of the newly created token, copy the WHIP endpoint URL and your Publishing token as shown in the [WebRTC | WHIP guide](/millicast/broadcast/webrtc-and-whip.mdx).
 
 Open LiveU Studio and click on "PUBLISH" in the left-side menu. Click on "ADD OR EDIT PUBLISHING POINTS".
 
@@ -29,7 +29,7 @@ import LiveUStudio2 from '../../assets/img/liveustudio_2.png';
   <img src={LiveUStudio2} width="600" />
 </div>
 
-Paste the WHIP endpoint URL and your Publishing token copied from the OptiView Streaming Dashboard. Save the publishing point and select it.
+Paste the WHIP endpoint URL and your Publishing token copied from the OptiView Real-time Streaming Dashboard. Save the publishing point and select it.
 
 import LiveUStudio3 from '../../assets/img/liveustudio_3.png';
 

--- a/millicast/broadcast/software-encoders/liveu-studio.mdx
+++ b/millicast/broadcast/software-encoders/liveu-studio.mdx
@@ -5,13 +5,13 @@ slug: /software-encoders/liveu-studio
 
 # LiveU
 
-[LiveU Studio](https://www.liveu.tv/products/produce/liveu-studio) is a cloud production studio for live video that supports WebRTC streaming to the Dolby.io platform with [WHIP](/millicast/broadcast/webrtc-and-whip.mdx). This guide outlines how to create and broadcast a high-quality low-latency stream globally with Dolby.io streaming.
+[LiveU Studio](https://www.liveu.tv/products/produce/liveu-studio) is a cloud production studio for live video that supports WebRTC streaming to the OptiView Real-time platform with [WHIP](/millicast/broadcast/webrtc-and-whip.mdx). This guide outlines how to create and broadcast a high-quality low-latency stream globally with OptiView Real-time Streaming.
 
 See the official [LiveU Studio](https://www.liveu.tv/support) site for documentation, installation instructions, and additional [support](https://knowledge-base.studio.liveu.tv/en/).
 
 ## How-to use LiveU with WHIP
 
-To get started, [create a token](/millicast/streaming-dashboard/managing-your-tokens.mdx) in your Dolby.io dashboard. On the Publishing tab of the newly created token, copy the WHIP endpoint URL and your Publishing token as shown in the [WebRTC | WHIP guide](/millicast/broadcast/webrtc-and-whip.mdx).
+To get started, [create a token](/millicast/streaming-dashboard/managing-your-tokens.mdx) in your OptiView Streaming Dashboard. On the Publishing tab of the newly created token, copy the WHIP endpoint URL and your Publishing token as shown in the [WebRTC | WHIP guide](/millicast/broadcast/webrtc-and-whip.mdx).
 
 Open LiveU Studio and click on "PUBLISH" in the left-side menu. Click on "ADD OR EDIT PUBLISHING POINTS".
 
@@ -29,7 +29,7 @@ import LiveUStudio2 from '../../assets/img/liveustudio_2.png';
   <img src={LiveUStudio2} width="600" />
 </div>
 
-Paste the WHIP endpoint URL and your Publishing token copied from the Dolby.io dashboard. Save the publishing point and select it.
+Paste the WHIP endpoint URL and your Publishing token copied from the OptiView Streaming Dashboard. Save the publishing point and select it.
 
 import LiveUStudio3 from '../../assets/img/liveustudio_3.png';
 
@@ -45,7 +45,7 @@ import LiveUStudio4 from '../../assets/img/liveustudio_4.png';
   <img src={LiveUStudio4} width="600" />
 </div>
 
-Click "START PUBLISHING AND RECORD" to start publishing from LiveU Studio to Dolby.io.
+Click "START PUBLISHING AND RECORD" to start publishing from LiveU Studio to OptiView Real-time Streaming.
 
 import LiveUStudio5 from '../../assets/img/liveustudio_5.png';
 
@@ -53,7 +53,7 @@ import LiveUStudio5 from '../../assets/img/liveustudio_5.png';
   <img src={LiveUStudio5} width="600" />
 </div>
 
-LiveU Studio will publish to the Dolby.io Real-time Streaming service using WHIP. To view the stream, navigate back to your newly created token and switch to the "Playback" tab. From the "Playback" tab, copy the "Hosted Player path" URL and open it in your browser.
+LiveU Studio will publish to the OptiView Real-time Streaming service using WHIP. To view the stream, navigate back to your newly created token and switch to the "Playback" tab. From the "Playback" tab, copy the "Hosted Player path" URL and open it in your browser.
 
 import LiveUStudio6 from '../../assets/img/liveustudio_6.png';
 
@@ -64,7 +64,7 @@ import LiveUStudio6 from '../../assets/img/liveustudio_6.png';
 Your LiveU broadcast should now be playing in your browser.
 
 :::caution Publishing Bitrates
-LiveU Studio recommends publishing to the Dolby.io Real-time Streaming service with a max bitrate of 4 Mbps. A bitrate of 4 Mbps up to 6 Mbps may cause instabilities or artifacts. A bitrate above 6 Mbps may cause visible problems and/or your stream will not start.
+LiveU Studio recommends publishing to the OptiView Real-time Streaming service with a max bitrate of 4 Mbps. A bitrate of 4 Mbps up to 6 Mbps may cause instabilities or artifacts. A bitrate above 6 Mbps may cause visible problems and/or your stream will not start.
 :::
 
 ## Learn more

--- a/millicast/broadcast/software-encoders/obs/index.mdx
+++ b/millicast/broadcast/software-encoders/obs/index.mdx
@@ -3,7 +3,7 @@ title: OBS
 slug: /software-encoders/obs
 ---
 
-**Open Broadcaster Software (OBS)** is a free open-source software created for broadcasting and recording on your desktop. You can take advantage of this tool to stream high-quality video to your viewers in real time using the [Dolby.io Real-time Streaming](https://optiview.dolby.com/solutions/real-time-streaming/) service.
+**Open Broadcaster Software (OBS)** is a free open-source software created for broadcasting and recording on your desktop. You can take advantage of this tool to stream high-quality video to your viewers in real time using the [OptiView Real-time Streaming](https://optiview.dolby.com/solutions/real-time-streaming/) service.
 
 See the official [obsproject.com](https://obsproject.com) documentation for installation instructions and additional support about using OBS.
 
@@ -206,7 +206,7 @@ import Obs3 from '../../../assets/img/software-encoders/obs3.png';
   <img src={Obs3} width="600" />
 </div>
 
-You may need to click **start streaming in OBS** to update the current configuration, then click **stop streaming** and return to the **multiple output panel**. When you click **start streaming** again, the config will be updated, and the RTMP MBR renditions will stream to Dolby.io Real-time Streaming CDN.
+You may need to click **start streaming in OBS** to update the current configuration, then click **stop streaming** and return to the **multiple output panel**. When you click **start streaming** again, the config will be updated, and the RTMP MBR renditions will stream to OptiView Real-time Streaming CDN.
 
 #### 5. Playback
 
@@ -222,7 +222,7 @@ import RtmpMbrSimulcast from '../../../assets/img/rtmp-mbr-webrtc-simulcast.jpeg
 
 You'll need to use the [OBS-studio-webrtc](https://github.com/CoSMoSoftware/OBS-studio-webrtc/releases) fork because advanced simulcast settings are not yet available in OBS 30.x with WHIP support.
 
-Add your stream name and token from your Dolby.io Real-time Streaming token into OBS's settings. Select either _ H.264_ or _VP8_ for the **codec** as Simulcast only works for those two codecs. Click on the **advanced settings** button and check the **Simulcast** box to enable the feature inside OBS. Finally, apply the changes.
+Add your stream name and token from your OptiView Real-time Streaming token into OBS's settings. Select either _ H.264_ or _VP8_ for the **codec** as Simulcast only works for those two codecs. Click on the **advanced settings** button and check the **Simulcast** box to enable the feature inside OBS. Finally, apply the changes.
 
 import ObsImg1 from '../../../assets/img/Capture_decran_2023-07-24_a_2.51.38_PM.png';
 
@@ -278,7 +278,7 @@ import Surround3 from '../../../assets/img/surround_3.png';
 
 ##### Ambisonics
 
-If you have an Ambisonic it is also possible to publish spatial audio using the same setup. Here for the demo a [Zoom H3-VR](https://zoomcorp.com/en/us/handheld-recorders/handheld-recorders/h3-vr-360-audio-recorder/) can be used. Set for Dolby.io OBS WebRTC is the same as 5.1 and with Zoom mic you will see for channels to capture and stream to your surround sound set up.
+If you have an Ambisonic it is also possible to publish spatial audio using the same setup. Here for the demo a [Zoom H3-VR](https://zoomcorp.com/en/us/handheld-recorders/handheld-recorders/h3-vr-360-audio-recorder/) can be used. Set for OptiView OBS WebRTC is the same as 5.1 and with Zoom mic you will see for channels to capture and stream to your surround sound set up.
 
 import AmbImg from '../../../assets/img/amb.png';
 
@@ -328,7 +328,7 @@ On your Windows make sure you are using Chrome browser for your viewer.
 
 ##### Mac
 
-Surround sound playback should be enabled by default on your Mac. You can listen to the stream in-browser or via the Dolby.io Stream Monitor app can be installed for free on your iPad or AppleTV.
+Surround sound playback should be enabled by default on your Mac. You can listen to the stream in-browser or via the OptiView Stream Monitor app can be installed for free on your iPad or AppleTV.
 
 ### Installing OBS-Multi-RTMP Plugin
 

--- a/millicast/broadcast/software-encoders/vmix.mdx
+++ b/millicast/broadcast/software-encoders/vmix.mdx
@@ -50,7 +50,7 @@ Save your publishing profile and you are ready to start publishing with vMix.
 With vMix you have the ability to send a live stream simultaneously to up to three separate streaming destinations. This vMix feature combined with OptiView Real-time Streaming [Multisource Streams](/millicast/broadcast/multi-source-broadcasting.mdx) enables Simulcast of multiple renditions of the stream. Viewers with bandwidth constraints would receive a stream optimized for that condition. Keep in mind, the broadcaster will be sending multiple streams so will need adequate bandwidth.
 
 :::info Enable Multisource for Your OptiView Publish Token
-To utilize [multisource](/millicast/broadcast/multi-source-broadcasting.mdx) it must be enabled for the publish token. You can do this from the OptiView Streaming Dashboard. For more information, review [Managing Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx).
+To utilize [multisource](/millicast/broadcast/multi-source-broadcasting.mdx) it must be enabled for the publish token. You can do this from the OptiView Real-time Streaming Dashboard. For more information, review [Managing Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx).
 :::
 
 #### Streaming destination 1: 1080p

--- a/millicast/broadcast/software-encoders/vmix.mdx
+++ b/millicast/broadcast/software-encoders/vmix.mdx
@@ -47,10 +47,10 @@ Save your publishing profile and you are ready to start publishing with vMix.
 
 ### Setup multi-bitrate RTMP streaming with vMix
 
-With vMix you have the ability to send a live stream simultaneously to up to three separate streaming destinations. This vMix feature combined with Dolby.io [Multisource Streams](/millicast/broadcast/multi-source-broadcasting.mdx) enables Simulcast of multiple renditions of the stream. Viewers with bandwidth constraints would receive a stream optimized for that condition. Keep in mind, the broadcaster will be sending multiple streams so will need adequate bandwidth.
+With vMix you have the ability to send a live stream simultaneously to up to three separate streaming destinations. This vMix feature combined with OptiView Real-time Streaming [Multisource Streams](/millicast/broadcast/multi-source-broadcasting.mdx) enables Simulcast of multiple renditions of the stream. Viewers with bandwidth constraints would receive a stream optimized for that condition. Keep in mind, the broadcaster will be sending multiple streams so will need adequate bandwidth.
 
-:::info Enable Multisource for Your Dolby.io Publish Token
-To utilize [multisource](/millicast/broadcast/multi-source-broadcasting.mdx) it must be enabled for the publish token. You can do this from the Dolby.io dashboard. For more information, review [Managing Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx).
+:::info Enable Multisource for Your OptiView Publish Token
+To utilize [multisource](/millicast/broadcast/multi-source-broadcasting.mdx) it must be enabled for the publish token. You can do this from the OptiView Streaming Dashboard. For more information, review [Managing Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx).
 :::
 
 #### Streaming destination 1: 1080p

--- a/millicast/broadcast/software-encoders/zoom.mdx
+++ b/millicast/broadcast/software-encoders/zoom.mdx
@@ -3,11 +3,11 @@ title: Zoom
 slug: /software-encoders/zoom
 ---
 
-[Zoom](https://zoom.us/) is a video collaboration tool for hosting conferences and meetings. Zoom supports streaming to consumer platforms or any [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) source such as distributing Real-time Streaming content with Dolby.io.
+[Zoom](https://zoom.us/) is a video collaboration tool for hosting conferences and meetings. Zoom supports streaming to consumer platforms or any [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) source such as distributing Real-time Streaming content with OptiView Real-time Streaming.
 
 See the official [Zoom](https://zoom.us/) site for documentation, installation instructions, and additional support.
 
-## Get your Dolby.io RTMP publish URL
+## Get your OptiView RTMP publish URL
 
 In order to broadcast with RTMP, you will need to have your **RTMP publish path** and **RTMP publish stream name** available.
 
@@ -15,7 +15,7 @@ See the [RTMP Broadcast Guide](/millicast/broadcast/rtmp-and-rtmps.mdx#how-to-fi
 
 ## How-to stream a Zoom meeting or webinar with RTMP
 
-First, you must need a Zoom paid account in order to ingest your Zoom meetings into Dolby.io Real-time Streaming via RTMP so you can broadcast it massively in almost real-time.
+First, you must need a Zoom paid account in order to ingest your Zoom meetings into OptiView Real-time Streaming via RTMP so you can broadcast it massively in almost real-time.
 
 - Note: The account needs to be either a Pro, Business, Education, or Enterprise plan.
 
@@ -42,7 +42,7 @@ import Zoom1 from '../../assets/img/zoom1.png';
 
 Choose Live on Custom Live Stream Service. A browser window will open to show the progress as Zoom prepares the live stream of your webinar. If you haven’t set up this webinar for live custom streaming, you should simply enter the values provided in the instructions.
 
-### 4. Enter your Dolby.io RTMP publish details
+### 4. Enter your OptiView RTMP publish details
 
 import Zoom2 from '../../assets/img/zoom1.png';
 
@@ -50,7 +50,7 @@ import Zoom2 from '../../assets/img/zoom1.png';
   <img src={Zoom2} width="600" />
 </div>
 
-Enter your Dolby.io Real-time Streaming RTMP publish token details.
+Enter your OptiView Real-time Streaming RTMP publish token details.
 
 | Zoom field | Dolby.io field           | Example value                                                                       |
 | :--------- | :----------------------- | :---------------------------------------------------------------------------------- |

--- a/millicast/broadcast/srt.mdx
+++ b/millicast/broadcast/srt.mdx
@@ -3,17 +3,17 @@ title: SRT
 sidebar_position: 4
 ---
 
-**Secure Reliable Transport (SRT)** is an open-source protocol that uses an intelligent packet retransmit mechanism on top of a UDP data flow, along with AES-128 and 256-bit encryption. [Dolby.io Real-time Streaming](https://optiview.dolby.com/solutions/real-time-streaming/) natively supports publishing from an SRT source.
+**Secure Reliable Transport (SRT)** is an open-source protocol that uses an intelligent packet retransmit mechanism on top of a UDP data flow, along with AES-128 and 256-bit encryption. [OptiView Real-time Streaming](https://optiview.dolby.com/solutions/real-time-streaming/) natively supports publishing from an SRT source.
 
-This document will guide you on how to [broadcast](/millicast/broadcast/index.mdx) an SRT Stream to Dolby.io Real-time Streaming with SRT-capable software or hardware.
+This document will guide you on how to [broadcast](/millicast/broadcast/index.mdx) an SRT Stream to OptiView Real-time Streaming with SRT-capable software or hardware.
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast. You will need to create a publish token to generate the necessary SRT details.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast. You will need to create a publish token to generate the necessary SRT details.
 :::
 
 ## How-to find the SRT publish settings with the dashboard
 
-The Dolby.io [Streaming Dashboard](/millicast/streaming-dashboard/index.mdx) helps generate the parameters you can use for configuring your encoders.
+The OptiView [Streaming Dashboard](/millicast/streaming-dashboard/index.mdx) helps generate the parameters you can use for configuring your encoders.
 
 Some examples of encoders supporting SRT include the [Osprey](/millicast/broadcast/hardware-encoders/osprey.mdx) Talon, [Teradek](/millicast/broadcast/hardware-encoders/teradek.mdx) Wave, [Videon](/millicast/broadcast/hardware-encoders/videon.mdx) EdgeCaster, [Haivision](/millicast/broadcast/hardware-encoders/haivision.mdx) KB Encoder, [Flowcaster](/millicast/broadcast/software-encoders/flowcaster.mdx), Adobe Premiere Pro, Avid Media Composer, and [vMix](/millicast/broadcast/software-encoders/vmix.mdx).
 
@@ -29,7 +29,7 @@ import SrtToken from '../assets/img/srt-token.png';
 
 ### 2. Select the _Publishing_ tab
 
-Click on the _Publishing_ tab for information on how to connect as a publisher to your Dolby.io account. There is a section specifically for all of the SRT publish settings.
+Click on the _Publishing_ tab for information on how to connect as a publisher to your OptiView Real-time account. There is a section specifically for all of the SRT publish settings.
 
 import SrtSettings from '../assets/img/dolbyio-streaming-srt-settings.png';
 
@@ -39,7 +39,7 @@ import SrtSettings from '../assets/img/dolbyio-streaming-srt-settings.png';
 
 ### 3. Configure your encoder with the SRT settings
 
-The settings you use will be dependent on the specific encoder being configured. Typically though, the source of the broadcast may be referred to as the caller of the Dolby.io service which will listen for the incoming stream.
+The settings you use will be dependent on the specific encoder being configured. Typically though, the source of the broadcast may be referred to as the caller of the OptiView Real-time service which will listen for the incoming stream.
 
 - For some encoders, a _single_ target URL parameter is all that is required. For this you use the combined **SRT publish URL** as the configured endpoint.
 - For other encoders, it is a _multi part_ setting comprised of a Hostname (or URL) and a separate Stream ID entry. For this you use the **SRT publish path** and **SRT stream ID** separately. Some encoders will also distinguish the **port** separately from the publish path as a third configurable setting.

--- a/millicast/broadcast/using-native-sdk-ingest-raw-frames.md
+++ b/millicast/broadcast/using-native-sdk-ingest-raw-frames.md
@@ -5,7 +5,7 @@ sidebar_position: 11
 
 Ingesting raw video and audio frames can be useful for creating and managing unique WebRTC encoding workflows. Whilst [traditional encoders](./hardware-encoders/index.mdx) provide general-purpose encoding solutions, there are some use cases such as [real-time streaming from drones](/millicast/capture/live-streaming-from-drones.mdx) where traditional encoding solutions are too heavy, power consumptive, or expensive to suffice.
 
-This guide is designed to help you leverage the Dolby.io Streaming Native SDKs to ingest raw audio and video frames, allowing the stream encoding to be handled by the SDK. There are three ways to accomplish raw frame ingestion:
+This guide is designed to help you leverage the OptiView Real-time Streaming Native SDKs to ingest raw audio and video frames, allowing the stream encoding to be handled by the SDK. There are three ways to accomplish raw frame ingestion:
 
 1. [Using the Core API](#creating-custom-audio-and-video-frame-classes): For desktop applications such as Windows, Mac, or Linux
 2. [Using the iOS API](#using-the-ios-api): Including tvOS

--- a/millicast/broadcast/webrtc-and-whip.mdx
+++ b/millicast/broadcast/webrtc-and-whip.mdx
@@ -39,7 +39,7 @@ WebRTC broadcasting is enabled via WHIP, to learn more about support for WebRTC 
 If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast. You will need to create a publish token to gather the necessary WHIP parameters.
 :::
 
-Log into the OptiView Streaming Dashboard and go to the [Live Broadcast section](https://streaming.dolby.io/#/tokens) and select the publish token that you want to use for your WHIP streaming application.
+Log into the OptiView Real-time Streaming Dashboard and go to the [Live Broadcast section](https://streaming.dolby.io/#/tokens) and select the publish token that you want to use for your WHIP streaming application.
 
 ### 1. Open the publish token settings
 

--- a/millicast/broadcast/webrtc-and-whip.mdx
+++ b/millicast/broadcast/webrtc-and-whip.mdx
@@ -3,7 +3,7 @@ title: WebRTC | WHIP
 sidebar_position: 1
 ---
 
-**Web Real-Time Communication (WebRTC)** is an open-source project that defines secure voice, audio, and data delivery between peers using web browsers or native clients. Dolby.io Real-time Streaming allows you to broadcast and distribute content using WebRTC for real-time global streaming to large-scale audiences.
+**Web Real-Time Communication (WebRTC)** is an open-source project that defines secure voice, audio, and data delivery between peers using web browsers or native clients. OptiView Real-time Streaming allows you to broadcast and distribute content using WebRTC for real-time global streaming to large-scale audiences.
 
 ## WebRTC support with WHIP
 
@@ -25,10 +25,10 @@ import { IconGrid, IconGridButton } from '@site/src/components/IconGrid';
 </IconGrid>
 <!-- prettier-ignore-end -->
 
-The Dolby.io CDN for WebRTC Real-time Streaming supports streaming up to 4k 60fps video with 4:4:4 color encoded into H.264, H.265, VP8, VP9, and AV1. Additionally, Dolby.io fully supports transporting audio via the Opus codec, allowing for bitrates from 6 kb/s to 510 kb/s and sampling rates from 8 kHz (narrowband) to 48 kHz (full-band).
+The OptiView Real-time CDN for WebRTC Real-time Streaming supports streaming up to 4k 60fps video with 4:4:4 color encoded into H.264, H.265, VP8, VP9, and AV1. Additionally, OptiView Real-time Streaming fully supports transporting audio via the Opus codec, allowing for bitrates from 6 kb/s to 510 kb/s and sampling rates from 8 kHz (narrowband) to 48 kHz (full-band).
 
 :::tip Support for WHIP, SRT, and RTMP
-Dolby.io supports broadcasting [using SRT or RTMP](/millicast/broadcast/index.mdx) as well.
+OptiView Real-time Streaming supports broadcasting [using SRT or RTMP](/millicast/broadcast/index.mdx) as well.
 :::
 
 WebRTC broadcasting is enabled via WHIP, to learn more about support for WebRTC egressing and playback learn more about [WHEP](/millicast/distribution/index.mdx).
@@ -36,10 +36,10 @@ WebRTC broadcasting is enabled via WHIP, to learn more about support for WebRTC 
 ## How-to find your WHIP publish settings
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast. You will need to create a publish token to gather the necessary WHIP parameters.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast. You will need to create a publish token to gather the necessary WHIP parameters.
 :::
 
-Log into the Dolby.io dashboard and go to the [Live Broadcast section](https://streaming.dolby.io/#/tokens) and select the publish token that you want to use for your WHIP streaming application.
+Log into the OptiView Streaming Dashboard and go to the [Live Broadcast section](https://streaming.dolby.io/#/tokens) and select the publish token that you want to use for your WHIP streaming application.
 
 ### 1. Open the publish token settings
 
@@ -53,9 +53,9 @@ import TokensMainSetting from '../assets/img/tokens-main-setting.png';
 
 ### 2. Gather your WHIP publish endpoint
 
-In order for you to publish to Dolby.io Real-time Streaming with WebRTC you will need two things from the dashboard, the **WHIP endpoint** (including your Stream name) and the **Publishing token**.
+In order for you to publish to OptiView Real-time Streaming with WebRTC you will need two things from the dashboard, the **WHIP endpoint** (including your Stream name) and the **Publishing token**.
 
-Click on the **Publishing** tab for information on how to connect as a publisher to your Dolby.io account.
+Click on the **Publishing** tab for information on how to connect as a publisher to your OptiView Real-time account.
 
 import WebRtcPublish from '../assets/img/webrtc-publish.png';
 
@@ -63,7 +63,7 @@ import WebRtcPublish from '../assets/img/webrtc-publish.png';
   <img src={WebRtcPublish} width="600" />
 </div>
 
-This information will authenticate you as a publisher on Dolby.io Real-time Streaming and allow you to successfully broadcast from a WebRTC source using your account.
+This information will authenticate you as a publisher on OptiView Real-time Streaming and allow you to successfully broadcast from a WebRTC source using your account.
 
 How the WebRTC endpoint and the WebRTC token values are used is dependent on your software or hardware device. For example, some devices/encoders accept the values as separate parameters and some require them combined as a single URL. If your encoder has a separate token field, you will want to provide the WebRTC endpoint and the publishing token from the dashboard separately.
 
@@ -73,9 +73,9 @@ The following are examples of how these values can be used:
 - Combine the endpoint and the token as a single WebRTC publish URL using `?auth=`. In the screen above the example is `https://director.millicast.com/api/whip/myStreamName?auth=3bc330607a15a0ecebebd8c9ee2a559fd143c937174bd276e213a96425bb107e`
 
 :::caution The Hardware or Software MUST support WebRTC
-Many hardware or software encoding solutions may include _endpoint_ and _token_ fields. This does not mean they support WebRTC or WHIP. You should review the tool's documentation to confirm it supports WebRTC before trying to stream to Dolby.io.
+Many hardware or software encoding solutions may include _endpoint_ and _token_ fields. This does not mean they support WebRTC or WHIP. You should review the tool's documentation to confirm it supports WebRTC before trying to stream to OptiView Real-time Streaming.
 
-Dolby.io streaming also supports [SRT](/millicast/broadcast/srt.mdx) and [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) streams for wider compatibility for tools that do not yet support WHIP.
+OptiView Real-time Streaming also supports [SRT](/millicast/broadcast/srt.mdx) and [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) streams for wider compatibility for tools that do not yet support WHIP.
 :::
 
 ## Learn more

--- a/millicast/callouts/_rebranding_notice.md
+++ b/millicast/callouts/_rebranding_notice.md
@@ -1,0 +1,5 @@
+:::info OptiView Rebranding
+
+Dolby OptiView Real-time Streaming is the new name for Dolby.io Real-time Streaming (Millicast) as part of the OptiView product suite. During the transition, you may still see references to Millicast or Dolby.io. These all refer to the same product.
+
+:::

--- a/millicast/callouts/_rebranding_notice.md
+++ b/millicast/callouts/_rebranding_notice.md
@@ -1,5 +1,5 @@
 :::info OptiView Rebranding
 
-Dolby OptiView Real-time Streaming is the new name for Dolby.io (Millicast) as part of the OptiView product suite. During the transition, you may still see references to Millicast or Dolby.io. These all refer to the same product.  You still access the dashboard at https://streaming.dolby.io.
+Dolby OptiView Real-time Streaming is the new name for Dolby.io (Millicast) as part of the OptiView product suite. During the transition, you may still see references to Millicast or Dolby.io. These all refer to the same product. You still access the dashboard at https://streaming.dolby.io.
 
 :::

--- a/millicast/callouts/_rebranding_notice.md
+++ b/millicast/callouts/_rebranding_notice.md
@@ -1,5 +1,5 @@
 :::info OptiView Rebranding
 
-Dolby OptiView Real-time Streaming is the new name for Dolby.io Real-time Streaming (Millicast) as part of the OptiView product suite. During the transition, you may still see references to Millicast or Dolby.io. These all refer to the same product.
+Dolby OptiView Real-time Streaming is the new name for Dolby.io (Millicast) as part of the OptiView product suite. During the transition, you may still see references to Millicast or Dolby.io. These all refer to the same product.  You still access the dashboard at https://streaming.dolby.io.
 
 :::

--- a/millicast/capture/360-cameras.mdx
+++ b/millicast/capture/360-cameras.mdx
@@ -4,7 +4,7 @@ slug: /capture/360-vr-cameras
 sidebar_position: 4
 ---
 
-Dolby.io Real-time Streaming allows for 360-degree [Real-time broadcasts](https://optiview.dolby.com/solutions/real-time-streaming/).
+OptiView Real-time Streaming allows for 360-degree [Real-time broadcasts](https://optiview.dolby.com/solutions/real-time-streaming/).
 
 Create a 360/VR experience delivered to your audience for real time engagement.
 
@@ -24,7 +24,7 @@ import Insta360 from '../assets/img/insta360.png';
   <img src={Insta360} width="500" />
 </div>
 
-6. Enter you Dolby.io RTMP publishing path.
+6. Enter your OptiView RTMP publishing path.
 
 import Insta360rtmp from '../assets/img/insta360rtmp.png';
 
@@ -40,14 +40,14 @@ import Insta360rtmp from '../assets/img/insta360rtmp.png';
 
 This set up be will using a Ricoh Theta 360 camera with a USB connection. It can also be used with any 360 camera that supports camera capture with via USB, NDI or HDMI output.
 
-The built in Dolby.io Broadcaster can be used or you can also use a 360 video with OBS if no 360 camera is available.
+The built in OptiView Broadcaster can be used or you can also use a 360 video with OBS if no 360 camera is available.
 
 ## Installing software required for the computer
 
 Use a high-performance computer and install the required software. This guide uses Windows 11.  
 Refer to each software website for details on the installation method.
 
-- [Dolby.io](https://dolby.io) account. The portal can be used to publish your stream.
+- [OptiView Real-time Streaming](https://optiview.dolby.com) account. The portal can be used to publish your stream.
 - [Millicast OBS version](https://github.com/CoSMoSoftware/OBS-studio-webrtc/releases) for maximum bitrate and resolution.
 - Web browser Google Chrome for VP9 codec and AV1.
 - AV1 will require Millicast browser publisher with OBS set as a virtual cam.
@@ -57,7 +57,7 @@ Refer to each software website for details on the installation method.
 ## Setting up OBS for your 360 live stream
 
 1. Start OBS WebRTC and select "Settings">"Stream" from the menu.
-2. Enter your Dolby.io Real-time Streaming Stream Name and Publishing Token.
+2. Enter your OptiView Real-time Streaming Stream Name and Publishing Token.
 3. Select the preferred codec. For best reach, use H264 or VP8. Here I am using VP9 for the best compression at 8000 Kbps.
 
 import I2721a043601 from '../assets/img/2721a04-3601.png';
@@ -104,11 +104,11 @@ import I4efff433605 from '../assets/img/4efff43-3605.png';
 
 12. Start your stream.
 
-## Viewing your Dolby.io Real-time Streaming 360 stream
+## Viewing your OptiView Real-time Streaming 360 stream
 
 1. Go to this [360 VR player](https://rnkvogel.github.io/dolby360-VR/) using Chrome for VP9.  
    _Use codec H264 or VP8 if you would like to view it on mobile devices._
-2. Enter your AccountID and StreamName from your Dolby.io developer portal and start player.
+2. Enter your AccountID and StreamName from your OptiView developer portal and start player.
 
 Your 360 stream should now be viewable.  
 You can use your mouse to select your view.
@@ -125,7 +125,7 @@ The player can be downloaded and customized as needed.
 
 1. Go to this [360 VR player](https://rnkvogel.github.io/dolby360-VR/) using Chrome for VP9.  
    _Use codec H264 or VP8 if you would like to view it on mobile devices._
-2. Enter your AccountID and StreamName from your Dolby.io developer portal and start player.
+2. Enter your AccountID and StreamName from your OptiView developer portal and start player.
 
 import I54e32f3vr1 from '../assets/img/54e32f3-vr1.png';
 

--- a/millicast/capture/360-cameras.mdx
+++ b/millicast/capture/360-cameras.mdx
@@ -24,7 +24,7 @@ import Insta360 from '../assets/img/insta360.png';
   <img src={Insta360} width="500" />
 </div>
 
-6. Enter your OptiView RTMP publishing path.
+6. Enter your OptiView Real-time RTMP publishing path.
 
 import Insta360rtmp from '../assets/img/insta360rtmp.png';
 

--- a/millicast/capture/action-cameras.mdx
+++ b/millicast/capture/action-cameras.mdx
@@ -16,13 +16,13 @@ If you are using an action camera that is not listed, you should be able to use 
 
 ![GoPro](https://dolby.io/wp-content/uploads/2023/01/Dolby.io_Live-Stream-With-GoPro-Via-Dolby.io-Streaming@3x-100-2048x847.jpg)
 
-[GoPro](https://gopro.com/) is a leader in action cameras. With the latest models of GoPro cameras, you can achieve sub-second latency by streaming with RTMP from your GoPro directly to Dolby.io for [distribution](/millicast/distribution/index.mdx) over WebRTC.
+[GoPro](https://gopro.com/) is a leader in action cameras. With the latest models of GoPro cameras, you can achieve sub-second latency by streaming with RTMP from your GoPro directly to OptiView Real-time Streaming for [distribution](/millicast/distribution/index.mdx) over WebRTC.
 
 - GoPro HERO Black
 - GoPro MAX
 
-:::tip Dolby.io Dashboard - Publish Token Details
-You will need to have your Dolby.io **publishing token** and **stream name** in order to complete this setup. See the [Getting Started](/millicast/getting-started/using-the-dashboard.mdx) guide for instructions on creating a new app for the first time. You will also need the **RTMP publish path** from the _Publishing_ tab in the Dolby.io Dashboard. See the [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) guide for more detail on where to find it.
+:::tip OptiView Streaming Dashboard - Publish Token Details
+You will need to have your OptiView **publishing token** and **stream name** in order to complete this setup. See the [Getting Started](/millicast/getting-started/using-the-dashboard.mdx) guide for instructions on creating a new app for the first time. You will also need the **RTMP publish path** from the _Publishing_ tab in the OptiView Streaming Dashboard. See the [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) guide for more detail on where to find it.
 :::
 
 ### Using the GoPro Quik App
@@ -33,7 +33,7 @@ An overview of the steps to begin capturing from a GoPro include:
 
 1. Select Live Stream While Connected to Camera
 2. Select RTMP as Platform
-3. Enter your Dolby.io RTMP Publish URL
+3. Enter your OptiView RTMP Publish URL
 4. Go Live
 
 The **Quick App** is a GoPro product, so the user interface and instructions may change in future releases from what is described below. Visit the official [GoPro Support](https://community.gopro.com/s/?language=en_US) for resources like product manuals, help articles, and video tutorials on using the app if you have any questions.
@@ -50,7 +50,7 @@ import GoProLiveStream from '../assets/img/go-pro-hero8-camera-quik-app-live-str
 
 #### 2. Select RTMP as platform
 
-Some of the popular public streaming options are listed. To set up your private stream using Dolby.io, select _RTMP_ from the options.
+Some of the popular public streaming options are listed. To set up your private stream using OptiView Real-time Streaming, select _RTMP_ from the options.
 
 import GoProLiveStreamRtmp from '../assets/img/go-pro-quik-live-stream-rtmp.jpg';
 
@@ -58,9 +58,9 @@ import GoProLiveStreamRtmp from '../assets/img/go-pro-quik-live-stream-rtmp.jpg'
   <img src={GoProLiveStreamRtmp} width="400" />
 </div>
 
-#### 3. Enter your Dolby.io RTMP publish path
+#### 3. Enter your OptiView RTMP publish path
 
-The _Publishing_ tab of the _Live broadcast - Publish tokens_ section of the Dolby.io dashboard includes the details you need.
+The _Publishing_ tab of the _Live broadcast - Publish tokens_ section of the OptiView Streaming Dashboard includes the details you need.
 
 > `RTMP publish path` + `/` + `RTMP publish stream name`
 
@@ -98,7 +98,7 @@ import GoProStreamHealth from '../assets/img/gopro-stream-health.png';
   <img src={GoProStreamHealth} width="400" />
 </div>
 
-To verify everything is working, you view the stream using any suitable [playback](/millicast/playback/index.mdx) method, such as the hosted web viewer described in the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) guide available directly from the Dolby.io Dashboard.
+To verify everything is working, you view the stream using any suitable [playback](/millicast/playback/index.mdx) method, such as the hosted web viewer described in the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) guide available directly from the OptiView Streaming Dashboard.
 
 ### Using the GoPro webcam utility
 
@@ -106,7 +106,7 @@ The GoPro [Webcam](https://community.gopro.com/s/article/GoPro-Webcam?language=e
 
 The **Webcam Utility** is a GoPro product, so the behavior and instructions may change in future releases from what is described below. Visit the official [GoPro Support](https://community.gopro.com/s/?language=en_US) for resources like Product Manuals, Help Articles, and Video Tutorials on using the app if you have any questions.
 
-#### Stream with the Dolby.io dashboard
+#### Stream with the OptiView Streaming Dashboard
 
 With the GoPro Webcam utility, your GoPro camera will be present as an option from the media device selection. Follow the same instructions for broadcasting described in [Part 1: Using the Streaming Dashboard](/millicast/getting-started/using-the-dashboard.mdx).
 
@@ -118,7 +118,7 @@ import GoProWebCam from '../assets/img/GoPro_Web_Cam.png';
 
 #### Stream using a GoPro from OBS
 
-Similar to using the Dolby.io Dashboard, you can select the GoPro Webcam from the list of available devices. See the [OBS](/millicast/broadcast/software-encoders/obs/index.mdx) guide for more detail on how to configure OBS to broadcast the captured stream.
+Similar to using the OptiView Streaming Dashboard, you can select the GoPro Webcam from the list of available devices. See the [OBS](/millicast/broadcast/software-encoders/obs/index.mdx) guide for more detail on how to configure OBS to broadcast the captured stream.
 
 import GoProObs from '../assets/img/GoProOBS.png';
 

--- a/millicast/capture/action-cameras.mdx
+++ b/millicast/capture/action-cameras.mdx
@@ -21,8 +21,8 @@ If you are using an action camera that is not listed, you should be able to use 
 - GoPro HERO Black
 - GoPro MAX
 
-:::tip OptiView Streaming Dashboard - Publish Token Details
-You will need to have your OptiView **publishing token** and **stream name** in order to complete this setup. See the [Getting Started](/millicast/getting-started/using-the-dashboard.mdx) guide for instructions on creating a new app for the first time. You will also need the **RTMP publish path** from the _Publishing_ tab in the OptiView Streaming Dashboard. See the [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) guide for more detail on where to find it.
+:::tip OptiView Real-time Streaming Dashboard - Publish Token Details
+You will need to have your OptiView **publishing token** and **stream name** in order to complete this setup. See the [Getting Started](/millicast/getting-started/using-the-dashboard.mdx) guide for instructions on creating a new app for the first time. You will also need the **RTMP publish path** from the _Publishing_ tab in the OptiView Real-time Streaming Dashboard. See the [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) guide for more detail on where to find it.
 :::
 
 ### Using the GoPro Quik App
@@ -60,7 +60,7 @@ import GoProLiveStreamRtmp from '../assets/img/go-pro-quik-live-stream-rtmp.jpg'
 
 #### 3. Enter your OptiView RTMP publish path
 
-The _Publishing_ tab of the _Live broadcast - Publish tokens_ section of the OptiView Streaming Dashboard includes the details you need.
+The _Publishing_ tab of the _Live broadcast - Publish tokens_ section of the OptiView Real-time Streaming Dashboard includes the details you need.
 
 > `RTMP publish path` + `/` + `RTMP publish stream name`
 
@@ -98,7 +98,7 @@ import GoProStreamHealth from '../assets/img/gopro-stream-health.png';
   <img src={GoProStreamHealth} width="400" />
 </div>
 
-To verify everything is working, you view the stream using any suitable [playback](/millicast/playback/index.mdx) method, such as the hosted web viewer described in the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) guide available directly from the OptiView Streaming Dashboard.
+To verify everything is working, you view the stream using any suitable [playback](/millicast/playback/index.mdx) method, such as the hosted web viewer described in the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) guide available directly from the OptiView Real-time Streaming Dashboard.
 
 ### Using the GoPro webcam utility
 
@@ -106,7 +106,7 @@ The GoPro [Webcam](https://community.gopro.com/s/article/GoPro-Webcam?language=e
 
 The **Webcam Utility** is a GoPro product, so the behavior and instructions may change in future releases from what is described below. Visit the official [GoPro Support](https://community.gopro.com/s/?language=en_US) for resources like Product Manuals, Help Articles, and Video Tutorials on using the app if you have any questions.
 
-#### Stream with the OptiView Streaming Dashboard
+#### Stream with the OptiView Real-time Streaming Dashboard
 
 With the GoPro Webcam utility, your GoPro camera will be present as an option from the media device selection. Follow the same instructions for broadcasting described in [Part 1: Using the Streaming Dashboard](/millicast/getting-started/using-the-dashboard.mdx).
 
@@ -118,7 +118,7 @@ import GoProWebCam from '../assets/img/GoPro_Web_Cam.png';
 
 #### Stream using a GoPro from OBS
 
-Similar to using the OptiView Streaming Dashboard, you can select the GoPro Webcam from the list of available devices. See the [OBS](/millicast/broadcast/software-encoders/obs/index.mdx) guide for more detail on how to configure OBS to broadcast the captured stream.
+Similar to using the OptiView Real-time Streaming Dashboard, you can select the GoPro Webcam from the list of available devices. See the [OBS](/millicast/broadcast/software-encoders/obs/index.mdx) guide for more detail on how to configure OBS to broadcast the captured stream.
 
 import GoProObs from '../assets/img/GoProOBS.png';
 

--- a/millicast/capture/index.mdx
+++ b/millicast/capture/index.mdx
@@ -28,7 +28,7 @@ Check with your specific hardware provider for direct support of WebRTC or one o
       icon: '🚀',
     },
     label: 'Getting Started',
-    description: 'Quick start for capturing video using the OptiView Streaming Dashboard.',
+    description: 'Quick start for capturing video using the OptiView Real-time Streaming Dashboard.',
   }}
 />
 

--- a/millicast/capture/index.mdx
+++ b/millicast/capture/index.mdx
@@ -14,7 +14,7 @@ Many devices are able to capture a compatible media stream encoding that is read
 - **NDI**, Network Device Interface, is a free protocol for Video over IP that is supported by video mixers, capture cards, and other devices
 - **RTSP**, Real-time Streaming Protocol, is commonly supported in media streaming servers that capture and process video and audio feeds
 
-In facilitating efficient and reliable transmission of multimedia content over networks, Dolby.io CDN ingests streams in WebRTC, RTMP and RTMPs, and SRT.
+In facilitating efficient and reliable transmission of multimedia content over networks, the OptiView Real-time CDN ingests streams in WebRTC, RTMP and RTMPs, and SRT.
 
 Check with your specific hardware provider for direct support of WebRTC or one of these common device interfaces.
 
@@ -28,7 +28,7 @@ Check with your specific hardware provider for direct support of WebRTC or one o
       icon: '🚀',
     },
     label: 'Getting Started',
-    description: 'Quick start for capturing video using the Dolby.io dashboard.',
+    description: 'Quick start for capturing video using the OptiView Streaming Dashboard.',
   }}
 />
 
@@ -46,10 +46,10 @@ Any physical camera that supports standard interfaces like SDI, HDMI, NDI or RTS
 The **Millicast Web SDK** enables many popular web browsers to capture a video feed from a built-in camera or webcam that is connected to a computer system such as a Mac, Windows PC, or Linux desktop.
 
 [How-to Stream from DJI Drones](live-streaming-from-drones.mdx)<br/>
-**DJI** creates a number of devices such as the Phantom or Mavic that let you stream directly from the drone to Dolby.io with RTMP.
+**DJI** creates a number of devices such as the Phantom or Mavic that let you stream directly from the drone to OptiView Real-time Streaming with RTMP.
 
 [How-to Stream from a GoPro](action-cameras.mdx)<br/>
-**GoPro** is a leading device used for capturing action footage. The latest cameras allow you to stream direct from the device to Dolby.io with RTMP.
+**GoPro** is a leading device used for capturing action footage. The latest cameras allow you to stream direct from the device to OptiView Real-time Streaming with RTMP.
 
 ### Virtual cameras
 

--- a/millicast/capture/live-streaming-from-drones.mdx
+++ b/millicast/capture/live-streaming-from-drones.mdx
@@ -71,11 +71,11 @@ import DjiLiveStreamingMenu from '../assets/img/dolbyio-dji-drone-live-streaming
 
 #### 4. Enter Livestream settings
 
-:::tip OptiView Streaming Dashboard - Publish Token Details
-You will need to have your OptiView **publishing token** and **stream name** in order to complete this setup. See the [Getting Started](/millicast/getting-started/using-the-dashboard.mdx) guide for instructions on creating a new app for the first time. You will also need the **RTMP publish path** from the _Publishing_ tab in the OptiView Streaming Dashboard. See the [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) guide for more detail on where to find it.
+:::tip OptiView Real-time Streaming Dashboard - Publish Token Details
+You will need to have your OptiView **publishing token** and **stream name** in order to complete this setup. See the [Getting Started](/millicast/getting-started/using-the-dashboard.mdx) guide for instructions on creating a new app for the first time. You will also need the **RTMP publish path** from the _Publishing_ tab in the OptiView Real-time Streaming Dashboard. See the [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) guide for more detail on where to find it.
 :::
 
-For the Livestream settings, you must provide a URL for the **RTMP Address**. This is constructed from a few of your publisher token settings gathered from the OptiView Streaming Dashboard.
+For the Livestream settings, you must provide a URL for the **RTMP Address**. This is constructed from a few of your publisher token settings gathered from the OptiView Real-time Streaming Dashboard.
 
 > `RTMP publish path` + `/` + `RTMP publish stream name`
 

--- a/millicast/capture/live-streaming-from-drones.mdx
+++ b/millicast/capture/live-streaming-from-drones.mdx
@@ -20,7 +20,7 @@ _Please observe any safety protocols and regulations for drone usage in your reg
 
 ## DJI
 
-[DJI](https://www.dji.com/) is a leader in consumer and professional drones used for aerial videography. Several models support networking and RTMP streaming from the device that can be sent directly to Dolby.io for [distribution](/millicast/distribution/index.mdx) over WebRTC.
+[DJI](https://www.dji.com/) is a leader in consumer and professional drones used for aerial videography. Several models support networking and RTMP streaming from the device that can be sent directly to OptiView Real-time Streaming for [distribution](/millicast/distribution/index.mdx) over WebRTC.
 
 Some examples:
 
@@ -71,11 +71,11 @@ import DjiLiveStreamingMenu from '../assets/img/dolbyio-dji-drone-live-streaming
 
 #### 4. Enter Livestream settings
 
-:::tip Dolby.io Dashboard - Publish Token Details
-You will need to have your Dolby.io **publishing token** and **stream name** in order to complete this setup. See the [Getting Started](/millicast/getting-started/using-the-dashboard.mdx) guide for instructions on creating a new app for the first time. You will also need the **RTMP publish path** from the _Publishing_ tab in the Dolby.io Dashboard. See the [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) guide for more detail on where to find it.
+:::tip OptiView Streaming Dashboard - Publish Token Details
+You will need to have your OptiView **publishing token** and **stream name** in order to complete this setup. See the [Getting Started](/millicast/getting-started/using-the-dashboard.mdx) guide for instructions on creating a new app for the first time. You will also need the **RTMP publish path** from the _Publishing_ tab in the OptiView Streaming Dashboard. See the [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx) guide for more detail on where to find it.
 :::
 
-For the Livestream settings, you must provide a URL for the **RTMP Address**. This is constructed from a few of your publisher token settings gathered from the Dolby.io Dashboard.
+For the Livestream settings, you must provide a URL for the **RTMP Address**. This is constructed from a few of your publisher token settings gathered from the OptiView Streaming Dashboard.
 
 > `RTMP publish path` + `/` + `RTMP publish stream name`
 
@@ -105,12 +105,12 @@ import Screenshot20220113112908 from '../assets/img/Screenshot_20220113-112908.j
 
 #### Viewing
 
-You can now share your viewer link provided from your Dolby.io developer portal under the API tab.  
+You can now share your viewer link provided from your OptiView developer portal under the API tab.  
 Example: https://viewer.millicast.com/?streamId=k9Mwad/multiview
 
 ### Record drone footage
 
-By configuring your publish token to [record](/millicast/distribution/stream-recordings/index.mdx) footage you can maintain a copy of anything that is captured to your [Dolby.io Recording Archive](/millicast/distribution/stream-recordings/index.mdx). This feature can incur additional charges.
+By configuring your publish token to [record](/millicast/distribution/stream-recordings/index.mdx) footage you can maintain a copy of anything that is captured to your [OptiView Recording Archive](/millicast/distribution/stream-recordings/index.mdx). This feature can incur additional charges.
 
 #### Video: Real-time Streaming drone latency test
 

--- a/millicast/capture/production-cameras.mdx
+++ b/millicast/capture/production-cameras.mdx
@@ -3,7 +3,7 @@ title: Professional Cameras
 sidebar_position: 2
 ---
 
-Dolby.io Real-time Streaming supports broadcast-grade workflows that use professional cameras and encoders to deliver high-quality, real-time video and audio streams globally to massive audiences. Broadcast-grade cameras are typically recommended for sports streaming, live events, and experiences where quality and low latency are prioritized. This guide will outline how to prepare professional cameras for capture so you can broadcast with Dolby.io Real-time Streaming.
+OptiView Real-time Streaming supports broadcast-grade workflows that use professional cameras and encoders to deliver high-quality, real-time video and audio streams globally to massive audiences. Broadcast-grade cameras are typically recommended for sports streaming, live events, and experiences where quality and low latency are prioritized. This guide will outline how to prepare professional cameras for capture so you can broadcast with OptiView Real-time Streaming.
 
 When capturing video and audio for broadcast, there are a number of decisions that need to be made, such as:
 
@@ -13,19 +13,19 @@ When capturing video and audio for broadcast, there are a number of decisions th
 - Does my camera have a built-in encoder, or will I need to connect to one?
 - Am I planning to broadcast with [RTMP, RTMPs](/millicast/broadcast/rtmp-and-rtmps.mdx), [SRT](/millicast/broadcast/srt.mdx), or [WebRTC](/millicast/broadcast/hardware-encoders/osprey.mdx)?
 
-These decisions may be impacted by the camera you are capturing with, the encoder you are planning to use to broadcast, and the Dolby.io CDN itself.
+These decisions may be impacted by the camera you are capturing with, the encoder you are planning to use to broadcast, and the OptiView Real-time CDN itself.
 
-The Dolby.io CDN for WebRTC Real-time Streaming supports streaming up to 4k 60fps video with 4:4:4 color encoded into H.264, H.265, VP8, VP9, and AV1. Additionally, Dolby.io also fully supports transporting audio via the [Opus codec](https://opus-codec.org/), allowing for bitrates from 6 kb/s to 510 kb/s and sampling rates from 8 kHz (narrowband) to 48 kHz (full-band). RTMP, RTMPs, and SRT streams can also be ingested and will be transmuxed into a WebRTC stream via the Dolby.io CDN, though their codec support may vary.
+The OptiView Real-time CDN for WebRTC Real-time Streaming supports streaming up to 4k 60fps video with 4:4:4 color encoded into H.264, H.265, VP8, VP9, and AV1. Additionally, OptiView Real-time Streaming also fully supports transporting audio via the [Opus codec](https://opus-codec.org/), allowing for bitrates from 6 kb/s to 510 kb/s and sampling rates from 8 kHz (narrowband) to 48 kHz (full-band). RTMP, RTMPs, and SRT streams can also be ingested and will be transmuxed into a WebRTC stream via the OptiView Real-time CDN, though their codec support may vary.
 
 :::tip Codec support varies between RTMP, RTMPs, SRT, and WebRTC
-Since RTMP, RTMPs, and SRT streams are transmuxed into WebRTC via the Dolby.io CDN they each have different audio and video codec support. Learn more in the [broadcast section](/millicast/broadcast/index.mdx) of the streaming guides.
+Since RTMP, RTMPs, and SRT streams are transmuxed into WebRTC via the OptiView Real-time CDN they each have different audio and video codec support. Learn more in the [broadcast section](/millicast/broadcast/index.mdx) of the streaming guides.
 :::
 
-Once you have calibrated the camera for the appropriate video resolution and audio resolution for your use case, you will then need to connect the camera to an encoder or calibrate the built-in encoder. Dolby.io supports broadcasting [RTMP and RTMPs streams](/millicast/broadcast/rtmp-and-rtmps.mdx), [SRT streams](/millicast/broadcast/srt.mdx), and [WebRTC streams](/millicast/broadcast/hardware-encoders/osprey.mdx). To start streaming with Dolby.io Real-time Streaming, proceed to the [Broadcast](/millicast/broadcast/index.mdx) to learn about hardware and software encoder support.
+Once you have calibrated the camera for the appropriate video resolution and audio resolution for your use case, you will then need to connect the camera to an encoder or calibrate the built-in encoder. OptiView Real-time Streaming supports broadcasting [RTMP and RTMPs streams](/millicast/broadcast/rtmp-and-rtmps.mdx), [SRT streams](/millicast/broadcast/srt.mdx), and [WebRTC streams](/millicast/broadcast/hardware-encoders/osprey.mdx). To start streaming with OptiView Real-time Streaming, proceed to the [Broadcast](/millicast/broadcast/index.mdx) to learn about hardware and software encoder support.
 
 ## Preparing to broadcast with the SalrayWorks raySHOT camera
 
-One example of preparing a professional camera for broadcasting is setting up the [SalrayWorks raySHOT Ultra Latency camera](http://salrayworks.com/eng/bbs/board.php?bo_table=pro_05&wr_id=4). The raySHOT Ultra Latency camera specializes in capturing video with a delay between 0-15ms allowing for exceptionally fast streaming when paired with Dolby.io Real-time Streaming. Using the decision list above, we can break down what our capture profile and broadcast workflow will look like for the camera:
+One example of preparing a professional camera for broadcasting is setting up the [SalrayWorks raySHOT Ultra Latency camera](http://salrayworks.com/eng/bbs/board.php?bo_table=pro_05&wr_id=4). The raySHOT Ultra Latency camera specializes in capturing video with a delay between 0-15ms allowing for exceptionally fast streaming when paired with OptiView Real-time Streaming. Using the decision list above, we can break down what our capture profile and broadcast workflow will look like for the camera:
 
 - **What video resolution and framerate should I capture?** The camera is limited to 1080p and 60fps.
 - **Should I use chroma subsampling or capture at 4:4:4?** The raySHOT supports 4:4:4 to allow for the lowest possible delay.

--- a/millicast/capture/production-cameras.mdx
+++ b/millicast/capture/production-cameras.mdx
@@ -21,7 +21,7 @@ The OptiView Real-time CDN for WebRTC Real-time Streaming supports streaming up 
 Since RTMP, RTMPs, and SRT streams are transmuxed into WebRTC via the OptiView Real-time CDN they each have different audio and video codec support. Learn more in the [broadcast section](/millicast/broadcast/index.mdx) of the streaming guides.
 :::
 
-Once you have calibrated the camera for the appropriate video resolution and audio resolution for your use case, you will then need to connect the camera to an encoder or calibrate the built-in encoder. OptiView Real-time Streaming supports broadcasting [RTMP and RTMPs streams](/millicast/broadcast/rtmp-and-rtmps.mdx), [SRT streams](/millicast/broadcast/srt.mdx), and [WebRTC streams](/millicast/broadcast/hardware-encoders/osprey.mdx). To start streaming with OptiView Real-time Streaming, proceed to the [Broadcast](/millicast/broadcast/index.mdx) to learn about hardware and software encoder support.
+Once you have calibrated the camera for the appropriate video resolution and audio resolution for your use case, you will then need to connect the camera to an encoder or calibrate the built-in encoder. OptiView Real-time Streaming supports broadcasting [RTMP and RTMPs streams](/millicast/broadcast/rtmp-and-rtmps.mdx), [SRT streams](/millicast/broadcast/srt.mdx), and [WebRTC streams](/millicast/broadcast/hardware-encoders/osprey.mdx). To start streaming with OptiView Real-time Streaming, proceed to the [Broadcast section](/millicast/broadcast/index.mdx) to learn about hardware and software encoder support.
 
 ## Preparing to broadcast with the SalrayWorks raySHOT camera
 

--- a/millicast/capture/screensharing.mdx
+++ b/millicast/capture/screensharing.mdx
@@ -3,9 +3,9 @@ title: Screensharing
 sidebar_position: 3
 ---
 
-Screensharing or screen capturing is an important feature for virtual events, webinars, and many other types of broadcasts that involve sharing information. This guide will outline three options for managing screen capture in a way that is compatible with Dolby.io:
+Screensharing or screen capturing is an important feature for virtual events, webinars, and many other types of broadcasts that involve sharing information. This guide will outline three options for managing screen capture in a way that is compatible with OptiView Real-time Streaming:
 
-1. [Screensharing with the Dolby.io Dashboard Broadcaster](/millicast/capture/screensharing.mdx#screensharing-with-the-dolbyio-dashboard-broadcaster)
+1. [Screensharing with the OptiView Streaming Dashboard Broadcaster](/millicast/capture/screensharing.mdx#screensharing-with-the-dolbyio-dashboard-broadcaster)
 2. [Screensharing with OBS](/millicast/capture/screensharing.mdx#screensharing-with-obs)
 3. [Screensharing with JavaScript](/millicast/capture/screensharing.mdx#screensharing-with-javascript)
 
@@ -15,9 +15,9 @@ If you want to enable both screensharing and share your webcam at the same time,
 
 :::
 
-## Screensharing with the Dolby.io dashboard broadcaster
+## Screensharing with the OptiView Streaming Dashboard broadcaster
 
-Once you have created a Dolby.io account, you can begin using the Dolby.io dashboard to create and manage tokens, manage your Dolby.io account, and broadcast and view active streams.
+Once you have created a OptiView Real-time account, you can begin using the OptiView Streaming Dashboard to create and manage tokens, manage your OptiView Real-time account, and broadcast and view active streams.
 
 Inside the dashboard, click the Broadcast button located adjacent to the token.
 
@@ -82,7 +82,7 @@ With our options defined, we can use the `getDisplayMedia` method to capture our
 const screenCapture = await navigator.mediaDevices.getDisplayMedia(displayMediaOptions);
 ```
 
-With that, the screen is now being captured. When this function is called, users will receive a permissions prompt from the browser which they will have to approve for the device to begin capturing content. This screen capture can then be passed as a `mediaStream` into the Dolby.io Millicast JavaScript SDK. To learn more about how you can begin broadcasting a screen capture, explore the Client SDK guides or check out this detailed blog for [screenshare streaming in JavaScript](https://optiview.dolby.com/resources/blog/streaming/how-to-screen-capture-for-streaming-in-javascript/).
+With that, the screen is now being captured. When this function is called, users will receive a permissions prompt from the browser which they will have to approve for the device to begin capturing content. This screen capture can then be passed as a `mediaStream` into the OptiView Real-time JavaScript SDK. To learn more about how you can begin broadcasting a screen capture, explore the Client SDK guides or check out this detailed blog for [screenshare streaming in JavaScript](https://optiview.dolby.com/resources/blog/streaming/how-to-screen-capture-for-streaming-in-javascript/).
 
 ## Additional Client SDKs
 

--- a/millicast/capture/screensharing.mdx
+++ b/millicast/capture/screensharing.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 Screensharing or screen capturing is an important feature for virtual events, webinars, and many other types of broadcasts that involve sharing information. This guide will outline three options for managing screen capture in a way that is compatible with OptiView Real-time Streaming:
 
-1. [Screensharing with the OptiView Streaming Dashboard Broadcaster](/millicast/capture/screensharing.mdx#screensharing-with-the-optiview-streaming-dashboard-broadcaster)
+1. [Screensharing with the OptiView Real-time Streaming Dashboard Broadcaster](/millicast/capture/screensharing.mdx#screensharing-with-the-optiview-real-time-streaming-dashboard-broadcaster)
 2. [Screensharing with OBS](/millicast/capture/screensharing.mdx#screensharing-with-obs)
 3. [Screensharing with JavaScript](/millicast/capture/screensharing.mdx#screensharing-with-javascript)
 
@@ -15,9 +15,9 @@ If you want to enable both screensharing and share your webcam at the same time,
 
 :::
 
-## Screensharing with the OptiView Streaming Dashboard broadcaster
+## Screensharing with the OptiView Real-time Streaming Dashboard broadcaster
 
-Once you have created a OptiView Real-time account, you can begin using the OptiView Streaming Dashboard to create and manage tokens, manage your OptiView Real-time account, and broadcast and view active streams.
+Once you have created an OptiView Real-time account, you can begin using the OptiView Real-time Streaming Dashboard to create and manage tokens, manage your OptiView Real-time account, and broadcast and view active streams.
 
 Inside the dashboard, click the Broadcast button located adjacent to the token.
 

--- a/millicast/capture/screensharing.mdx
+++ b/millicast/capture/screensharing.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 Screensharing or screen capturing is an important feature for virtual events, webinars, and many other types of broadcasts that involve sharing information. This guide will outline three options for managing screen capture in a way that is compatible with OptiView Real-time Streaming:
 
-1. [Screensharing with the OptiView Streaming Dashboard Broadcaster](/millicast/capture/screensharing.mdx#screensharing-with-the-dolbyio-dashboard-broadcaster)
+1. [Screensharing with the OptiView Streaming Dashboard Broadcaster](/millicast/capture/screensharing.mdx#screensharing-with-the-optiview-streaming-dashboard-broadcaster)
 2. [Screensharing with OBS](/millicast/capture/screensharing.mdx#screensharing-with-obs)
 3. [Screensharing with JavaScript](/millicast/capture/screensharing.mdx#screensharing-with-javascript)
 

--- a/millicast/capture/web-cameras.mdx
+++ b/millicast/capture/web-cameras.mdx
@@ -3,17 +3,17 @@ title: Web Cameras
 sidebar_position: 1
 ---
 
-Web cameras are an easy and accessible way to capture content for broadcast with Dolby.io Streaming. Since web cameras are ubiquitous, there are many different software solutions to capture from a web camera.
+Web cameras are an easy and accessible way to capture content for broadcast with OptiView Real-time Streaming. Since web cameras are ubiquitous, there are many different software solutions to capture from a web camera.
 
 This guide outlines three options for managing web camera capture:
 
-1. [Connecting a Web Camera to the Dolby.io Dashboard Broadcaster](/millicast/capture/web-cameras.mdx)
+1. [Connecting a Web Camera to the OptiView Streaming Dashboard Broadcaster](/millicast/capture/web-cameras.mdx)
 2. [Connecting a Web Camera to OBS](/millicast/capture/web-cameras.mdx)
 3. [Capturing from a Web Camera using JavaScript](/millicast/capture/web-cameras.mdx)
 
-## Connecting a web camera to the Dolby.io dashboard broadcaster
+## Connecting a web camera to the OptiView Streaming Dashboard broadcaster
 
-Once you have created a Dolby.io account, you can begin using the [Dolby.io dashboard](https://streaming.dolby.io/#/tokens) to create and manage tokens, manage your Dolby.io account, and [broadcast](/millicast/broadcast/index.mdx) and view active streams.
+Once you have created a OptiView Real-time account, you can begin using the [OptiView Streaming Dashboard](https://streaming.dolby.io/#/tokens) to create and manage tokens, manage your OptiView Real-time account, and [broadcast](/millicast/broadcast/index.mdx) and view active streams.
 
 Inside the dashboard, click the Broadcast button located adjacent to the token.
 
@@ -75,7 +75,7 @@ With your camera selected, click "OK". You've now set up your Web Camera for cap
 
 ## Capturing from a web camera using JavaScript
 
-If you are looking to prepare a Web Camera for capture within your application or platform, you'll need a programmatic solution. Dolby.io streaming supports [a number of SDKs](/millicast/playback/players-sdks/index.mdx) for building streaming solutions bespoke to your project.
+If you are looking to prepare a Web Camera for capture within your application or platform, you'll need a programmatic solution. OptiView Real-time Streaming supports [a number of SDKs](/millicast/playback/players-sdks/index.mdx) for building streaming solutions bespoke to your project.
 
 ### Identify available cameras
 

--- a/millicast/capture/web-cameras.mdx
+++ b/millicast/capture/web-cameras.mdx
@@ -7,13 +7,13 @@ Web cameras are an easy and accessible way to capture content for broadcast with
 
 This guide outlines three options for managing web camera capture:
 
-1. [Connecting a Web Camera to the OptiView Streaming Dashboard Broadcaster](/millicast/capture/web-cameras.mdx)
+1. [Connecting a Web Camera to the OptiView Real-time Streaming Dashboard Broadcaster](/millicast/capture/web-cameras.mdx)
 2. [Connecting a Web Camera to OBS](/millicast/capture/web-cameras.mdx)
 3. [Capturing from a Web Camera using JavaScript](/millicast/capture/web-cameras.mdx)
 
-## Connecting a web camera to the OptiView Streaming Dashboard broadcaster
+## Connecting a web camera to the OptiView Real-time Streaming Dashboard broadcaster
 
-Once you have created a OptiView Real-time account, you can begin using the [OptiView Streaming Dashboard](https://streaming.dolby.io/#/tokens) to create and manage tokens, manage your OptiView Real-time account, and [broadcast](/millicast/broadcast/index.mdx) and view active streams.
+Once you have created an OptiView Real-time account, you can begin using the [OptiView Real-time Streaming Dashboard](https://streaming.dolby.io/#/tokens) to create and manage tokens, manage your OptiView Real-time account, and [broadcast](/millicast/broadcast/index.mdx) and view active streams.
 
 Inside the dashboard, click the Broadcast button located adjacent to the token.
 

--- a/millicast/changelog/changelog-dolbyio-platform-media-server.md
+++ b/millicast/changelog/changelog-dolbyio-platform-media-server.md
@@ -227,7 +227,7 @@ Introduced support for VP9 codec that provides better color fidelity with the su
 
 ### Web Viewer Multi-view Support
 
-Introduced the Web Viewer multi-view support that allows customers to display multiple streams in a single viewer and interactively switch between them. The multi-view web viewer can be configured in the [Dolby.io dashboard](https://dashboard.dolby.io/) with a no-code hosted player, removing the need to deploy multiple player instances to view multiple streams.
+Introduced the Web Viewer multi-view support that allows customers to display multiple streams in a single viewer and interactively switch between them. The multi-view web viewer can be configured in the [Dolby.io dashboard](https://streaming.dolby.io/) with a no-code hosted player, removing the need to deploy multiple player instances to view multiple streams.
 
 For more information, see:
 

--- a/millicast/distribution/access-control/allowed-origins.md
+++ b/millicast/distribution/access-control/allowed-origins.md
@@ -22,10 +22,10 @@ This approach helps prevent unauthorized usage of tokens.
 You can manage allowed origins by changing settings from the user interface of the [Streaming Dashboard](/millicast/streaming-dashboard/index.mdx).
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You will need to have a publishing token. See [Managing Your Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx) for more details about tokens.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast. You will need to have a publishing token. See [Managing Your Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx) for more details about tokens.
 :::
 
-Open the Live Broadcast section of the OptiView Streaming Dashboard. Select the publishing token you want to secure. Within the **Security** section you can edit the _Allowed origins_ to specify a list of domain names.
+Open the Live Broadcast section of the OptiView Real-time Streaming Dashboard. Select the publishing token you want to secure. Within the **Security** section you can edit the _Allowed origins_ to specify a list of domain names.
 
 import DashboardAllowedOrigins from '../../assets/img/dashboard-allowed-origins.png';
 
@@ -75,10 +75,10 @@ _For example_, if you want to be able to share a stream with a specific end-user
 You can manage IP filters by changing settings from the user interface of the [Streaming Dashboard](/millicast/streaming-dashboard/index.mdx).
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You will need to have a publishing token. See [Managing Your Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx) for more details about tokens.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast. You will need to have a publishing token. See [Managing Your Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx) for more details about tokens.
 :::
 
-Open the Live Broadcast section of the OptiView Streaming Dashboard. Select the publishing token you want to secure. Within the **Security** section you can change the _IP filter type_ from the dropdown.
+Open the Live Broadcast section of the OptiView Real-time Streaming Dashboard. Select the publishing token you want to secure. Within the **Security** section you can change the _IP filter type_ from the dropdown.
 
 import DashboardIpFilterType from '../../assets/img/dashboard-ip-filter-type.png';
 

--- a/millicast/distribution/access-control/allowed-origins.md
+++ b/millicast/distribution/access-control/allowed-origins.md
@@ -22,10 +22,10 @@ This approach helps prevent unauthorized usage of tokens.
 You can manage allowed origins by changing settings from the user interface of the [Streaming Dashboard](/millicast/streaming-dashboard/index.mdx).
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast. You will need to have a publishing token. See [Managing Your Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx) for more details about tokens.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You will need to have a publishing token. See [Managing Your Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx) for more details about tokens.
 :::
 
-Open the Live Broadcast section of the Dolby.io Dashboard. Select the publishing token you want to secure. Within the **Security** section you can edit the _Allowed origins_ to specify a list of domain names.
+Open the Live Broadcast section of the OptiView Streaming Dashboard. Select the publishing token you want to secure. Within the **Security** section you can edit the _Allowed origins_ to specify a list of domain names.
 
 import DashboardAllowedOrigins from '../../assets/img/dashboard-allowed-origins.png';
 
@@ -75,10 +75,10 @@ _For example_, if you want to be able to share a stream with a specific end-user
 You can manage IP filters by changing settings from the user interface of the [Streaming Dashboard](/millicast/streaming-dashboard/index.mdx).
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast. You will need to have a publishing token. See [Managing Your Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx) for more details about tokens.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You will need to have a publishing token. See [Managing Your Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx) for more details about tokens.
 :::
 
-Open the Live Broadcast section of the Dolby.io Dashboard. Select the publishing token you want to secure. Within the **Security** section you can change the _IP filter type_ from the dropdown.
+Open the Live Broadcast section of the OptiView Streaming Dashboard. Select the publishing token you want to secure. Within the **Security** section you can change the _IP filter type_ from the dropdown.
 
 import DashboardIpFilterType from '../../assets/img/dashboard-ip-filter-type.png';
 
@@ -182,5 +182,5 @@ import DashOriginBroadcastError from '../../assets/img/dashboard-origin-broadcas
 Verify that the domain your application is running from is included.
 
 :::tip Allow the Streaming Dashboard
-Include _streaming.dolby.io_ in your list of domains if you want to be able to continue broadcasting using the [Dolby.io Streaming Dashboard](/millicast/streaming-dashboard/index.mdx).
+Include _streaming.dolby.io_ in your list of domains if you want to be able to continue broadcasting using the [OptiView Real-time Streaming Dashboard](/millicast/streaming-dashboard/index.mdx).
 :::

--- a/millicast/distribution/access-control/geo-blocking.mdx
+++ b/millicast/distribution/access-control/geo-blocking.mdx
@@ -57,10 +57,10 @@ Enabling geo-blocking account wide will have all previous and future publish tok
 ### How-to allow or block countries for a specific token
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast. You will need to have a publishing token.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You will need to have a publishing token.
 :::
 
-Open the Streaming section of the [Dolby.io Dashboard](/millicast/streaming-dashboard/index.mdx) and select an existing token or `+ Create` a new one.
+Open the Streaming section of the [OptiView Streaming Dashboard](/millicast/streaming-dashboard/index.mdx) and select an existing token or `+ Create` a new one.
 
 Toggle the Geo-blocking setting to enable it for a token.
 

--- a/millicast/distribution/access-control/geo-blocking.mdx
+++ b/millicast/distribution/access-control/geo-blocking.mdx
@@ -57,10 +57,10 @@ Enabling geo-blocking account wide will have all previous and future publish tok
 ### How-to allow or block countries for a specific token
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You will need to have a publishing token.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast. You will need to have a publishing token.
 :::
 
-Open the Streaming section of the [OptiView Streaming Dashboard](/millicast/streaming-dashboard/index.mdx) and select an existing token or `+ Create` a new one.
+Open the Streaming section of the [OptiView Real-time Streaming Dashboard](/millicast/streaming-dashboard/index.mdx) and select an existing token or `+ Create` a new one.
 
 Toggle the Geo-blocking setting to enable it for a token.
 

--- a/millicast/distribution/access-control/index.md
+++ b/millicast/distribution/access-control/index.md
@@ -3,10 +3,10 @@ title: Access Control
 sidebar_position: 1
 ---
 
-Stream security is a priority for the Dolby.io platform. Along with stream protocol encryption, Dolby.io provides a number of different server-side features to help protect both broadcasting (_Publishing_) a stream and viewing (_Subscribing_) to a stream, all managed via their respective tokens.
+Stream security is a priority for the OptiView Real-time platform. Along with stream protocol encryption, OptiView Real-time Streaming provides a number of different server-side features to help protect both broadcasting (_Publishing_) a stream and viewing (_Subscribing_) to a stream, all managed via their respective tokens.
 
 :::tip Looking for Dolby.io Account Access Management?
-To manage access for your team to share the same Dolby.io account, visit the [Dolby.io support portal FAQ section](https://support.dolby.io/hc/en-au/articles/4411755046159-FAQs-Account-Management) to learn more.
+To manage access for your team to share the same OptiView Real-time account, visit the [Dolby.io support portal FAQ section](https://support.dolby.io/hc/en-au/articles/4411755046159-FAQs-Account-Management) to learn more.
 :::
 
 ## Publishing access control

--- a/millicast/distribution/access-control/index.md
+++ b/millicast/distribution/access-control/index.md
@@ -20,7 +20,7 @@ During the Publish token creation process, you can further limit access in a few
 - [IP Filtering](/millicast/distribution/access-control/allowed-origins.md#ip-filters): With IP Address Filters, you can impose restrictions that limit access to a real-time stream by specifying specific IP network addresses.
 - [Geo-Blocking](/millicast/distribution/access-control/geo-blocking.mdx): Geo-blocking refers to restricting access to certain content based on the geographic location of the user. It can be filtered by "allowed" and "denied" countries. With geo-blocking, providers can adhere to specific licensing agreements and distribution rights, protect copyrighted material, or service another layer of privacy when working on classified content.
 
-These restrictions can be implemented in the [Dashboard](https://dashboard.dolby.io/signin) or [via the token REST APIs](/millicast/streaming-dashboard/token-api.mdx).
+These restrictions can be implemented in the [Dashboard](https://streaming.dolby.io/signin) or [via the token REST APIs](/millicast/streaming-dashboard/token-api.mdx).
 
 ## Subscribing access control
 
@@ -37,4 +37,4 @@ During the Subscribe token creation process, you can further limit access in a f
 The **Tracking ID** lets you create an alphanumeric ID that can be used to track and associate streaming statistics, such as bandwidth consumption, to various viewers on a stream. This can be useful for detecting token sharing and disabling misused tokens. For more information, see [Syndication](/millicast/distribution/syndication#creating-a-subscribe-token-with-tracking-id).
 :::
 
-These restrictions can be implemented in the [Dashboard](https://dashboard.dolby.io/signin) or via the [token REST APIs](/millicast/streaming-dashboard/token-api.mdx).
+These restrictions can be implemented in the [Dashboard](https://streaming.dolby.io/signin) or via the [token REST APIs](/millicast/streaming-dashboard/token-api.mdx).

--- a/millicast/distribution/cloud-transcoder.mdx
+++ b/millicast/distribution/cloud-transcoder.mdx
@@ -190,7 +190,7 @@ The platform also offers the [Configure Transcoder](/millicast/api/transcoder-up
 
 ## Webhook events
 
-The Dolby.io Streaming platform offers the following [webhook events](/millicast/webhooks/transcoder.md) to notify about transcoder state changes:
+The OptiView Real-time Streaming platform offers the following [webhook events](/millicast/webhooks/transcoder.md) to notify about transcoder state changes:
 
 - **Transcoder started**: Triggered whenever a transcoder is started and ready to use.
 - **Transcoder stopped**: Triggered whenever a transcoder is stopped.
@@ -210,7 +210,7 @@ Some encoders have TTL settings that can exceed 60 minutes so a work-around is t
 
 ### Feature Compatibility
 
-The Dolby.io Streaming platform allows using cloud transcoders with all other features, even with [Multi-view](/millicast/playback/multi-view.md) and [Redundant Ingest](/millicast/broadcast/redundant-ingest/index.mdx). However, publishing redundant feeds requires streaming feeds into two transcoders.
+The OptiView Real-time Streaming platform allows using cloud transcoders with all other features, even with [Multi-view](/millicast/playback/multi-view.md) and [Redundant Ingest](/millicast/broadcast/redundant-ingest/index.mdx). However, publishing redundant feeds requires streaming feeds into two transcoders.
 
 When using transcoding with recording, the platform records only the top layer.
 

--- a/millicast/distribution/cloud-transcoder.mdx
+++ b/millicast/distribution/cloud-transcoder.mdx
@@ -61,7 +61,7 @@ You can start and manage cloud transcoders either through the dashboard or Trans
 
 To create a dedicated transcoder in the dashboard and use it for your stream, follow these steps:
 
-1. [Log in](https://dashboard.dolby.io/) to the dashboard and create a new publish token with a cluster set to Ashburn or Phoenix.
+1. [Log in](https://streaming.dolby.io/) to the dashboard and create a new publish token with a cluster set to Ashburn or Phoenix.
 2. Click the name of the created token and select the **Publishing** tab.
 3. Toggle the **Transcoding** setting to enable transcoding for the token.
 4. Click the **Create new transcoder** button.

--- a/millicast/distribution/index.mdx
+++ b/millicast/distribution/index.mdx
@@ -5,7 +5,7 @@ title: Distribution
 import DocCard from '@theme/DocCard';
 import DocCardList from '@theme/DocCardList';
 
-The Dolby.io Streaming Content Delivery Network (CDN) offers a range of server-side features that users can toggle and adjust via the REST APIs or your account Dashboard to ensure streams are secure, stable, and scalable.
+The OptiView Real-time Content Delivery Network (CDN) offers a range of server-side features that users can toggle and adjust via the REST APIs or your account Dashboard to ensure streams are secure, stable, and scalable.
 
 - **Scalability** to distribute content to large audiences across [multiple regions](/millicast/distribution/multi-region-support/index.mdx) in real-time.
 - **Stability** with features like [simulcast with WebRTC](/millicast/distribution/using-webrtc-simulcast) that provide redundancy and adaptability to maintain a good user experience across different network and device conditions while maintaining a high uptime and Quality of Experience (QoE).
@@ -63,15 +63,15 @@ import ISOIEC270012022 from '../assets/img/ISO-IEC-27001-2022-005.webp';
   <img src={ISOIEC270012022} width="150" />
 </div>
 
-The Dolby.io Millicast platform has been assessed and found to be in accordance with the management system requirements in [ISO/IEC 27001:2022](https://www.iso.org/standard/27001).
+The OptiView Real-time platform has been assessed and found to be in accordance with the management system requirements in [ISO/IEC 27001:2022](https://www.iso.org/standard/27001).
 
-ISO 27001 is an internationally recognized standard for information security management systems (ISMS). Dolby.io's conformity to ISO/IEC standards means that we've established systems, plans, and security measures to protect and safely handle user data, along with general information security.
+ISO 27001 is an internationally recognized standard for information security management systems (ISMS). Dolby's conformity to ISO/IEC standards means that we've established systems, plans, and security measures to protect and safely handle user data, along with general information security.
 
 If you'd like confirmation of our certification, please see [the IAF's accreditation verification tool](https://www.iafcertsearch.org/certification/DQmrsq4w4DnUf2KBVA3WYdmR).
 
 ### Stability
 
-Whether the stream has one viewer or hundreds of thousands, the stability of the stream is a top priority. To support stream stability and adaptability, Dolby.io provides several important features.
+Whether the stream has one viewer or hundreds of thousands, the stability of the stream is a top priority. To support stream stability and adaptability, OptiView Real-time Streaming provides several important features.
 
 [Multi-source streaming](/millicast/broadcast/multi-source-broadcasting.mdx)<br/>
 Add redundancy with multiple independent broadcast sources as part of the same stream. This distribution of multiple audio and video tracks enables the viewer to playback a different feed in case an incoming source becomes unavailable.
@@ -93,7 +93,7 @@ Similar to multi-source streaming, **backup publishing** allows for a parallel b
 
 ### Scalability
 
-To support global audiences into the hundreds of thousands of viewers, Dolby.io provides features that help with scaling streams to meet those demands without impacting the quality or stability of the stream.
+To support global audiences into the hundreds of thousands of viewers, OptiView Real-time Streaming provides features that help with scaling streams to meet those demands without impacting the quality or stability of the stream.
 
 [Multi-region support](/millicast/distribution/multi-region-support/index.mdx)<br/>
 We utilize a network of data centers distributed around the globe. This allows streams to maintain ultra-low latency and high scalability to audiences that may be scattered to many different regions.
@@ -105,10 +105,10 @@ Through distribution partners, **syndication** allows you to send the same strea
 A live broadcast can be archived by enabling the storage of a recording of the stream.
 
 [Self-signed tokens](/millicast/streaming-dashboard/subscribe-tokens.mdx#creating-a-self-signed-token)<br/>
-To improve performance when tracking many individual streams among your users, you only need to generate one Dolby.io token and can then delegate that authorization by generating new self-signed **JWT tokens** in your application without needing to fetch a new subscriber token from Dolby.io for each new stream.
+To improve performance when tracking many individual streams among your users, you only need to generate one token and can then delegate that authorization by generating new self-signed **JWT tokens** in your application without needing to fetch a new subscriber token for each new stream.
 
 [Streaming analytics](/millicast/analytics/index.md)<br/>
-The Dolby.io dashboard provides data-rich information about streaming usage for your individual account. There are also **REST** and **GraphQL** endpoints to generate custom reports and behaviors by querying that data.
+The OptiView Streaming Dashboard provides data-rich information about streaming usage for your individual account. There are also **REST** and **GraphQL** endpoints to generate custom reports and behaviors by querying that data.
 
 ## Learn more
 

--- a/millicast/distribution/index.mdx
+++ b/millicast/distribution/index.mdx
@@ -108,7 +108,7 @@ A live broadcast can be archived by enabling the storage of a recording of the s
 To improve performance when tracking many individual streams among your users, you only need to generate one token and can then delegate that authorization by generating new self-signed **JWT tokens** in your application without needing to fetch a new subscriber token for each new stream.
 
 [Streaming analytics](/millicast/analytics/index.md)<br/>
-The OptiView Streaming Dashboard provides data-rich information about streaming usage for your individual account. There are also **REST** and **GraphQL** endpoints to generate custom reports and behaviors by querying that data.
+The OptiView Real-time Streaming Dashboard provides data-rich information about streaming usage for your individual account. There are also **REST** and **GraphQL** endpoints to generate custom reports and behaviors by querying that data.
 
 ## Learn more
 

--- a/millicast/distribution/multi-region-support/index.mdx
+++ b/millicast/distribution/multi-region-support/index.mdx
@@ -63,7 +63,7 @@ The `ams-1` region will be discontinued after _September 30, 2024_. For any acti
 You can manage cluster regions by changing settings from user interface of the [Streaming Dashboard](/millicast/streaming-dashboard/index.mdx).
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You will need to have a publishing token. See [Managing Your Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx) for more details about tokens.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast. You will need to have a publishing token. See [Managing Your Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx) for more details about tokens.
 :::
 
 :::tip Blocking Regional Access
@@ -72,7 +72,7 @@ If you are looking to stop streaming traffic in a particular geographic region, 
 
 ### How-to set the cluster region using the dashboard
 
-Open the Streaming section of the <a href="https://streaming.dolby.io/#/tokens" target="_new">OptiView Streaming Dashboard</a>. Select the publishing token you want to modify. Within the **Settings** section you can choose the _Cluster Region_ from the dropdown.
+Open the Streaming section of the <a href="https://streaming.dolby.io/#/tokens" target="_new">OptiView Real-time Streaming Dashboard</a>. Select the publishing token you want to modify. Within the **Settings** section you can choose the _Cluster Region_ from the dropdown.
 
 import ClusterRegion from '../../assets/img/cluster-region.png';
 
@@ -82,7 +82,7 @@ import ClusterRegion from '../../assets/img/cluster-region.png';
 
 ### How-to identify the cluster region for an active stream
 
-When using the OptiView Streaming Dashboard [publisher](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx) to broadcast or the viewer to playback you can select the gear setting to view the **Media Stats**.
+When using the OptiView Real-time Streaming Dashboard [publisher](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx) to broadcast or the viewer to playback you can select the gear setting to view the **Media Stats**.
 
 import MediaStatsDialog from '../../assets/img/publisher-media-stats-dialog.png';
 

--- a/millicast/distribution/multi-region-support/index.mdx
+++ b/millicast/distribution/multi-region-support/index.mdx
@@ -3,9 +3,9 @@ title: Multi-Region Support
 sidebar_position: 4
 ---
 
-The WebRTC **Content Delivery Network (CDN)** refers to geographically distributed _clusters_ of servers which work together to provide real-time streaming worldwide at scale. Dolby.io distributes streaming content across multiple _regions_ through a network of cloud hosting providers.
+The WebRTC **Content Delivery Network (CDN)** refers to geographically distributed _clusters_ of servers which work together to provide real-time streaming worldwide at scale. OptiView Real-time Streaming distributes streaming content across multiple _regions_ through a network of cloud hosting providers.
 
-A traditional CDN needs to cache live stream segments on a network before they are able to be delivered to viewers over HTTP. This operation would generally add many seconds of latency to a live stream. The intelligent scaling provided by Dolby.io over global infrastructure is what enables increasingly large audiences with concurrent streams to experience ultra low latency.
+A traditional CDN needs to cache live stream segments on a network before they are able to be delivered to viewers over HTTP. This operation would generally add many seconds of latency to a live stream. The intelligent scaling provided by OptiView Real-time Streaming over global infrastructure is what enables increasingly large audiences with concurrent streams to experience ultra low latency.
 
 This guide covers a few examples:
 
@@ -63,7 +63,7 @@ The `ams-1` region will be discontinued after _September 30, 2024_. For any acti
 You can manage cluster regions by changing settings from user interface of the [Streaming Dashboard](/millicast/streaming-dashboard/index.mdx).
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast. You will need to have a publishing token. See [Managing Your Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx) for more details about tokens.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You will need to have a publishing token. See [Managing Your Tokens](/millicast/streaming-dashboard/managing-your-tokens.mdx) for more details about tokens.
 :::
 
 :::tip Blocking Regional Access
@@ -72,7 +72,7 @@ If you are looking to stop streaming traffic in a particular geographic region, 
 
 ### How-to set the cluster region using the dashboard
 
-Open the Streaming section of the <a href="https://streaming.dolby.io/#/tokens" target="_new">Dolby.io Dashboard</a>. Select the publishing token you want to modify. Within the **Settings** section you can choose the _Cluster Region_ from the dropdown.
+Open the Streaming section of the <a href="https://streaming.dolby.io/#/tokens" target="_new">OptiView Streaming Dashboard</a>. Select the publishing token you want to modify. Within the **Settings** section you can choose the _Cluster Region_ from the dropdown.
 
 import ClusterRegion from '../../assets/img/cluster-region.png';
 
@@ -82,7 +82,7 @@ import ClusterRegion from '../../assets/img/cluster-region.png';
 
 ### How-to identify the cluster region for an active stream
 
-When using the Dolby.io Dashboard [publisher](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx) to broadcast or the viewer to playback you can select the gear setting to view the **Media Stats**.
+When using the OptiView Streaming Dashboard [publisher](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx) to broadcast or the viewer to playback you can select the gear setting to view the **Media Stats**.
 
 import MediaStatsDialog from '../../assets/img/publisher-media-stats-dialog.png';
 

--- a/millicast/distribution/stream-recordings/how-to-setup-media-storage.md
+++ b/millicast/distribution/stream-recordings/how-to-setup-media-storage.md
@@ -76,7 +76,7 @@ Configuration:
 The following procedure explains how to grant Dolby upload access to Google Cloud Storage buckets. Upon completion, the Dolby service account will have the storage object creator role for the selected storage bucket.
 
 1. Log in to your GCP account.
-2. Within your GCP console, navigate to the bucket you wish to grant access to Dolby.io and select the **Permissions** tab.
+2. Within your GCP console, navigate to the bucket you wish to grant access to OptiView Real-time Streaming and select the **Permissions** tab.
 
 ![](../../assets/img/Screenshot_2024-02-14_at_2.30.39_pm.png)
 
@@ -84,7 +84,7 @@ The following procedure explains how to grant Dolby upload access to Google Clou
 
 ![](../../assets/img/Screenshot_2024-02-14_at_2.35.17_pm.png)
 
-4. On the side panel that appears, enter the Dolby.io service account email `millicast-recording-service@millicast.iam.gserviceaccount.com` into the **New Principals** text box, and select the **Storage Object Creator** role. These are the minimum recommended permissions for enabling reliable upload access to your storage bucket.
+4. On the side panel that appears, enter the OptiView service account email `millicast-recording-service@millicast.iam.gserviceaccount.com` into the **New Principals** text box, and select the **Storage Object Creator** role. These are the minimum recommended permissions for enabling reliable upload access to your storage bucket.
 
 ![](../../assets/img/Screenshot_2024-02-14_at_2.37.07_pm.png)
 

--- a/millicast/distribution/stream-recordings/start-recording.mdx
+++ b/millicast/distribution/stream-recordings/start-recording.mdx
@@ -4,12 +4,12 @@ title: How-to Start Recording
 
 You can keep a recording of a full broadcast and download it to share or provide as video on demand. The recording will be made available shortly after the end of a broadcast. If you want a recording of a live event while it is in progress, you should learn more about [Live Clipping](live-clipping.mdx) feature.
 
-Recording can be started when using the [Dashboard](#recording-from-the-dolbyio-dashboard), [Client SDKs](#recording-using-client-sdks), or third-party applications such as [OBS](#recording-from-obs). These approaches are described below.
+Recording can be started when using the [Dashboard](#recording-from-the-optiview-real-time-streaming-dashboard), [Client SDKs](#recording-using-client-sdks), or third-party applications such as [OBS](#recording-from-obs). These approaches are described below.
 
-## Recording from the OptiView Streaming Dashboard
+## Recording from the OptiView Real-time Streaming Dashboard
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You'll need your _publish token_ and _stream name_ for the steps described below.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast. You'll need your _publish token_ and _stream name_ for the steps described below.
 :::
 
 1. Enable recording on a [publish token](/millicast/streaming-dashboard/managing-your-tokens.mdx) by clicking **Record broadcast** when creating a new token.
@@ -32,7 +32,7 @@ import Image2 from '../../assets/img/Capture_decran_2023-07-19_a_5.34.23_PM.png'
 The recording property cannot be updated while the token is being used in a live broadcast; you must stop broadcasting to update it.
 :::
 
-2. Go into the [OptiView Streaming Dashboard ](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx)and click the **Broadcast** button. Once the record feature is active, a red **Record** indicator will show up next to the **Start** button. Clicking the **Broadcast** button before starting streaming results in recording the stream prior to beginning the stream.
+2. Go into the [OptiView Real-time Streaming Dashboard ](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx)and click the **Broadcast** button. Once the record feature is active, a red **Record** indicator will show up next to the **Start** button. Clicking the **Broadcast** button before starting streaming results in recording the stream prior to beginning the stream.
 3. Click the **Start** button to begin broadcasting with recording enabled.
 
 import Image3 from '../../assets/img/Capture_decran_2023-07-19_a_5.47.51_PM.png';

--- a/millicast/distribution/stream-recordings/start-recording.mdx
+++ b/millicast/distribution/stream-recordings/start-recording.mdx
@@ -6,10 +6,10 @@ You can keep a recording of a full broadcast and download it to share or provide
 
 Recording can be started when using the [Dashboard](#recording-from-the-dolbyio-dashboard), [Client SDKs](#recording-using-client-sdks), or third-party applications such as [OBS](#recording-from-obs). These approaches are described below.
 
-## Recording from the Dolby.io dashboard
+## Recording from the OptiView Streaming Dashboard
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast. You'll need your _publish token_ and _stream name_ for the steps described below.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You'll need your _publish token_ and _stream name_ for the steps described below.
 :::
 
 1. Enable recording on a [publish token](/millicast/streaming-dashboard/managing-your-tokens.mdx) by clicking **Record broadcast** when creating a new token.
@@ -32,7 +32,7 @@ import Image2 from '../../assets/img/Capture_decran_2023-07-19_a_5.34.23_PM.png'
 The recording property cannot be updated while the token is being used in a live broadcast; you must stop broadcasting to update it.
 :::
 
-2. Go into the [Dolby.io Live broadcast dashboard ](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx)and click the **Broadcast** button. Once the record feature is active, a red **Record** indicator will show up next to the **Start** button. Clicking the **Broadcast** button before starting streaming results in recording the stream prior to beginning the stream.
+2. Go into the [OptiView Streaming Dashboard ](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx)and click the **Broadcast** button. Once the record feature is active, a red **Record** indicator will show up next to the **Start** button. Clicking the **Broadcast** button before starting streaming results in recording the stream prior to beginning the stream.
 3. Click the **Start** button to begin broadcasting with recording enabled.
 
 import Image3 from '../../assets/img/Capture_decran_2023-07-19_a_5.47.51_PM.png';
@@ -47,7 +47,7 @@ import Image3 from '../../assets/img/Capture_decran_2023-07-19_a_5.47.51_PM.png'
 
 ## Recording from OBS
 
-You can record your broadcasts if you are using 3rd party applications, such as [OBS](https://github.com/CoSMoSoftware/OBS-studio-webrtc/releases) or your own custom broadcaster application. If you have not broadcasted to Dolby.io Real-time Streaming from OBS, please read the [Using OBS](/millicast/broadcast/software-encoders/obs/index.mdx) page to enable your first broadcast with the software.
+You can record your broadcasts if you are using 3rd party applications, such as [OBS](https://github.com/CoSMoSoftware/OBS-studio-webrtc/releases) or your own custom broadcaster application. If you have not broadcasted to OptiView Real-time Streaming from OBS, please read the [Using OBS](/millicast/broadcast/software-encoders/obs/index.mdx) page to enable your first broadcast with the software.
 
 1. Set up OBS by visiting the **Settings** button to add the token information required.
 

--- a/millicast/distribution/syndication.mdx
+++ b/millicast/distribution/syndication.mdx
@@ -37,7 +37,7 @@ To manage viewing access, there are two types of tokens you use to syndicate:
 
 ### Creating a Subscribe token with tracking ID
 
-You can create a subscribe token with a tracking ID using either the [Create Token](/millicast/api/subscribe-token-v-1-create-token.api.mdx) API or the [OptiView Real-time Streaming Dashboard](https://dashboard.dolby.io/).
+You can create a subscribe token with a tracking ID using either the [Create Token](/millicast/api/subscribe-token-v-1-create-token.api.mdx) API or the [OptiView Real-time Streaming Dashboard](https://streaming.dolby.io/).
 
 To use the [Create Token](/millicast/api/subscribe-token-v-1-create-token.api.mdx) API, add the following to your API request body:
 
@@ -61,7 +61,7 @@ To use the [Create Token](/millicast/api/subscribe-token-v-1-create-token.api.md
 The published stream and Subscribe token must originate from the same cluster region. The "Auto" region may be selected for both if the broadcast region changes from stream to stream. For more information, see [Multi-region Support](/millicast/distribution/multi-region-support/index.mdx).
 :::
 
-Alternatively, you can specify a tracking ID using the [OptiView Real-time Streaming Dashboard](https://dashboard.dolby.io/) when [creating a Subscribe token](/millicast/streaming-dashboard/subscribe-tokens.mdx#creating-a-subscribe-token).
+Alternatively, you can specify a tracking ID using the [OptiView Real-time Streaming Dashboard](https://streaming.dolby.io/) when [creating a Subscribe token](/millicast/streaming-dashboard/subscribe-tokens.mdx#creating-a-subscribe-token).
 
 import Sub2 from '../assets/img/sub2.png';
 

--- a/millicast/distribution/syndication.mdx
+++ b/millicast/distribution/syndication.mdx
@@ -3,7 +3,7 @@ title: Syndication
 sidebar_position: 8
 ---
 
-With Dolby.io Real-time Streaming you can syndicate content through multiple distribution partners or channels. This can be helpful to maximize the number of viewers or monetizing content through other platforms. In order to accomplish this, it is important to be able to track syndicated streams for analytics and billing.
+With OptiView Real-time Streaming you can syndicate content through multiple distribution partners or channels. This can be helpful to maximize the number of viewers or monetizing content through other platforms. In order to accomplish this, it is important to be able to track syndicated streams for analytics and billing.
 
 ## Syndication
 
@@ -15,8 +15,8 @@ The following is an **example workflow** for setting up syndicated substreams:
 
 1. [Create a Publish token](/millicast/streaming-dashboard/managing-your-tokens.mdx) for your broadcast. Make sure this token has the **secured** setting enabled.
 2. Before the broadcast begins, create a [Subscribe token with tracking](#creating-a-subscribe-token-with-tracking-id) for each 3rd party you are syndicating a stream. These Subscribe tokens function as "master" tokens for each platform you are syndicating content. The master Subscribe token can be used by the 3rd party to [self-sign other Subscribe tokens](/millicast/streaming-dashboard/subscribe-tokens.mdx#self-signing-subscribe-tokens) for their users if they need to secure their streams.
-3. Begin [broadcasting](/millicast/broadcast/index.mdx) your premium content via Dolby.io. The 3rd parties can use the provided Subscribe token to [access the stream](/millicast/playback/index.mdx) for their viewers or to [sign more Subscribe tokens for their viewers](/millicast/streaming-dashboard/subscribe-tokens.mdx#self-signing-subscribe-tokens).
-4. When the stream is running, the media server will [gather statistics](#viewing-statistics) for the viewer associated with the tracking ID information. Since Dolby.io charges based on bandwidth, this data can be used to bill the 3rd parties relative to their consumed data.
+3. Begin [broadcasting](/millicast/broadcast/index.mdx) your premium content via OptiView Real-time Streaming. The 3rd parties can use the provided Subscribe token to [access the stream](/millicast/playback/index.mdx) for their viewers or to [sign more Subscribe tokens for their viewers](/millicast/streaming-dashboard/subscribe-tokens.mdx#self-signing-subscribe-tokens).
+4. When the stream is running, the media server will [gather statistics](#viewing-statistics) for the viewer associated with the tracking ID information. Since OptiView Real-time Streaming charges based on bandwidth, this data can be used to bill the 3rd parties relative to their consumed data.
 
 ### RTMP syndication
 
@@ -37,7 +37,7 @@ To manage viewing access, there are two types of tokens you use to syndicate:
 
 ### Creating a Subscribe token with tracking ID
 
-You can create a subscribe token with a tracking ID using either the [Create Token](/millicast/api/subscribe-token-v-1-create-token.api.mdx) API or the [Dolby.io dashboard](https://dashboard.dolby.io/).
+You can create a subscribe token with a tracking ID using either the [Create Token](/millicast/api/subscribe-token-v-1-create-token.api.mdx) API or the [OptiView Streaming Dashboard](https://dashboard.dolby.io/).
 
 To use the [Create Token](/millicast/api/subscribe-token-v-1-create-token.api.mdx) API, add the following to your API request body:
 
@@ -61,7 +61,7 @@ To use the [Create Token](/millicast/api/subscribe-token-v-1-create-token.api.md
 The published stream and Subscribe token must originate from the same cluster region. The "Auto" region may be selected for both if the broadcast region changes from stream to stream. For more information, see [Multi-region Support](/millicast/distribution/multi-region-support/index.mdx).
 :::
 
-Alternatively, you can specify a tracking ID using the [Dolby.io dashboard](https://dashboard.dolby.io/) when [creating a Subscribe token](/millicast/streaming-dashboard/subscribe-tokens.mdx#creating-a-subscribe-token).
+Alternatively, you can specify a tracking ID using the [OptiView Streaming Dashboard](https://dashboard.dolby.io/) when [creating a Subscribe token](/millicast/streaming-dashboard/subscribe-tokens.mdx#creating-a-subscribe-token).
 
 import Sub2 from '../assets/img/sub2.png';
 
@@ -75,7 +75,7 @@ Once you have created a Subscribe token with a tracking ID, you can self-sign th
 
 ### Viewing statistics
 
-With your API Secret found on the Dolby.io dashboard, you can query information based on your viewer's tracking ID and other data using the following REST APIs:
+With your API Secret found on the OptiView Streaming Dashboard, you can query information based on your viewer's tracking ID and other data using the following REST APIs:
 
 - [Total bandwidth per TrackingID per stream](/millicast/api/analytics-get-tracking-total-for-streams.api.mdx)
 - [Series bandwidth per TrackingID per stream](/millicast/api/analytics-get-tracking-series-for-streams.api.mdx)

--- a/millicast/distribution/syndication.mdx
+++ b/millicast/distribution/syndication.mdx
@@ -37,7 +37,7 @@ To manage viewing access, there are two types of tokens you use to syndicate:
 
 ### Creating a Subscribe token with tracking ID
 
-You can create a subscribe token with a tracking ID using either the [Create Token](/millicast/api/subscribe-token-v-1-create-token.api.mdx) API or the [OptiView Streaming Dashboard](https://dashboard.dolby.io/).
+You can create a subscribe token with a tracking ID using either the [Create Token](/millicast/api/subscribe-token-v-1-create-token.api.mdx) API or the [OptiView Real-time Streaming Dashboard](https://dashboard.dolby.io/).
 
 To use the [Create Token](/millicast/api/subscribe-token-v-1-create-token.api.mdx) API, add the following to your API request body:
 
@@ -61,7 +61,7 @@ To use the [Create Token](/millicast/api/subscribe-token-v-1-create-token.api.md
 The published stream and Subscribe token must originate from the same cluster region. The "Auto" region may be selected for both if the broadcast region changes from stream to stream. For more information, see [Multi-region Support](/millicast/distribution/multi-region-support/index.mdx).
 :::
 
-Alternatively, you can specify a tracking ID using the [OptiView Streaming Dashboard](https://dashboard.dolby.io/) when [creating a Subscribe token](/millicast/streaming-dashboard/subscribe-tokens.mdx#creating-a-subscribe-token).
+Alternatively, you can specify a tracking ID using the [OptiView Real-time Streaming Dashboard](https://dashboard.dolby.io/) when [creating a Subscribe token](/millicast/streaming-dashboard/subscribe-tokens.mdx#creating-a-subscribe-token).
 
 import Sub2 from '../assets/img/sub2.png';
 
@@ -75,7 +75,7 @@ Once you have created a Subscribe token with a tracking ID, you can self-sign th
 
 ### Viewing statistics
 
-With your API Secret found on the OptiView Streaming Dashboard, you can query information based on your viewer's tracking ID and other data using the following REST APIs:
+With your API Secret found on the OptiView Real-time Streaming Dashboard, you can query information based on your viewer's tracking ID and other data using the following REST APIs:
 
 - [Total bandwidth per TrackingID per stream](/millicast/api/analytics-get-tracking-total-for-streams.api.mdx)
 - [Series bandwidth per TrackingID per stream](/millicast/api/analytics-get-tracking-series-for-streams.api.mdx)

--- a/millicast/distribution/using-webrtc-simulcast.mdx
+++ b/millicast/distribution/using-webrtc-simulcast.mdx
@@ -38,7 +38,7 @@ Before broadcasting content using Simulcast, make sure you:
 Simulcast is included with plans at no additional cost when enabled. However, since multiple streams will be published, there will be more bits sent to the platform which counts as a bandwidth increase. Conversely, viewers may receive a resolution and bitrate at a lower level which may decrease bandwidth consumption overall.
 :::
 
-### How-to enable Simulcast with the OptiView Streaming Dashboard
+### How-to enable Simulcast with the OptiView Real-time Streaming Dashboard
 
 To activate Simulcast and stream using the [Streaming Dashboard Broadcaster](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx#broadcaster), open the _Media Settings_ by clicking on the gear icon. This allows you to toggle the option to be on. The bandwidth settings can also be adjusted to achieve the desired bitrate.
 

--- a/millicast/distribution/using-webrtc-simulcast.mdx
+++ b/millicast/distribution/using-webrtc-simulcast.mdx
@@ -18,7 +18,7 @@ This bitrate adaptation is available for [RTMP](/millicast/broadcast/rtmp-and-rt
 Simulcast provides flexibility that allows viewers to adjust their individual experience for specific circumstances. For _multicast_ use cases of distributing to multiple destinations, review the [Syndication](/millicast/distribution/syndication) guide.
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast.
 :::
 
 ## Configuring Simulcast
@@ -38,7 +38,7 @@ Before broadcasting content using Simulcast, make sure you:
 Simulcast is included with plans at no additional cost when enabled. However, since multiple streams will be published, there will be more bits sent to the platform which counts as a bandwidth increase. Conversely, viewers may receive a resolution and bitrate at a lower level which may decrease bandwidth consumption overall.
 :::
 
-### How-to enable Simulcast with the Dolby.io dashboard
+### How-to enable Simulcast with the OptiView Streaming Dashboard
 
 To activate Simulcast and stream using the [Streaming Dashboard Broadcaster](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx#broadcaster), open the _Media Settings_ by clicking on the gear icon. This allows you to toggle the option to be on. The bandwidth settings can also be adjusted to achieve the desired bitrate.
 

--- a/millicast/getting-started/creating-real-time-streaming-web-app.mdx
+++ b/millicast/getting-started/creating-real-time-streaming-web-app.mdx
@@ -4,7 +4,7 @@ slug: /getting-started/creating-real-time-streaming-web-app
 sidebar_position: 2
 ---
 
-In [Part 1](/millicast/getting-started/using-the-dashboard.mdx) we reviewed how-to log into your Dolby.io Streaming Dashboard, create a publish token, start a broadcast, and playback that broadcast in the hosted web viewer or in an iframe, all without writing any code. We'll continue getting started by substituting the broadcast and playback components with a custom-built web application.
+In [Part 1](/millicast/getting-started/using-the-dashboard.mdx) we reviewed how-to log into your OptiView Streaming Dashboard, create a publish token, start a broadcast, and playback that broadcast in the hosted web viewer or in an iframe, all without writing any code. We'll continue getting started by substituting the broadcast and playback components with a custom-built web application.
 
 This tutorial is split into three sections:
 
@@ -105,7 +105,7 @@ When importing the SDK from jsdelivr you will automatically be updated to the la
 
 ### c. Configure account ID and stream name
 
-In [Part 1](/millicast/getting-started/using-the-dashboard.mdx) we created a stream with a unique name such as _myStreamName_. You'll need to add that to the code along with the **Account ID** that is associated with the publishing token. You can find both of these values from the Dolby.io Dashboard.
+In [Part 1](/millicast/getting-started/using-the-dashboard.mdx) we created a stream with a unique name such as _myStreamName_. You'll need to add that to the code along with the **Account ID** that is associated with the publishing token. You can find both of these values from the OptiView Streaming Dashboard.
 
 ```js
 // Step 2.1c: Set your account id and stream name while Getting Started
@@ -154,7 +154,7 @@ try {
 }
 ```
 
-If you start broadcasting using the Dolby.io Dashboard as you did in [Part 1](/millicast/getting-started/using-the-dashboard.mdx), you will then have a simple web app with video playback to continue customizing.
+If you start broadcasting using the OptiView Streaming Dashboard as you did in [Part 1](/millicast/getting-started/using-the-dashboard.mdx), you will then have a simple web app with video playback to continue customizing.
 
 import DolbyioWebPlayback from '../assets/img/dolbyio-web-playback.png';
 
@@ -179,7 +179,7 @@ The [Web SDK](/millicast/playback/players-sdks/web/sdk/index.mdx) is pulled in w
 
 ### b. Configure publishing token and stream name
 
-You'll need to retrieve the **Publishing Token** from the Dolby.io dashboard that corresponds with the _streamName_ used in the _playback-app_ section.
+You'll need to retrieve the **Publishing Token** from the OptiView Streaming Dashboard that corresponds with the _streamName_ used in the _playback-app_ section.
 
 ```js
 // Step 2.2b: Set your account id and stream name while Getting Started

--- a/millicast/getting-started/creating-real-time-streaming-web-app.mdx
+++ b/millicast/getting-started/creating-real-time-streaming-web-app.mdx
@@ -4,7 +4,7 @@ slug: /getting-started/creating-real-time-streaming-web-app
 sidebar_position: 2
 ---
 
-In [Part 1](/millicast/getting-started/using-the-dashboard.mdx) we reviewed how-to log into your OptiView Streaming Dashboard, create a publish token, start a broadcast, and playback that broadcast in the hosted web viewer or in an iframe, all without writing any code. We'll continue getting started by substituting the broadcast and playback components with a custom-built web application.
+In [Part 1](/millicast/getting-started/using-the-dashboard.mdx) we reviewed how-to log into your OptiView Real-time Streaming Dashboard, create a publish token, start a broadcast, and playback that broadcast in the hosted web viewer or in an iframe, all without writing any code. We'll continue getting started by substituting the broadcast and playback components with a custom-built web application.
 
 This tutorial is split into three sections:
 
@@ -105,7 +105,7 @@ When importing the SDK from jsdelivr you will automatically be updated to the la
 
 ### c. Configure account ID and stream name
 
-In [Part 1](/millicast/getting-started/using-the-dashboard.mdx) we created a stream with a unique name such as _myStreamName_. You'll need to add that to the code along with the **Account ID** that is associated with the publishing token. You can find both of these values from the OptiView Streaming Dashboard.
+In [Part 1](/millicast/getting-started/using-the-dashboard.mdx) we created a stream with a unique name such as _myStreamName_. You'll need to add that to the code along with the **Account ID** that is associated with the publishing token. You can find both of these values from the OptiView Real-time Streaming Dashboard.
 
 ```js
 // Step 2.1c: Set your account id and stream name while Getting Started
@@ -154,7 +154,7 @@ try {
 }
 ```
 
-If you start broadcasting using the OptiView Streaming Dashboard as you did in [Part 1](/millicast/getting-started/using-the-dashboard.mdx), you will then have a simple web app with video playback to continue customizing.
+If you start broadcasting using the OptiView Real-time Streaming Dashboard as you did in [Part 1](/millicast/getting-started/using-the-dashboard.mdx), you will then have a simple web app with video playback to continue customizing.
 
 import DolbyioWebPlayback from '../assets/img/dolbyio-web-playback.png';
 
@@ -179,7 +179,7 @@ The [Web SDK](/millicast/playback/players-sdks/web/sdk/index.mdx) is pulled in w
 
 ### b. Configure publishing token and stream name
 
-You'll need to retrieve the **Publishing Token** from the OptiView Streaming Dashboard that corresponds with the _streamName_ used in the _playback-app_ section.
+You'll need to retrieve the **Publishing Token** from the OptiView Real-time Streaming Dashboard that corresponds with the _streamName_ used in the _playback-app_ section.
 
 ```js
 // Step 2.2b: Set your account id and stream name while Getting Started

--- a/millicast/getting-started/index.mdx
+++ b/millicast/getting-started/index.mdx
@@ -20,7 +20,7 @@ For an introduction to the platform overall, start with the [Introduction to Str
 
 ## Part 1: Use the Streaming Dashboard
 
-Begin by broadcasting directly [using the OptiView Streaming Dashboard](/millicast/getting-started/using-the-dashboard.mdx).
+Begin by broadcasting directly [using the OptiView Real-time Streaming Dashboard](/millicast/getting-started/using-the-dashboard.mdx).
 
 - Create a Publish token
 - Broadcast a stream with the Streaming Dashboard

--- a/millicast/getting-started/index.mdx
+++ b/millicast/getting-started/index.mdx
@@ -4,6 +4,9 @@ slug: /getting-started
 ---
 
 import DocCard from '@theme/DocCard';
+import RebrandingNotice from '@site/millicast/callouts/_rebranding_notice.md';
+
+<RebrandingNotice />
 
 # Getting started with Millicast
 

--- a/millicast/getting-started/index.mdx
+++ b/millicast/getting-started/index.mdx
@@ -8,19 +8,19 @@ import RebrandingNotice from '@site/millicast/callouts/_rebranding_notice.md';
 
 <RebrandingNotice />
 
-# Getting started with Millicast
+# Getting started with OptiView Real-time Streaming
 
-**Dolby's Real-time Streaming APIs make it easier to globally stream your high-value content with broadcast-quality picture and sound to massive audiences all with subsecond latency. Use this tutorial to quickly set up and run your own private stream and begin building applications for a variety of use cases.**
+Dolby OptiView's Real-time Streaming makes it easier to globally stream your high-value content with broadcast-quality picture and sound to massive audiences all with subsecond latency. Use this tutorial to quickly set up and run your own private stream and begin building applications for a variety of use cases.
 
-:::tip[Dolby.io Account]
-Sign in into your [Dolby.io account](https://streaming.dolby.io) to access the Streaming Dashboard.
+:::tip[OptiView Real-time Account]
+Sign in into your [OptiView Real-time account](https://streaming.dolby.io) to access the Streaming Dashboard.
 :::
 
 For an introduction to the platform overall, start with the [Introduction to Streaming APIs](/millicast/introduction-to-streaming-apis.mdx).
 
 ## Part 1: Use the Streaming Dashboard
 
-Begin by broadcasting directly [using the Dolby.io Streaming Dashboard](/millicast/getting-started/using-the-dashboard.mdx).
+Begin by broadcasting directly [using the OptiView Streaming Dashboard](/millicast/getting-started/using-the-dashboard.mdx).
 
 - Create a Publish token
 - Broadcast a stream with the Streaming Dashboard

--- a/millicast/getting-started/using-rest-apis.mdx
+++ b/millicast/getting-started/using-rest-apis.mdx
@@ -4,14 +4,14 @@ slug: /getting-started/using-rest-apis
 sidebar_position: 3
 ---
 
-The Dolby.io Streaming REST API allows remote management of your Dolby.io Real-time Streaming account. To enable remote access you must first use the Token system to securely authenticate your applications with Dolby.io Real-time Streaming. To acquire an API Token, log into your Dolby.io Real-time Streaming account and follow the directions here: [acquiring your API token](/millicast/streaming-dashboard/token-api.mdx).
+The OptiView Real-time Streaming REST API allows remote management of your OptiView Real-time Streaming account. To enable remote access you must first use the Token system to securely authenticate your applications with OptiView Real-time Streaming. To acquire an API Token, log into your OptiView Real-time Streaming account and follow the directions here: [acquiring your API token](/millicast/streaming-dashboard/token-api.mdx).
 
 For security you should always make your API calls from a secure server like Node.js, .NET or PHP. If you feel that your token has been compromised you can manage your token from your account by creating a new token or simply disabling access all together. Refer back to [acquiring a token](/millicast/streaming-dashboard/token-api.mdx) to learn how to achieve this.
 
-In this tutorial we will build a very rudimentary example for calling the API service and delivering the results down to the publishing client. You will be using Node.js as a secure layer to your Dolby.io Real-time Streaming account, as to not expose the secret API Token publicly. If you have not worked with Node.js before, its best to start with a tutorial or one of their basic guides https://nodejs.org/en/docs/guides/getting-started-guide/ to better understand how things are setup. You can also just follow along, learn the concepts, and use the server-side technology of your choice to achieve the same outcome.
+In this tutorial we will build a very rudimentary example for calling the API service and delivering the results down to the publishing client. You will be using Node.js as a secure layer to your OptiView Real-time Streaming account, as to not expose the secret API Token publicly. If you have not worked with Node.js before, its best to start with a tutorial or one of their basic guides https://nodejs.org/en/docs/guides/getting-started-guide/ to better understand how things are setup. You can also just follow along, learn the concepts, and use the server-side technology of your choice to achieve the same outcome.
 
 - [REST API Client](https://github.com/DolbyIO/dolbyio-rest-apis-client-node): Client sample code for calling REST APIs from a Node environment
-- [Postman Collection](https://www.postman.com/dolbyio): The Dolby.io Streaming API workspace has collections for the REST APIs.
+- [Postman Collection](https://www.postman.com/dolbyio): The OptiView Real-time Streaming API workspace has collections for the REST APIs.
 - [API Reference](/millicast/api/millicast-api/): The API Reference documentation
 
 ## Setting up the environment
@@ -121,7 +121,7 @@ https.createServer(httpsOptions, app).listen(port, (err) => {
 });
 ```
 
-Find the variable labeled **"apiKey"** and update the string to the Dolby.io Real-time Streaming **API key**, which you created earlier. Without your secret key, the API calls will be rejected. Also the **port** variable has a default value, but you can update that port number to whatever best suits your needs. After you have updated these properties go ahead and save your file.
+Find the variable labeled **"apiKey"** and update the string to the OptiView Real-time Streaming **API key**, which you created earlier. Without your secret key, the API calls will be rejected. Also the **port** variable has a default value, but you can update that port number to whatever best suits your needs. After you have updated these properties go ahead and save your file.
 
 Now open your index.html file in the text editor, copy this code and save it:
 
@@ -129,7 +129,7 @@ Now open your index.html file in the text editor, copy this code and save it:
 <!DOCTYPE >
 <html>
   <head>
-    <title>Dolby.io Real-time Streaming Token API Tutorial</title>
+    <title>OptiView Real-time Streaming Token API Tutorial</title>
   </head>
   <body>
     <label for="streamName">Stream Name</label>
@@ -167,7 +167,7 @@ This small sample creates an HTTPS server and listens to a call from the client 
 
 Now that you have your files save, lets run our Nodejs server. Go to your DOS, TERMINAL, or if you're using a service use their tools to run your Node project. Now, type in **`node server`** in your Terminal or DOS command line to run the server.js script. For simplicity’s sake, this example is running on the localhost.
 
-The server will initiate and display the port that it is listening to. In this case, we are using 8084, so the path to the file in the browser will be https://localhost:8084/. You should see a simple UI for getting a new token and that's it. To test, first open your browser’s developer console, then on the UI enter an arbitrary name for the stream we want to use and click the button. The server will proxy your request to the Dolby.io Real-time Streaming where the service generates your new token and returns the results down to you. You should see the results in the developer console window.
+The server will initiate and display the port that it is listening to. In this case, we are using 8084, so the path to the file in the browser will be https://localhost:8084/. You should see a simple UI for getting a new token and that's it. To test, first open your browser's developer console, then on the UI enter an arbitrary name for the stream we want to use and click the button. The server will proxy your request to OptiView Real-time Streaming where the service generates your new token and returns the results down to you. You should see the results in the developer console window.
 
 import BasicApiResult from '../assets/img/basic-api-result.png';
 
@@ -175,7 +175,7 @@ import BasicApiResult from '../assets/img/basic-api-result.png';
   <img src={BasicApiResult} width="600" />
 </div>
 
-In addition, if you log into your Dolby.io dashboard, you should now see your new token there in the list. If you are already on the page, a simple page refresh will do.
+In addition, if you log into your OptiView Streaming Dashboard, you should now see your new token there in the list. If you are already on the page, a simple page refresh will do.
 
 ## The code in detail
 
@@ -456,7 +456,7 @@ https.createServer(httpsOptions, app).listen(port, (err) => {
 <!DOCTYPE >
 <html>
   <head>
-    <title>Dolby.io Real-time Streaming Token API Tutorial</title>
+    <title>OptiView Real-time Streaming Token API Tutorial</title>
     <style>
       .mb-1 {
         margin-bottom: 0.7rem;

--- a/millicast/getting-started/using-rest-apis.mdx
+++ b/millicast/getting-started/using-rest-apis.mdx
@@ -175,7 +175,7 @@ import BasicApiResult from '../assets/img/basic-api-result.png';
   <img src={BasicApiResult} width="600" />
 </div>
 
-In addition, if you log into your OptiView Streaming Dashboard, you should now see your new token there in the list. If you are already on the page, a simple page refresh will do.
+In addition, if you log into your OptiView Real-time Streaming Dashboard, you should now see your new token there in the list. If you are already on the page, a simple page refresh will do.
 
 ## The code in detail
 

--- a/millicast/getting-started/using-the-dashboard.mdx
+++ b/millicast/getting-started/using-the-dashboard.mdx
@@ -1,10 +1,10 @@
 ---
-title: '1. Use the Streaming Dashboard'
+title: '1. Use the Dashboard'
 slug: /getting-started/using-the-dashboard
 sidebar_position: 1
 ---
 
-This part explains how to get started using just the Dolby.io Streaming Dashboard to both broadcast and playback a real-time stream without writing any code.
+This part explains how to get started using just the OptiView Streaming Dashboard to both broadcast and playback a real-time stream without writing any code.
 
 This tutorial is split into two sections:
 
@@ -13,11 +13,11 @@ This tutorial is split into two sections:
 
 ## Capture and broadcast from the dashboard
 
-We will begin by [broadcasting](/millicast/broadcast/index.mdx) directly from the Dolby.io Streaming Dashboard, [capturing](/millicast/capture/index.mdx) audio and video with a web camera.
+We will begin by [broadcasting](/millicast/broadcast/index.mdx) directly from the OptiView Streaming Dashboard, [capturing](/millicast/capture/index.mdx) audio and video with a web camera.
 
 ### a. Create a publish token
 
-When you log into your Dolby.io account you should select the **Streaming** tab. If you haven't used your account before, you'll see a screen similar to Figure 1a below.
+When you log into your OptiView Real-time account you should select the **Streaming** tab. If you haven't used your account before, you'll see a screen similar to Figure 1a below.
 
 import DashboardTokensEmpty from '../assets/img/dashboard-tokens-empty.png';
 

--- a/millicast/getting-started/using-the-dashboard.mdx
+++ b/millicast/getting-started/using-the-dashboard.mdx
@@ -4,7 +4,7 @@ slug: /getting-started/using-the-dashboard
 sidebar_position: 1
 ---
 
-This part explains how to get started using just the OptiView Streaming Dashboard to both broadcast and playback a real-time stream without writing any code.
+This part explains how to get started using just the OptiView Real-time Streaming Dashboard to both broadcast and playback a real-time stream without writing any code.
 
 This tutorial is split into two sections:
 
@@ -13,7 +13,7 @@ This tutorial is split into two sections:
 
 ## Capture and broadcast from the dashboard
 
-We will begin by [broadcasting](/millicast/broadcast/index.mdx) directly from the OptiView Streaming Dashboard, [capturing](/millicast/capture/index.mdx) audio and video with a web camera.
+We will begin by [broadcasting](/millicast/broadcast/index.mdx) directly from the OptiView Real-time Streaming Dashboard, [capturing](/millicast/capture/index.mdx) audio and video with a web camera.
 
 ### a. Create a publish token
 

--- a/millicast/introduction-to-streaming-apis.mdx
+++ b/millicast/introduction-to-streaming-apis.mdx
@@ -4,7 +4,6 @@ sidebar_position: 10
 title: 'OptiView Real-time Streaming'
 ---
 
-
 import DocCard from '@theme/DocCard';
 import RebrandingNotice from '@site/millicast/callouts/_rebranding_notice.md';
 
@@ -140,9 +139,12 @@ The OptiView Real-time CDN can ingest streams encoded in a few main formats:
     **WebRTC**, an internet transfer protocol that supports video codecs H.264, H.265, VP8, VP9, AV1, and the Opus audio codec. Broad support is made
     possible through implementations of **WebRTC HTTP Ingest Protocol (WHIP)**.
   </li>
-  <li>**SRT**, a video transfer protocol that can be transmuxed to WebRTC via the OptiView Real-time CDN and supports H.264 video and AAC audio codecs.</li>
   <li>
-    **RTMP and RTMPs**, internet transfer protocols that can be transmuxed to WebRTC via the OptiView Real-time CDN that supports only the H.264 video codec.
+    **SRT**, a video transfer protocol that can be transmuxed to WebRTC via the OptiView Real-time CDN and supports H.264 video and AAC audio codecs.
+  </li>
+  <li>
+    **RTMP and RTMPs**, internet transfer protocols that can be transmuxed to WebRTC via the OptiView Real-time CDN that supports only the H.264 video
+    codec.
   </li>
 </ul>
 

--- a/millicast/introduction-to-streaming-apis.mdx
+++ b/millicast/introduction-to-streaming-apis.mdx
@@ -6,6 +6,9 @@ sidebar_position: 10
 # Introduction to Streaming APIs
 
 import DocCard from '@theme/DocCard';
+import RebrandingNotice from '@site/millicast/callouts/_rebranding_notice.md';
+
+<RebrandingNotice />
 
 Dolby.io Streaming APIs were created to make it easier to stream your high-value content at scale with ultra-low latency.
 

--- a/millicast/introduction-to-streaming-apis.mdx
+++ b/millicast/introduction-to-streaming-apis.mdx
@@ -1,18 +1,18 @@
 ---
 slug: /
 sidebar_position: 10
+title: 'OptiView Real-time Streaming'
 ---
 
-# Introduction to Streaming APIs
 
 import DocCard from '@theme/DocCard';
 import RebrandingNotice from '@site/millicast/callouts/_rebranding_notice.md';
 
 <RebrandingNotice />
 
-Dolby.io Streaming APIs were created to make it easier to stream your high-value content at scale with ultra-low latency.
+OptiView Real-time Streaming APIs were created to make it easier to stream your high-value content at scale with ultra-low latency.
 
-Deliver 4k video and audio streams to massive audiences while maintaining under half a second of latency anywhere in the world. With the scale, speed, and quality of the service, the Dolby.io Real-time Streaming APIs support a range of use cases including live events, sports betting, virtual auctions, remote production, and more.
+Deliver 4k video and audio streams to massive audiences while maintaining under half a second of latency anywhere in the world. With the scale, speed, and quality of the service, the OptiView Real-time Streaming APIs support a range of use cases including live events, sports betting, virtual auctions, remote production, and more.
 
 ## Real-time Streaming
 
@@ -131,18 +131,18 @@ Check with your specific hardware provider for direct support of WebRTC or one o
 
 ## Broadcast encoded media
 
-[Broadcasting](/millicast/broadcast/index.mdx) content requires access to the public internet and encoding, which can be accomplished via the browser, software, hardware, and via the [Dolby.io Client-side broadcaster SDKs](/millicast/playback/players-sdks).
+[Broadcasting](/millicast/broadcast/index.mdx) content requires access to the public internet and encoding, which can be accomplished via the browser, software, hardware, and via the [OptiView Real-time client-side broadcaster SDKs](/millicast/playback/players-sdks).
 
-The Dolby.io CDN can ingest streams encoded in a few main formats:
+The OptiView Real-time CDN can ingest streams encoded in a few main formats:
 
 <ul className="checkBoxList">
   <li>
     **WebRTC**, an internet transfer protocol that supports video codecs H.264, H.265, VP8, VP9, AV1, and the Opus audio codec. Broad support is made
     possible through implementations of **WebRTC HTTP Ingest Protocol (WHIP)**.
   </li>
-  <li>**SRT**, a video transfer protocol that can be transmuxed to WebRTC via the Dolby.io CDN and supports H.264 video and AAC audio codecs.</li>
+  <li>**SRT**, a video transfer protocol that can be transmuxed to WebRTC via the OptiView Real-time CDN and supports H.264 video and AAC audio codecs.</li>
   <li>
-    **RTMP and RTMPs**, internet transfer protocols that can be transmuxed to WebRTC via the Dolby.io CDN that supports only the H.264 video codec.
+    **RTMP and RTMPs**, internet transfer protocols that can be transmuxed to WebRTC via the OptiView Real-time CDN that supports only the H.264 video codec.
   </li>
 </ul>
 
@@ -163,7 +163,7 @@ _SRT and RTMP will automatically have AAC audio converted to Opus via the CDN_
 
 ## Distribution with WebRTC CDN
 
-The Dolby.io Streaming CDN offers a range of server-side features that users can toggle and adjust via [the REST APIs](/millicast/getting-started/using-rest-apis.mdx) or the Dashboard to ensure [distribution](/millicast/distribution/index.mdx) of streams is secure, stable, and scalable.
+The OptiView Real-time CDN offers a range of server-side features that users can toggle and adjust via [the REST APIs](/millicast/getting-started/using-rest-apis.mdx) or the Dashboard to ensure [distribution](/millicast/distribution/index.mdx) of streams is secure, stable, and scalable.
 
 <ul className="checkBoxList">
   <li>**Scalability** to distribute content to large audiences across multiple regions in real-time.</li>
@@ -194,7 +194,7 @@ Distribution of streaming content requires scalability, stability, and security 
 
 ## Playback streaming media
 
-The final component of the streaming workflow is taking the stream, after it has been passed through the Dolby.io CDN, and playing it back to the end viewer. Similar to the broadcasting side, decoding and [playback](/millicast/playback/index.mdx) is supported via web and mobile browsers, software, hardware, and via client-side broadcast SDKs.
+The final component of the streaming workflow is taking the stream, after it has been passed through the OptiView Real-time CDN, and playing it back to the end viewer. Similar to the broadcasting side, decoding and [playback](/millicast/playback/index.mdx) is supported via web and mobile browsers, software, hardware, and via client-side broadcast SDKs.
 
 <ul className="checkBoxList">
   <li>Hosted streaming player with low-code drop-in support for many applications.</li>

--- a/millicast/platform-requirements/index.md
+++ b/millicast/platform-requirements/index.md
@@ -9,7 +9,7 @@ See the [Broadcast](/millicast/broadcast/index.mdx) streaming guide for addition
 
 ## Network Ports
 
-If you have an environment that is behind a restrictive network, use the following information to create the proper firewall whitelist configuration to enable the Dolby.io Real-time Streaming services to pass:
+If you have an environment that is behind a restrictive network, use the following information to create the proper firewall whitelist configuration to enable the OptiView Real-time Streaming services to pass:
 
 | Traffic Type        | Ports           | Type        |
 | :------------------ | :-------------- | :---------- |

--- a/millicast/playback/audience-engagement.md
+++ b/millicast/playback/audience-engagement.md
@@ -26,4 +26,4 @@ Real-time streaming enables broadcasters to engage with audiences by providing a
 **Singular.live** provides cloud-managed graphics that can be rendered on the broadcast side or on the client side to allow for user engagement and interaction with the stream.
 
 [Add Monetization into your Stream and Change the Way Streamers Interact](https://dolby.io/blog/maestro-x-dolbyio/)<br/>
-Combining **Maestro**'s robust video monetization and interactivity features with Dolby.io's real-time streaming technology enhances viewers' experiences enabling more lifelike interactions, ultimately revolutionizing the landscape of interactive live streaming for increased engagement and revenue opportunities.
+Combining **Maestro**'s robust video monetization and interactivity features with OptiView Real-time Streaming's real-time streaming technology enhances viewers' experiences enabling more lifelike interactions, ultimately revolutionizing the landscape of interactive live streaming for increased engagement and revenue opportunities.

--- a/millicast/playback/audience-engagement.md
+++ b/millicast/playback/audience-engagement.md
@@ -26,4 +26,4 @@ Real-time streaming enables broadcasters to engage with audiences by providing a
 **Singular.live** provides cloud-managed graphics that can be rendered on the broadcast side or on the client side to allow for user engagement and interaction with the stream.
 
 [Add Monetization into your Stream and Change the Way Streamers Interact](https://dolby.io/blog/maestro-x-dolbyio/)<br/>
-Combining **Maestro**'s robust video monetization and interactivity features with OptiView Real-time Streaming's real-time streaming technology enhances viewers' experiences enabling more lifelike interactions, ultimately revolutionizing the landscape of interactive live streaming for increased engagement and revenue opportunities.
+Combining **Maestro**'s robust video monetization and interactivity features with OptiView Real-time Streaming technology enhances viewers' experiences enabling more lifelike interactions, ultimately revolutionizing the landscape of interactive live streaming for increased engagement and revenue opportunities.

--- a/millicast/playback/audio-multiplexing.md
+++ b/millicast/playback/audio-multiplexing.md
@@ -112,7 +112,7 @@ async function projectOn(index) {
 
 To recap the above workflow:
 
-1. The app authenticates and connects with the OptiView Real-time Streaming (Millicast) Director.
+1. The app authenticates and connects with the OptiView Real-time Streaming Director.
 2. As the app connects the Director creates a main track plus an additional number of tracks equal to the `multiplexedAudioTracks` value. This triggers a `track` event for each track added.
 3. An audio feed is connected to the Publisher Node triggering a Broadcast event.
 4. The broadcast event creates an `<audio>` tag and triggers the `projectOn` function.

--- a/millicast/playback/audio-multiplexing.md
+++ b/millicast/playback/audio-multiplexing.md
@@ -4,11 +4,11 @@ slug: /playback/audio-multiplexing
 sidebar_position: 5
 ---
 
-The Dolby.io platform supports Audio Multiplexing, a feature that allows viewers to receive multiple audio streams in a conference-like experience, where each audio stream is emphasized or deemphasized based on activity.
+The OptiView Real-time platform supports Audio Multiplexing, a feature that allows viewers to receive multiple audio streams in a conference-like experience, where each audio stream is emphasized or deemphasized based on activity.
 
 ## Understanding Audio Multiplexing
 
-To first understand Audio Multiplexing, we need to understand how the Dolby.io servers ingest feeds. When [Broadcasting](/millicast/broadcast/index.mdx), the Dolby.io Streaming servers will assign the most recent published stream source as the "_Main Source_", a function that allows broadcasters to seamlessly overwrite streams or add [Redundant Streams](/millicast/broadcast/redundant-ingest/index.mdx). For basic broadcasts, this is sufficient, for more advanced broadcasts Dolby.io provides two features that are exceptions:
+To first understand Audio Multiplexing, we need to understand how the OptiView Real-time servers ingest feeds. When [Broadcasting](/millicast/broadcast/index.mdx), the OptiView Real-time Streaming servers will assign the most recent published stream source as the "_Main Source_", a function that allows broadcasters to seamlessly overwrite streams or add [Redundant Streams](/millicast/broadcast/redundant-ingest/index.mdx). For basic broadcasts, this is sufficient, for more advanced broadcasts OptiView Real-time Streaming provides two features that are exceptions:
 
 1. Creating a [Multisource stream](/millicast/broadcast/multi-source-broadcasting.mdx) for [Multi-view](multi-view.md) experiences.
 2. Audio Multiplexing, for experiences with multiple audio streams playing at once, such as that seen on "_Clubhouse_" type platforms and apps.
@@ -80,7 +80,7 @@ viewer.on('broadcastEvent', async (event) => {
 ```
 
 :::caution Viewer on "track" events
-The Dolby.io SDKs offer `.on("track",async (event) =>{})` functionality for triggering events as tracks are added. When using Audio Multiplexing this event will trigger a number of times equal to the `multiplexedAudioTracks` value, regardless of if those tracks actually contain data.
+The OptiView Real-time SDKs offer `.on("track",async (event) =>{})` functionality for triggering events as tracks are added. When using Audio Multiplexing this event will trigger a number of times equal to the `multiplexedAudioTracks` value, regardless of if those tracks actually contain data.
 
 This means that if `multiplexedAudioTracks` is set to `5` it will trigger once for the first track and five additional times for each multiplexed audio track, regardless of whether there are only two tracks broadcasting or twenty.
 :::
@@ -112,7 +112,7 @@ async function projectOn(index) {
 
 To recap the above workflow:
 
-1. The app authenticates and connects with the Dolby.io Streaming (Millicast) Director.
+1. The app authenticates and connects with the OptiView Real-time Streaming (Millicast) Director.
 2. As the app connects the Director creates a main track plus an additional number of tracks equal to the `multiplexedAudioTracks` value. This triggers a `track` event for each track added.
 3. An audio feed is connected to the Publisher Node triggering a Broadcast event.
 4. The broadcast event creates an `<audio>` tag and triggers the `projectOn` function.
@@ -126,7 +126,7 @@ To help with understanding and implementing the Audio Multiplexing feature is in
 	<head>
 		<title>Dolby.io Audio Multiplexing Demo</title>
 		<link rel="shortcut icon" href="https://go.dolby.io/hubfs/Dolby_April2021/images/favicon-32x32.png" />
-        <!-- Dolby.io Streaming Millicast JavaScript SDK -->
+        <!-- OptiView Real-time Streaming Millicast JavaScript SDK -->
 		<script src="https://cdn.jsdelivr.net/npm/@millicast/sdk/dist/millicast.umd.min.js"></script>
 		<!-- Bootstrap Bundle -->
 		<link

--- a/millicast/playback/frame-metadata.md
+++ b/millicast/playback/frame-metadata.md
@@ -229,7 +229,7 @@ function initialize({ readable, writable }) {
 }
 ```
 
-Create another JavaScript file called **scripts.js** that will be used to publish a stream to the Dolby.io Real-time Streaming and start the web worker to insert the metadata. First, in order to know what capabilities the web browser supports (insertable frames or WebRTC Script Transform), add the following logic to your file.
+Create another JavaScript file called **scripts.js** that will be used to publish a stream to the OptiView Real-time Streaming and start the web worker to insert the metadata. First, in order to know what capabilities the web browser supports (insertable frames or WebRTC Script Transform), add the following logic to your file.
 
 ```javascript
 // Insertable streams for `MediaStreamTrack` is supported.

--- a/millicast/playback/hosted-player/customization.md
+++ b/millicast/playback/hosted-player/customization.md
@@ -8,7 +8,7 @@ When having a stream, it is possible to set up a loading screen before your even
 ## How to add a stream preview to your event
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast. You'll need your _publish token_ and _stream name_ for the steps described below.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You'll need your _publish token_ and _stream name_ for the steps described below.
 :::
 
 Open up the management screen of your stream token and visit the Playback tab. To the right on the _Hosted player path_, there will be a space for an **Offline image URL**. Here place the image's link with an HTTP-compliant URL.

--- a/millicast/playback/hosted-player/customization.md
+++ b/millicast/playback/hosted-player/customization.md
@@ -8,7 +8,7 @@ When having a stream, it is possible to set up a loading screen before your even
 ## How to add a stream preview to your event
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast. You'll need your _publish token_ and _stream name_ for the steps described below.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast. You'll need your _publish token_ and _stream name_ for the steps described below.
 :::
 
 Open up the management screen of your stream token and visit the Playback tab. To the right on the _Hosted player path_, there will be a space for an **Offline image URL**. Here place the image's link with an HTTP-compliant URL.

--- a/millicast/playback/hosted-player/index.md
+++ b/millicast/playback/hosted-player/index.md
@@ -15,7 +15,7 @@ import HostedViewerPreview from '../../assets/img/dolbyio-hosted-viewer-preview.
 </div>
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast.
 
 You can follow the steps in [Part 1](/millicast/getting-started/using-the-dashboard.mdx) to learn how to use the [Live Broadcast](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx) and [Hosted Player](/millicast/playback/hosted-player/index.md).
 :::

--- a/millicast/playback/hosted-player/index.md
+++ b/millicast/playback/hosted-player/index.md
@@ -15,7 +15,7 @@ import HostedViewerPreview from '../../assets/img/dolbyio-hosted-viewer-preview.
 </div>
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast.
 
 You can follow the steps in [Part 1](/millicast/getting-started/using-the-dashboard.mdx) to learn how to use the [Live Broadcast](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx) and [Hosted Player](/millicast/playback/hosted-player/index.md).
 :::

--- a/millicast/playback/index.mdx
+++ b/millicast/playback/index.mdx
@@ -61,8 +61,8 @@ The previous stages of [Capture](/millicast/capture/index.mdx), [Broadcast](/mil
 
 ### Using the streaming viewer
 
-[Dolby.io Dashboard Viewer](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx)<br/>
-The quickest and easiest way to test playback is to use your account dashboard. The streaming viewer is built into the Dolby.io Dashboard, so you can test out streaming right away. To build a more customized application, the [Client SDKs](/millicast/playback/players-sdks/index.mdx) provide support for the most popular programming platforms.
+[OptiView Streaming Dashboard Viewer](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx)<br/>
+The quickest and easiest way to test playback is to use your account dashboard. The streaming viewer is built into the OptiView Streaming Dashboard, so you can test out streaming right away. To build a more customized application, the [Client SDKs](/millicast/playback/players-sdks/index.mdx) provide support for the most popular programming platforms.
 
 [How-to Create Subscriber Tokens](/millicast/streaming-dashboard/subscribe-tokens.mdx)<br/>
 To broadcast, you need a _publishing_ token. Similarly, to support playback in your application, you will need to be able to generate a _subscriber_ token. This can be done either in a web application or with an [API](/millicast/distribution/access-control/index.md).
@@ -126,7 +126,7 @@ You can find examples of more third-party viewer integrations, such as the [deve
 </div>
 
 [Webhooks](/millicast/webhooks/index.mdx)<br/>
-A **webhook** is a registered URL that will be called back from the Dolby.io platform with details about an event as it occurs. You can create webhooks for when a thumbnail is generated, a recording is complete, or when streams begin and end.
+A **webhook** is a registered URL that will be called back from the OptiView Real-time platform with details about an event as it occurs. You can create webhooks for when a thumbnail is generated, a recording is complete, or when streams begin and end.
 
 [Viewer events](/millicast/playback/players-sdks/viewer-events.md)<br/>
 Viewer events occur when a component of a stream changes, such as when a new source is published, simulcast layer information has changed, etc.
@@ -141,7 +141,7 @@ The account dashboard provides data-rich information about streaming usage for y
 
 The **WebRTC-HTTP Egress Protocol (WHEP)** is an IETF standard developed to leverage the capabilities of WebRTC to distribute and playback content onto a WebRTC-enabled device over HTTP. WHEP addresses problems with Real-time Streaming by removing translation layers during decoding.
 
-**Real-time Streaming Monitor** apps were created to allow your users to quickly and easily view live streams powered by Dolby.io. Plug in your Dolby.io subscriber token to view streams on any Apple iOS, iPadOS, tvOS, or Android TV device.
+**Real-time Streaming Monitor** apps were created to allow your users to quickly and easily view live streams powered by OptiView Real-time Streaming. Plug in your OptiView subscriber token to view streams on any Apple iOS, iPadOS, tvOS, or Android TV device.
 
 Create and customize your own Real-time Streaming Monitor apps with a native [Client SDK](/millicast/playback/players-sdks/index.mdx).
 

--- a/millicast/playback/index.mdx
+++ b/millicast/playback/index.mdx
@@ -61,8 +61,8 @@ The previous stages of [Capture](/millicast/capture/index.mdx), [Broadcast](/mil
 
 ### Using the streaming viewer
 
-[OptiView Streaming Dashboard Viewer](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx)<br/>
-The quickest and easiest way to test playback is to use your account dashboard. The streaming viewer is built into the OptiView Streaming Dashboard, so you can test out streaming right away. To build a more customized application, the [Client SDKs](/millicast/playback/players-sdks/index.mdx) provide support for the most popular programming platforms.
+[OptiView Real-time Streaming Dashboard Viewer](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx)<br/>
+The quickest and easiest way to test playback is to use your account dashboard. The streaming viewer is built into the OptiView Real-time Streaming Dashboard, so you can test out streaming right away. To build a more customized application, the [Client SDKs](/millicast/playback/players-sdks/index.mdx) provide support for the most popular programming platforms.
 
 [How-to Create Subscriber Tokens](/millicast/streaming-dashboard/subscribe-tokens.mdx)<br/>
 To broadcast, you need a _publishing_ token. Similarly, to support playback in your application, you will need to be able to generate a _subscriber_ token. This can be done either in a web application or with an [API](/millicast/distribution/access-control/index.md).

--- a/millicast/playback/ipv6-support.md
+++ b/millicast/playback/ipv6-support.md
@@ -36,7 +36,7 @@ To opt-in to with the Millicast iOS SDK, set the apiUrl in the credentials objec
 ```swift
 let credentials = MCSubscriberCredentials()
 credentials.streamName =  "STREAM_NAME"; // The name of the stream you want to subscribe to
-credentials.accountId = "ACCOUNT_ID"; // The ID of your Dolby.io Real-time Streaming account
+credentials.accountId = "ACCOUNT_ID"; // The ID of your OptiView Real-time Streaming account
 credentials.apiUrl = "https://director-ipv6.millicast.com/api/director/subscribe"; // The subscribe API URL
 
 try await subscriber.setCredentials(credentials)

--- a/millicast/playback/multi-view.md
+++ b/millicast/playback/multi-view.md
@@ -4,7 +4,7 @@ slug: /playback/multiview
 sidebar_position: 4
 ---
 
-Multi-view lets you ingest and render multiple Dolby.io real-time video and audio streams simultaneously inside a browser or mobile native applications. Once rendered, you can switch seamlessly between streams, allowing you to control how you view the content. By giving viewers content control, broadcasters can enable real-time experiences and engagement that leave viewers wanting more.
+Multi-view lets you ingest and render multiple OptiView real-time video and audio streams simultaneously inside a browser or mobile native applications. Once rendered, you can switch seamlessly between streams, allowing you to control how you view the content. By giving viewers content control, broadcasters can enable real-time experiences and engagement that leave viewers wanting more.
 
 <div className="youtube-container">
   <iframe
@@ -14,11 +14,11 @@ Multi-view lets you ingest and render multiple Dolby.io real-time video and audi
   ></iframe>
 </div>
 
-To create a multi-view experience you must capture multiple video or audio feeds and then broadcast them as a [multi-source stream](/millicast/broadcast/multi-source-broadcasting.mdx). Once broadcasting a multi-source stream, you can view the stream using the Dolby.io Millicast viewer app, or by building your own multi-view application. Dolby.io also supports [Audio Multiplexing](/millicast/playback/audio-multiplexing.md) for mixed audio playback.
+To create a multi-view experience you must capture multiple video or audio feeds and then broadcast them as a [multi-source stream](/millicast/broadcast/multi-source-broadcasting.mdx). Once broadcasting a multi-source stream, you can view the stream using the OptiView viewer app, or by building your own multi-view application. OptiView Real-time Streaming also supports [Audio Multiplexing](/millicast/playback/audio-multiplexing.md) for mixed audio playback.
 
-## Multi-view with the Dolby.io viewer
+## Multi-view with the OptiView viewer
 
-Once you have created a [Multisource stream](/millicast/broadcast/multi-source-broadcasting.mdx), you can open the stream viewer from the [Dolby.io dashboard](https://streaming.dolby.io/#/tokens) or by navigating to:
+Once you have created a [Multisource stream](/millicast/broadcast/multi-source-broadcasting.mdx), you can open the stream viewer from the [OptiView Streaming Dashboard](https://streaming.dolby.io/#/tokens) or by navigating to:
 
 ```
 https://viewer.millicast.com?streamId=[YOUR_ACCOUNT_ID]/[YOUR_STREAM_NAME]
@@ -40,22 +40,22 @@ https://viewer.millicast.com?streamId=[YOUR_ACCOUNT_ID]/[YOUR_STREAM_NAME]&multi
 
 ## Creating a Multi-view web application
 
-Dolby.io supports [Multisource Playback](/millicast/playback/source-and-layer-selection.md) via the [Client SDKs](/millicast/playback/players-sdks/index.mdx), allowing you to build your own multi-view experience for your app or platform.
+OptiView Real-time Streaming supports [Multisource Playback](/millicast/playback/source-and-layer-selection.md) via the [Client SDKs](/millicast/playback/players-sdks/index.mdx), allowing you to build your own multi-view experience for your app or platform.
 
 Before getting started building a multi-view application it is worth understanding;
 
 1. How to broadcast [Multisource Streams](/millicast/broadcast/multi-source-broadcasting.mdx).
 2. How to [Create a Basic Streaming Web App](/millicast/getting-started/creating-real-time-streaming-web-app.mdx).
 3. What [Broadcast Events](/millicast/playback/players-sdks/viewer-events.md) are and how to use them.
-4. How the Dolby.io platform organizes and handles [Multisource Playback](/millicast/playback/source-and-layer-selection.md).
+4. How the OptiView Real-time platform organizes and handles [Multisource Playback](/millicast/playback/source-and-layer-selection.md).
 
 ### Store and track incoming Multisource feeds
 
 :::info Not building a Web App?
-All Dolby.io [Client SDKs](/millicast/playback/players-sdks/index.mdx) support building Multi-view applications. Although the below example is using JavaScript the principles are the same for each SDK.
+All OptiView Real-time [Client SDKs](/millicast/playback/players-sdks/index.mdx) support building Multi-view applications. Although the below example is using JavaScript the principles are the same for each SDK.
 :::
 
-The Dolby.io platform tracks broadcasts by their `account ID` and `stream name` and individual streams within broadcasts by their `sourceID`, a unique identifier that can be used for selecting feeds to render from the [viewer node](source-and-layer-selection.md). Unlike a traditional broadcast where there is only one stream to playback, a multi-view application must account for multiple feeds arriving asynchronously. To accomplish this, the application should [listen for streams using a `broadcastEvent`](/millicast/playback/players-sdks/viewer-events.md#using-events), and store the stream `sourceID` as it becomes active.
+The OptiView Real-time platform tracks broadcasts by their `account ID` and `stream name` and individual streams within broadcasts by their `sourceID`, a unique identifier that can be used for selecting feeds to render from the [viewer node](source-and-layer-selection.md). Unlike a traditional broadcast where there is only one stream to playback, a multi-view application must account for multiple feeds arriving asynchronously. To accomplish this, the application should [listen for streams using a `broadcastEvent`](/millicast/playback/players-sdks/viewer-events.md#using-events), and store the stream `sourceID` as it becomes active.
 
 ```javascript
 const activeSources = new Set();
@@ -72,7 +72,7 @@ await millicastView.on('broadcastEvent', (event) => {
 
 ### Add video elements and render feeds
 
-Once we've captured the `sourceID` of an incoming stream, we need to signal to the Viewer node which _track_ the stream will play on. The Dolby.io Millicast SDKs include a function that allows you to [dynamically add a track to the Viewer node](source-and-layer-selection.md#dynamic-viewer-track) called `addRemoteTrack`.
+Once we've captured the `sourceID` of an incoming stream, we need to signal to the Viewer node which _track_ the stream will play on. The OptiView Real-time SDKs include a function that allows you to [dynamically add a track to the Viewer node](source-and-layer-selection.md#dynamic-viewer-track) called `addRemoteTrack`.
 
 [addRemoteTrack](https://millicast.github.io/millicast-sdk/View.html#addRemoteTrack) requires the media type of the incoming stream (_audio or video_) and a [`MediaStream`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream), an interface that signals a stream of media content. `addRemoteTrack` will then return a promise that will be resolved when the [`RTCRtpTransceiver`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver) is assigned a `mid` value.
 
@@ -123,7 +123,7 @@ In the above code `videoDiv` is where we want the `<video>` tag to show up in th
 4. Created a `<video>` element and associate that element with the newly created media.
 5. Added the `<video>` element and its `mediaStream` to the `<div>` where it will render.
 
-At this stage, all the pieces are together, however, the stream won't yet render. This is because you have yet to tell the Dolby.io Viewer node which stream to project onto the `Transceiver`. This is done using the [`project` function](/millicast/playback/source-and-layer-selection) which tells the node to begin _projecting_ the stream, identified by its `sourceID`, onto the `Transceiver`.
+At this stage, all the pieces are together, however, the stream won't yet render. This is because you have yet to tell the OptiView Viewer node which stream to project onto the `Transceiver`. This is done using the [`project` function](/millicast/playback/source-and-layer-selection) which tells the node to begin _projecting_ the stream, identified by its `sourceID`, onto the `Transceiver`.
 
 ```javascript
 await millicastView.project(sourceID, [
@@ -143,7 +143,7 @@ Once projected the stream will begin playing within the `<video>` tag.
 Put all together, a basic multi-view application would look something like this:
 
 ```javascript
-// Authenticate a Connection to the Dolby.io CDN
+// Authenticate a Connection to the OptiView Real-time CDN
 const tokenGenerator = () =>
   millicast.Director.getSubscriber({
     streamName: 'YOUR STREAM NAME',
@@ -242,7 +242,7 @@ const updateLayers = async (layers) => {
 
 ## Limitations of Multi-view
 
-Dolby.io Real-time Streaming does not limit the number of tracks that a viewer can receive, however, it limits the aggregate bitrate of all tracks to 12 Mbps. The pinned source is prioritized and allowed to exceed the 12 Mbps limit, and the other tracks share any remaining available bandwidth. The source with a null `sourceId` is pinned by default. You can change the pinned source by using the `pinnedSourceId` attribute in the `View.connect` command. You should configure the Simulcast/SVC bitrate of each source so that a viewer can receive the desired amount of video tracks in the viewer session while remaining under the aggregate bitrate limit.
+OptiView Real-time Streaming does not limit the number of tracks that a viewer can receive, however, it limits the aggregate bitrate of all tracks to 12 Mbps. The pinned source is prioritized and allowed to exceed the 12 Mbps limit, and the other tracks share any remaining available bandwidth. The source with a null `sourceId` is pinned by default. You can change the pinned source by using the `pinnedSourceId` attribute in the `View.connect` command. You should configure the Simulcast/SVC bitrate of each source so that a viewer can receive the desired amount of video tracks in the viewer session while remaining under the aggregate bitrate limit.
 
 | Example                                          | Bandwidth Allocation                                                                        |
 | :----------------------------------------------- | :------------------------------------------------------------------------------------------ |

--- a/millicast/playback/multi-view.md
+++ b/millicast/playback/multi-view.md
@@ -4,7 +4,7 @@ slug: /playback/multiview
 sidebar_position: 4
 ---
 
-Multi-view lets you ingest and render multiple OptiView real-time video and audio streams simultaneously inside a browser or mobile native applications. Once rendered, you can switch seamlessly between streams, allowing you to control how you view the content. By giving viewers content control, broadcasters can enable real-time experiences and engagement that leave viewers wanting more.
+Multi-view lets you ingest and render multiple OptiView Real-time video and audio streams simultaneously inside a browser or mobile native applications. Once rendered, you can switch seamlessly between streams, allowing you to control how you view the content. By giving viewers content control, broadcasters can enable real-time experiences and engagement that leave viewers wanting more.
 
 <div className="youtube-container">
   <iframe
@@ -18,7 +18,7 @@ To create a multi-view experience you must capture multiple video or audio feeds
 
 ## Multi-view with the OptiView viewer
 
-Once you have created a [Multisource stream](/millicast/broadcast/multi-source-broadcasting.mdx), you can open the stream viewer from the [OptiView Streaming Dashboard](https://streaming.dolby.io/#/tokens) or by navigating to:
+Once you have created a [Multisource stream](/millicast/broadcast/multi-source-broadcasting.mdx), you can open the stream viewer from the [OptiView Real-time Streaming Dashboard](https://streaming.dolby.io/#/tokens) or by navigating to:
 
 ```
 https://viewer.millicast.com?streamId=[YOUR_ACCOUNT_ID]/[YOUR_STREAM_NAME]

--- a/millicast/playback/players-sdks/android/samples/sample-apps-android-viewer.mdx
+++ b/millicast/playback/players-sdks/android/samples/sample-apps-android-viewer.mdx
@@ -30,7 +30,7 @@ This repository demonstrates how to develop a real-time streaming viewer or moni
 
 The application provided can be used as it is or with your own modifications to create or embed a real-time streaming viewer on Android app. You can clone the repository yourself, run the application locally or customize it to make it your own. Learn more about OptiView Real-time Streaming capabilities [here](https://optiview.dolby.com/solutions/real-time-streaming/).
 
-You can start monitoring a stream with the stream name and account ID, which you can create and start streaming from the [OptiView Real-time Streaming Dashboard](https://dashboard.dolby.io/).
+You can start monitoring a stream with the stream name and account ID, which you can create and start streaming from the [OptiView Real-time Streaming Dashboard](https://streaming.dolby.io/).
 
 Supported features:
 

--- a/millicast/playback/players-sdks/android/samples/sample-apps-android-viewer.mdx
+++ b/millicast/playback/players-sdks/android/samples/sample-apps-android-viewer.mdx
@@ -10,7 +10,7 @@ import StreamMonitor from '../../../../assets/img/iOS_stream_monitor.png';
   <img src={StreamMonitor} width="800" />
 </div>
 
-The application available in this repository demonstrates the capabilities of OptiView Real-time Streaming monitoring experience, built for Android and Android TV devices.
+The application available in this repository demonstrates the capabilities of the OptiView Real-time Streaming monitoring experience, built for Android and Android TV devices.
 
 import DocCard from '@theme/DocCard';
 
@@ -26,11 +26,11 @@ import DocCard from '@theme/DocCard';
   }}
 />
 
-This repository demonstrates how to develop a real-time streaming viewer or monitoring app using OptiView Real-time Streaming's Real-time Streaming solution which features ultra low-latency (sub 500ms).
+This repository demonstrates how to develop a real-time streaming viewer or monitoring app using the OptiView Real-time Streaming solution which features ultra low-latency (sub 500ms).
 
-The application provided can be used as it is or with your own modifications to create or embed a real-time streaming viewer on Android app. You can clone the repository yourself, run the application locally or customize it to make it your own. Learn more about Dolby.io’s Real-time Streaming capabilities [here](https://optiview.dolby.com/solutions/real-time-streaming/).
+The application provided can be used as it is or with your own modifications to create or embed a real-time streaming viewer on Android app. You can clone the repository yourself, run the application locally or customize it to make it your own. Learn more about OptiView Real-time Streaming capabilities [here](https://optiview.dolby.com/solutions/real-time-streaming/).
 
-You can start monitoring a stream with the stream name and account ID, which you can create and start streaming from the [OptiView Streaming Dashboard](https://dashboard.dolby.io/).
+You can start monitoring a stream with the stream name and account ID, which you can create and start streaming from the [OptiView Real-time Streaming Dashboard](https://dashboard.dolby.io/).
 
 Supported features:
 

--- a/millicast/playback/players-sdks/android/samples/sample-apps-android-viewer.mdx
+++ b/millicast/playback/players-sdks/android/samples/sample-apps-android-viewer.mdx
@@ -10,7 +10,7 @@ import StreamMonitor from '../../../../assets/img/iOS_stream_monitor.png';
   <img src={StreamMonitor} width="800" />
 </div>
 
-The application available in this repository demonstrates the capabilities of Dolby.io's Real-time Streaming monitoring experience, built for Android and Android TV devices.
+The application available in this repository demonstrates the capabilities of OptiView Real-time Streaming monitoring experience, built for Android and Android TV devices.
 
 import DocCard from '@theme/DocCard';
 
@@ -26,11 +26,11 @@ import DocCard from '@theme/DocCard';
   }}
 />
 
-This repository demonstrates how to develop a real-time streaming viewer or monitoring app using Dolby.io's Real-time Streaming solution which features ultra low-latency (sub 500ms).
+This repository demonstrates how to develop a real-time streaming viewer or monitoring app using OptiView Real-time Streaming's Real-time Streaming solution which features ultra low-latency (sub 500ms).
 
 The application provided can be used as it is or with your own modifications to create or embed a real-time streaming viewer on Android app. You can clone the repository yourself, run the application locally or customize it to make it your own. Learn more about Dolby.io’s Real-time Streaming capabilities [here](https://optiview.dolby.com/solutions/real-time-streaming/).
 
-You can start monitoring a stream with the stream name and account ID, which you can create and start streaming from the [Dolby.io dashboard](https://dashboard.dolby.io/).
+You can start monitoring a stream with the stream name and account ID, which you can create and start streaming from the [OptiView Streaming Dashboard](https://dashboard.dolby.io/).
 
 Supported features:
 

--- a/millicast/playback/players-sdks/android/sdk/getting-started-with-publishing.md
+++ b/millicast/playback/players-sdks/android/sdk/getting-started-with-publishing.md
@@ -86,7 +86,7 @@ val publisher = Core.createPublisher()
 
 ### 4.2 Set publisher credentials
 
-Make sure to use the publisher's methods in a coroutine context. Then, create a stream in your Dolby.io developer dashboard or using the Dolby.io Streaming REST API and [set your credentials](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/set-credentials.html). Collecting the [state](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/current-state.html) of the publisher object from its StateFlow is important for handling errors and knowing if the SDK is ready for the [publish](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/publish.html) call to happen.
+Make sure to use the publisher's methods in a coroutine context. Then, create a stream in your OptiView Streaming Dashboard or using the OptiView Real-time Streaming REST API and [set your credentials](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/set-credentials.html). Collecting the [state](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/current-state.html) of the publisher object from its StateFlow is important for handling errors and knowing if the SDK is ready for the [publish](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/publish.html) call to happen.
 
 ```kotlin
 // Helper for later usage
@@ -193,7 +193,7 @@ coroutineScope.safeLaunch {
 
 Connect to the Millicast service and publish your streams.
 
-Use the [connect](https://millicast.github.io/doc/latest/android/android/com.millicast/-client/connect.html) method to authenticate and access Dolby.io Real-time Streaming through the Director API. Successful authentication results in opening a WebSocket connection that allows using the Dolby.io Real-time Streaming server and receiving a StateFlow update to [state](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/current-state.html) as PublisherConnectionState.Connected.
+Use the [connect](https://millicast.github.io/doc/latest/android/android/com.millicast/-client/connect.html) method to authenticate and access OptiView Real-time Streaming through the Director API. Successful authentication results in opening a WebSocket connection that allows using the OptiView Real-time Streaming server and receiving a StateFlow update to [state](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/current-state.html) as PublisherConnectionState.Connected.
 
 Only after a successful connection, use the [publish](<https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/publish.html?query=suspend%20fun%20publish():%20Boolean>) method to start publishing the stream. Once the publisher starts sending media, the SDK will update [state](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/current-state.html) to PublisherConnectionState.Started.
 

--- a/millicast/playback/players-sdks/android/sdk/getting-started-with-publishing.md
+++ b/millicast/playback/players-sdks/android/sdk/getting-started-with-publishing.md
@@ -86,7 +86,7 @@ val publisher = Core.createPublisher()
 
 ### 4.2 Set publisher credentials
 
-Make sure to use the publisher's methods in a coroutine context. Then, create a stream in your OptiView Streaming Dashboard or using the OptiView Real-time Streaming REST API and [set your credentials](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/set-credentials.html). Collecting the [state](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/current-state.html) of the publisher object from its StateFlow is important for handling errors and knowing if the SDK is ready for the [publish](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/publish.html) call to happen.
+Make sure to use the publisher's methods in a coroutine context. Then, create a stream in your OptiView Real-time Streaming Dashboard or using the OptiView Real-time Streaming REST API and [set your credentials](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/set-credentials.html). Collecting the [state](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/current-state.html) of the publisher object from its StateFlow is important for handling errors and knowing if the SDK is ready for the [publish](https://millicast.github.io/doc/latest/android/android/com.millicast/-publisher/publish.html) call to happen.
 
 ```kotlin
 // Helper for later usage

--- a/millicast/playback/players-sdks/android/sdk/index.mdx
+++ b/millicast/playback/players-sdks/android/sdk/index.mdx
@@ -3,7 +3,7 @@ title: Millicast SDK
 sidebar_position: 2
 ---
 
-The Native SDK for creating Android applications. You may use it in your Android project to connect, capture, publish, or subscribe to streams using the Dolby.io Streaming Platform.
+The Native SDK for creating Android applications. You may use it in your Android project to connect, capture, publish, or subscribe to streams using the OptiView Real-time Streaming Platform.
 
 :::caution Player vs SDK
 **Dolby OptiView Player** (formerly THEOplayer) now supports real-time streaming (formerly Millicast). Unless directed by your onboarding team, please use the [Dolby OptiView Player](../player/index.mdx) and not the Millicast SDKs.
@@ -61,7 +61,7 @@ If you want to use Streaming APIs on Android and iOS, you can also use the [Flut
 
 ## Requirements
 
-- [Dolby.io account](https://streaming.dolby.io)
+- [OptiView Real-time account](https://streaming.dolby.io)
 - A working video camera and microphone
 - Android API [24](https://developer.android.com/tools/releases/platforms#7.0) or later
 - Client SDK [1.8.0](https://github.com/millicast/millicast-native-sdk/releases) or later

--- a/millicast/playback/players-sdks/desktop/getting-started-with-publishing.md
+++ b/millicast/playback/players-sdks/desktop/getting-started-with-publishing.md
@@ -52,7 +52,7 @@ millicast::Logger::set_logger([](/millicast/const std::string& msg, millicast::L
 
 ## 3. Publish a stream
 
-Create a publisher object and set a listener object to the publisher to receive proper events. This requires creating a class that inherits the publisher's listener interface. Then, create a stream in your OptiView Streaming Dashboard or using the OptiView Real-time Streaming REST API and set your credentials.
+Create a publisher object and set a listener object to the publisher to receive proper events. This requires creating a class that inherits the publisher's listener interface. Then, create a stream in your OptiView Real-time Streaming Dashboard or using the OptiView Real-time Streaming REST API and set your credentials.
 
 ```cpp
 // Create a publisher object

--- a/millicast/playback/players-sdks/desktop/getting-started-with-publishing.md
+++ b/millicast/playback/players-sdks/desktop/getting-started-with-publishing.md
@@ -41,7 +41,7 @@ if (videoTrack == nullptr)
 
 ## 2. Set logger
 
-Optionally, set your own logger function to print Dolby.io Real-time Streaming logs according to the severity. By default, the SDK prints the standard output, where the severity is first and then the message.
+Optionally, set your own logger function to print OptiView Real-time Streaming logs according to the severity. By default, the SDK prints the standard output, where the severity is first and then the message.
 
 ```cpp
 millicast::Logger::set_logger([](/millicast/const std::string& msg, millicast::LogLevel lvl) {
@@ -52,7 +52,7 @@ millicast::Logger::set_logger([](/millicast/const std::string& msg, millicast::L
 
 ## 3. Publish a stream
 
-Create a publisher object and set a listener object to the publisher to receive proper events. This requires creating a class that inherits the publisher's listener interface. Then, create a stream in your Dolby.io developer dashboard or using the Dolby.io Streaming REST API and set your credentials.
+Create a publisher object and set a listener object to the publisher to receive proper events. This requires creating a class that inherits the publisher's listener interface. Then, create a stream in your OptiView Streaming Dashboard or using the OptiView Real-time Streaming REST API and set your credentials.
 
 ```cpp
 // Create a publisher object
@@ -139,13 +139,13 @@ publisher->add_track(audio_track);
 
 ## 6. Authenticate using the Director API
 
-Authenticate to access Dolby.io Real-time Streaming through the Director API.
+Authenticate to access OptiView Real-time Streaming through the Director API.
 
 ```cpp
 publisher->connect();
 ```
 
-Successful authentication results in opening a WebSocket connection that allows using the Dolby.io Real-time Streaming server and calling the listener's [on_connected](https://millicast.github.io/doc/latest/cpp/structmillicast_1_1_client_listener.html#a50511fbcaf9ac3dd4fc54c4e94e74982) method.
+Successful authentication results in opening a WebSocket connection that allows using the OptiView Real-time Streaming server and calling the listener's [on_connected](https://millicast.github.io/doc/latest/cpp/structmillicast_1_1_client_listener.html#a50511fbcaf9ac3dd4fc54c4e94e74982) method.
 
 ## 7. Start publishing
 

--- a/millicast/playback/players-sdks/desktop/getting-started-with-subscribing.md
+++ b/millicast/playback/players-sdks/desktop/getting-started-with-subscribing.md
@@ -67,7 +67,7 @@ Get your **stream name** and **stream ID** from the dashboard and set them up in
 ```cpp
 auto credentials = viewer->get_credentials(); // Get the current credentials
 credentials.stream_name = "streamName"; // The name of the stream you want to subscribe to
-credentials.account_id = "ACCOUNT"; // The ID of your Dolby.io Real-time Streaming account
+credentials.account_id = "ACCOUNT"; // The ID of your OptiView Real-time Streaming account
 credentials.token = "aefea56153765316754fe"; // Optionally set the subscribing token
 credentials.api_url = "https://director.millicast.com/api/director/subscribe"; // The subscribe API URL
 publisher->set_credentials(std::move(credentials)); // Set the new credentials
@@ -90,7 +90,7 @@ viewer->set_options(options);
 
 ## 6. Create a WebSocket connection
 
-Authenticate and create a WebSocket connection to connect with the Dolby.io Real-time Streaming server.
+Authenticate and create a WebSocket connection to connect with the OptiView Real-time Streaming server.
 
 ```cpp
 viewer->connect();

--- a/millicast/playback/players-sdks/desktop/index.mdx
+++ b/millicast/playback/players-sdks/desktop/index.mdx
@@ -4,7 +4,7 @@ slug: /playback/players-sdks/desktop
 sidebar_position: 6
 ---
 
-The Native SDK provides C++ APIs for desktop platforms, such as Linux, Mac, and Windows. You may use the SDK in your project to connect, capture, publish, or subscribe to streams using the Dolby.io Streaming Platform.
+The Native SDK provides C++ APIs for desktop platforms, such as Linux, Mac, and Windows. You may use the SDK in your project to connect, capture, publish, or subscribe to streams using the OptiView Real-time Streaming Platform.
 
 import ThreeCardList from '@site/src/components/ThreeCardList';
 

--- a/millicast/playback/players-sdks/flutter/index.mdx
+++ b/millicast/playback/players-sdks/flutter/index.mdx
@@ -77,7 +77,7 @@ import 'package:millicast_flutter_sdk/millicast_flutter_sdk.dart';
 ### Publish a stream
 
 :::tip Getting started
-You will need to find or create a new stream name with a token in your OptiView Streaming Dashboard. You can do that following this [link](/millicast/streaming-dashboard/managing-your-tokens.mdx).
+You will need to find or create a new stream name with a token in your OptiView Real-time Streaming Dashboard. You can do that following this [link](/millicast/streaming-dashboard/managing-your-tokens.mdx).
 :::
 
 The main module to publish a stream is the [Publish module](https://pub.dev/documentation/millicast_flutter_sdk/latest/millicast_flutter_sdk/Publish-class.html).

--- a/millicast/playback/players-sdks/flutter/index.mdx
+++ b/millicast/playback/players-sdks/flutter/index.mdx
@@ -9,7 +9,7 @@ This SDK is no longer being developed. If you would like to use a Flutter SDK wi
 If you are an existing customer using this SDK, please contact us via our support channels for ongoing support and migration options.
 :::
 
-Dolby.io Streaming APIs support creating iOS and Android applications using the Flutter SDK.
+OptiView Real-time Streaming APIs support creating iOS and Android applications using the Flutter SDK.
 
 import ThreeCardList from '@site/src/components/ThreeCardList';
 
@@ -77,7 +77,7 @@ import 'package:millicast_flutter_sdk/millicast_flutter_sdk.dart';
 ### Publish a stream
 
 :::tip Getting started
-You will need to find or create a new stream name with a token in your Dolby.io dashboard. You can do that following this [link](/millicast/streaming-dashboard/managing-your-tokens.mdx).
+You will need to find or create a new stream name with a token in your OptiView Streaming Dashboard. You can do that following this [link](/millicast/streaming-dashboard/managing-your-tokens.mdx).
 :::
 
 The main module to publish a stream is the [Publish module](https://pub.dev/documentation/millicast_flutter_sdk/latest/millicast_flutter_sdk/Publish-class.html).
@@ -396,7 +396,7 @@ More information here:
 
 ### User count
 
-The Dolby.io Real-time Streaming server provides the number of current viewers through broadcast events. To start listening to different broadcast events you have to add which events you want to listen to in the Publisher/Subscriber options.
+The OptiView Real-time Streaming server provides the number of current viewers through broadcast events. To start listening to different broadcast events you have to add which events you want to listen to in the Publisher/Subscriber options.
 
 Both Publisher and Subscriber follow the same workflow.
 

--- a/millicast/playback/players-sdks/ios/samples/sample-apps-ios-viewer.mdx
+++ b/millicast/playback/players-sdks/ios/samples/sample-apps-ios-viewer.mdx
@@ -10,7 +10,7 @@ import IosStreamMonitor from '../../../../assets/img/iOS_stream_monitor.png';
   <img src={IosStreamMonitor} width="800" />
 </div>
 
-The application available in this repository demonstrates the capabilities of Dolby.io's Real-time Streaming monitoring experience, built for iOS, iPad OS, and tvOS devices.
+The application available in this repository demonstrates the capabilities of OptiView Real-time Streaming monitoring experience, built for iOS, iPad OS, and tvOS devices.
 
 import DocCard from '@theme/DocCard';
 
@@ -26,11 +26,11 @@ import DocCard from '@theme/DocCard';
   }}
 />
 
-This repository demonstrates how to develop a real-time streaming viewer or monitoring app using Dolby.io's Real-time Streaming solution which features ultra low-latency (sub 500ms).
+This repository demonstrates how to develop a real-time streaming viewer or monitoring app using OptiView Real-time Streaming's Real-time Streaming solution which features ultra low-latency (sub 500ms).
 
 The application provided can be used as it is or with your own modifications to create or embed a real-time streaming viewer on iOS/TvOS app. You can clone the repository yourself, run the application locally or customize it to make it your own. Learn more about Dolby.io’s Real-time Streaming capabilities [here](https://optiview.dolby.com/solutions/real-time-streaming/).
 
-You can start monitoring a stream with the stream name and account ID, which you can create and start streaming from the [Dolby.io dashboard](https://dashboard.dolby.io/).
+You can start monitoring a stream with the stream name and account ID, which you can create and start streaming from the [OptiView Streaming Dashboard](https://dashboard.dolby.io/).
 
 Supported features:
 

--- a/millicast/playback/players-sdks/ios/samples/sample-apps-ios-viewer.mdx
+++ b/millicast/playback/players-sdks/ios/samples/sample-apps-ios-viewer.mdx
@@ -30,7 +30,7 @@ This repository demonstrates how to develop a real-time streaming viewer or moni
 
 The application provided can be used as it is or with your own modifications to create or embed a real-time streaming viewer on iOS/TvOS app. You can clone the repository yourself, run the application locally or customize it to make it your own. Learn more about OptiView Real-time Streaming capabilities [here](https://optiview.dolby.com/solutions/real-time-streaming/).
 
-You can start monitoring a stream with the stream name and account ID, which you can create and start streaming from the [OptiView Real-time Streaming Dashboard](https://dashboard.dolby.io/).
+You can start monitoring a stream with the stream name and account ID, which you can create and start streaming from the [OptiView Real-time Streaming Dashboard](https://streaming.dolby.io/).
 
 Supported features:
 

--- a/millicast/playback/players-sdks/ios/samples/sample-apps-ios-viewer.mdx
+++ b/millicast/playback/players-sdks/ios/samples/sample-apps-ios-viewer.mdx
@@ -10,7 +10,7 @@ import IosStreamMonitor from '../../../../assets/img/iOS_stream_monitor.png';
   <img src={IosStreamMonitor} width="800" />
 </div>
 
-The application available in this repository demonstrates the capabilities of OptiView Real-time Streaming monitoring experience, built for iOS, iPad OS, and tvOS devices.
+The application available in this repository demonstrates the capabilities of the OptiView Real-time Streaming monitoring experience, built for iOS, iPad OS, and tvOS devices.
 
 import DocCard from '@theme/DocCard';
 
@@ -26,11 +26,11 @@ import DocCard from '@theme/DocCard';
   }}
 />
 
-This repository demonstrates how to develop a real-time streaming viewer or monitoring app using OptiView Real-time Streaming's Real-time Streaming solution which features ultra low-latency (sub 500ms).
+This repository demonstrates how to develop a real-time streaming viewer or monitoring app using the OptiView Real-time Streaming solution which features ultra low-latency (sub 500ms).
 
-The application provided can be used as it is or with your own modifications to create or embed a real-time streaming viewer on iOS/TvOS app. You can clone the repository yourself, run the application locally or customize it to make it your own. Learn more about Dolby.io’s Real-time Streaming capabilities [here](https://optiview.dolby.com/solutions/real-time-streaming/).
+The application provided can be used as it is or with your own modifications to create or embed a real-time streaming viewer on iOS/TvOS app. You can clone the repository yourself, run the application locally or customize it to make it your own. Learn more about OptiView Real-time Streaming capabilities [here](https://optiview.dolby.com/solutions/real-time-streaming/).
 
-You can start monitoring a stream with the stream name and account ID, which you can create and start streaming from the [OptiView Streaming Dashboard](https://dashboard.dolby.io/).
+You can start monitoring a stream with the stream name and account ID, which you can create and start streaming from the [OptiView Real-time Streaming Dashboard](https://dashboard.dolby.io/).
 
 Supported features:
 

--- a/millicast/playback/players-sdks/ios/sdk/getting-started-with-publishing.md
+++ b/millicast/playback/players-sdks/ios/sdk/getting-started-with-publishing.md
@@ -75,7 +75,7 @@ let publisher = MCPublisher(delegate: publisherDelegate)
 
 ### 2.2 Set publisher credentials
 
-Create a stream in your OptiView Streaming Dashboard or using the OptiView Real-time Streaming REST API. Then, set the credentials from the dashboard. All of the [MCPublisher](https://millicast.github.io/doc/latest/apple/documentation/millicastsdk/mcpublisher) APIs are asynchronous, so call them from asynchronous contexts.
+Create a stream in your OptiView Real-time Streaming Dashboard or using the OptiView Real-time Streaming REST API. Then, set the credentials from the dashboard. All of the [MCPublisher](https://millicast.github.io/doc/latest/apple/documentation/millicastsdk/mcpublisher) APIs are asynchronous, so call them from asynchronous contexts.
 
 ```swift
 // Get the credentials structure from your publisher instance, fill it in,

--- a/millicast/playback/players-sdks/ios/sdk/getting-started-with-publishing.md
+++ b/millicast/playback/players-sdks/ios/sdk/getting-started-with-publishing.md
@@ -75,7 +75,7 @@ let publisher = MCPublisher(delegate: publisherDelegate)
 
 ### 2.2 Set publisher credentials
 
-Create a stream in your Dolby.io developer dashboard or using the Dolby.io Streaming REST API. Then, set the credentials from the dashboard. All of the [MCPublisher](https://millicast.github.io/doc/latest/apple/documentation/millicastsdk/mcpublisher) APIs are asynchronous, so call them from asynchronous contexts.
+Create a stream in your OptiView Streaming Dashboard or using the OptiView Real-time Streaming REST API. Then, set the credentials from the dashboard. All of the [MCPublisher](https://millicast.github.io/doc/latest/apple/documentation/millicastsdk/mcpublisher) APIs are asynchronous, so call them from asynchronous contexts.
 
 ```swift
 // Get the credentials structure from your publisher instance, fill it in,

--- a/millicast/playback/players-sdks/ios/sdk/getting-started-with-subscribing.md
+++ b/millicast/playback/players-sdks/ios/sdk/getting-started-with-subscribing.md
@@ -44,7 +44,7 @@ Get your **stream name** and **stream ID** from the dashboard and set them up in
 ```swift
 let credentials = MCSubscriberCredentials()
 credentials.streamName =  "STREAM_NAME"; // The name of the stream you want to subscribe to
-credentials.accountId = "ACCOUNT_ID"; // The ID of your Dolby.io Real-time Streaming account
+credentials.accountId = "ACCOUNT_ID"; // The ID of your OptiView Real-time Streaming account
 credentials.apiUrl = "https://director.millicast.com/api/director/subscribe"; // The subscribe API URL
 
 try await subscriber.setCredentials(credentials)

--- a/millicast/playback/players-sdks/ios/sdk/index.mdx
+++ b/millicast/playback/players-sdks/ios/sdk/index.mdx
@@ -3,7 +3,7 @@ title: Millicast SDK
 sidebar_position: 2
 ---
 
-The Native SDK for creating iOS and tvOS applications. You may use it to connect, capture, publish, or subscribe to streams using the Dolby.io Streaming Platform.
+The Native SDK for creating iOS and tvOS applications. You may use it to connect, capture, publish, or subscribe to streams using the OptiView Real-time Streaming Platform.
 
 :::caution Player vs SDK
 **Dolby OptiView Player** (formerly THEOplayer) now supports real-time streaming (formerly Millicast). Unless directed by your onboarding team, please use the [Dolby OptiView Player](../player/index.mdx) and not the Millicast SDKs.
@@ -61,7 +61,7 @@ If you want to use Streaming APIs on Android and iOS, you can also use the [Flut
 
 ## Requirements
 
-- [Dolby.io account](https://streaming.dolby.io)
+- [OptiView Real-time account](https://streaming.dolby.io)
 - A working video camera and microphone
 - iOS [14.5](https://support.apple.com/en-us/HT211808) or later
 - Client SDK [1.8.0](https://github.com/millicast/millicast-native-sdk/releases) or later

--- a/millicast/playback/players-sdks/react-native/index.mdx
+++ b/millicast/playback/players-sdks/react-native/index.mdx
@@ -4,7 +4,7 @@ slug: /playback/players-sdks/react-native
 sidebar_position: 4
 ---
 
-Dolby.io Streaming APIs support using the [Web SDK](/millicast/playback/players-sdks/web/sdk/index.mdx) with React Native WebRTC to support creating iOS, Android, AndroidTV, and tvOS applications.
+OptiView Real-time Streaming APIs support using the [Web SDK](/millicast/playback/players-sdks/web/sdk/index.mdx) with React Native WebRTC to support creating iOS, Android, AndroidTV, and tvOS applications.
 
 import ThreeCardList from '@site/src/components/ThreeCardList';
 
@@ -167,7 +167,7 @@ android.enableDexingArtifactTransform.desugaring=false
 
 ### Examples
 
-Prior to using the viewer and publisher examples, you have to get your tokens. Use the [this guide](/millicast/streaming-dashboard/managing-your-tokens.mdx) to manage your Dolby.io Real-time Streaming tokens.
+Prior to using the viewer and publisher examples, you have to get your tokens. Use the [this guide](/millicast/streaming-dashboard/managing-your-tokens.mdx) to manage your OptiView Real-time Streaming tokens.
 
 In your App.js file, decide whether you want to test a viewer or publisher based on your needs.
 

--- a/millicast/playback/players-sdks/viewer-events.md
+++ b/millicast/playback/players-sdks/viewer-events.md
@@ -4,13 +4,13 @@ slug: /playback/players-sdks/viewer-events
 sidebar_position: 100
 ---
 
-Dolby.io Real-time Streaming supports `broadcastEvents`, sometimes called _viewer events_, which allow you to add functionality that triggers when various events occur during the stream. This functionality can be helpful for detecting active feeds, changes in simulcast layers, or even the viewer count of a stream.
+OptiView Real-time Streaming supports `broadcastEvents`, sometimes called _viewer events_, which allow you to add functionality that triggers when various events occur during the stream. This functionality can be helpful for detecting active feeds, changes in simulcast layers, or even the viewer count of a stream.
 
 This guide outlines what events are available and how to use them for your app or platform.
 
 ## List of events
 
-Currently, there are several events that can be listened to when connected to the Dolby.io Millicast Viewer:
+Currently, there are several events that can be listened to when connected to the OptiView Viewer:
 
 - `active`: Fires when a live stream is or has started broadcasting.
 - `inactive`: Triggers when the stream has stopped broadcasting but is still connected to the publisher.
@@ -24,10 +24,10 @@ Currently, there are several events that can be listened to when connected to th
 ## Using events
 
 :::tip Not familiar with our SDKs?
-Learn more about the Dolby.io Millicast streaming SDKs by following the [Getting Started](/millicast/getting-started/creating-real-time-streaming-web-app.mdx) guide or by learning about our [Client SDKs](/millicast/playback/players-sdks/index.mdx).
+Learn more about the OptiView Real-time streaming SDKs by following the [Getting Started](/millicast/getting-started/creating-real-time-streaming-web-app.mdx) guide or by learning about our [Client SDKs](/millicast/playback/players-sdks/index.mdx).
 :::
 
-To use or "listen" for these events, you first must authenticate and connect to the Dolby.io CDN using one of our [Client SDKs](/millicast/playback/players-sdks/index.mdx). When calling the `connect` function you can include a list of all events to listen for:
+To use or "listen" for these events, you first must authenticate and connect to the OptiView Real-time CDN using one of our [Client SDKs](/millicast/playback/players-sdks/index.mdx). When calling the `connect` function you can include a list of all events to listen for:
 
 ```javascript
 import { Director, View } from '@millicast/sdk';

--- a/millicast/playback/players-sdks/web/samples/sample-apps-react.mdx
+++ b/millicast/playback/players-sdks/web/samples/sample-apps-react.mdx
@@ -16,7 +16,7 @@ import ViewerImg from '../../../../assets/img/01.00.00_Viewer_Documentation_1200
   <img src={ViewerImg} width="800" />
 </div>
 
-The application available in this repository demonstrates the capabilities of OptiView Real-time Streaming solution for browser applications, built using React.
+The application available in this repository demonstrates the capabilities of the OptiView Real-time Streaming solution for browser applications, built using React.
 
 import DocCard from '@theme/DocCard';
 
@@ -32,9 +32,9 @@ import DocCard from '@theme/DocCard';
   }}
 />
 
-This repository demonstrates how to develop an app that showcases the capabilities of OptiView Real-time Streaming SDK and how it can be used to design solutions that require ultra low-latency (sub 500ms).
+This repository demonstrates how to develop an app that showcases the capabilities of the OptiView Real-time Streaming SDK and how it can be used to design solutions that require ultra low-latency (sub 500ms).
 
-The application provided allows you to evaluate solutions offered by OptiView Real-time Streaming APIs. You can clone the repository yourself, run the application locally and verify that it meets your requirements. Learn more about Dolby.io’s Real-time Streaming capabilities [here](https://optiview.dolby.com/solutions/real-time-streaming/).
+The application provided allows you to evaluate solutions offered by OptiView Real-time Streaming APIs. You can clone the repository yourself, run the application locally and verify that it meets your requirements. Learn more about OptiView Real-time Streaming capabilities [here](https://optiview.dolby.com/solutions/real-time-streaming/).
 
 The application allows you to publish from up to four sources, including more than one camera on the Millicast Publisher. You will have fine grained control over each stream's configuration, which includes bitrate and resolution settings, where applicable. The application also allows you to view multiple sources on the Millicast Viewer, and view stream statistics for each source individually.
 

--- a/millicast/playback/players-sdks/web/samples/sample-apps-react.mdx
+++ b/millicast/playback/players-sdks/web/samples/sample-apps-react.mdx
@@ -16,7 +16,7 @@ import ViewerImg from '../../../../assets/img/01.00.00_Viewer_Documentation_1200
   <img src={ViewerImg} width="800" />
 </div>
 
-The application available in this repository demonstrates the capabilities of Dolby.io's Real-time Streaming solution for browser applications, built using React.
+The application available in this repository demonstrates the capabilities of OptiView Real-time Streaming solution for browser applications, built using React.
 
 import DocCard from '@theme/DocCard';
 
@@ -32,9 +32,9 @@ import DocCard from '@theme/DocCard';
   }}
 />
 
-This repository demonstrates how to develop an app that showcases the capabilities of Dolby.io's Real-time Streaming SDK and how it can be used to design solutions that require ultra low-latency (sub 500ms).
+This repository demonstrates how to develop an app that showcases the capabilities of OptiView Real-time Streaming SDK and how it can be used to design solutions that require ultra low-latency (sub 500ms).
 
-The application provided allows you to evaluate solutions offered by Dolby.io Real-time Streaming APIs. You can clone the repository yourself, run the application locally and verify that it meets your requirements. Learn more about Dolby.io’s Real-time Streaming capabilities [here](https://optiview.dolby.com/solutions/real-time-streaming/).
+The application provided allows you to evaluate solutions offered by OptiView Real-time Streaming APIs. You can clone the repository yourself, run the application locally and verify that it meets your requirements. Learn more about Dolby.io’s Real-time Streaming capabilities [here](https://optiview.dolby.com/solutions/real-time-streaming/).
 
 The application allows you to publish from up to four sources, including more than one camera on the Millicast Publisher. You will have fine grained control over each stream's configuration, which includes bitrate and resolution settings, where applicable. The application also allows you to view multiple sources on the Millicast Viewer, and view stream statistics for each source individually.
 

--- a/millicast/playback/players-sdks/web/sdk/index.mdx
+++ b/millicast/playback/players-sdks/web/sdk/index.mdx
@@ -159,7 +159,7 @@ The `connect()` can optionally receive more parameters, all of these are describ
 For example:
 
 - If you want to start your stream with a bitrate limit, you can use the `bandwidth` option.
-- If your stream token in Dolby.io Real-time Streaming has the recording enabled, you can enable it with the `record` option. Once you have finished your stream, you can see the recording in the [Dashboard Recordings section](/millicast/distribution/stream-recordings/index.mdx).
+- If your stream token in OptiView Real-time Streaming has the recording enabled, you can enable it with the `record` option. Once you have finished your stream, you can see the recording in the [Dashboard Recordings section](/millicast/distribution/stream-recordings/index.mdx).
 - You can start a stream without audio or video setting the `disableAudio` or `disableVideo` respectively.
 - You can select which codec you want to stream using the `codec` option [Check Browser Capabilities](#check-browser-capabilities).
 

--- a/millicast/playback/securing-stream-playback.md
+++ b/millicast/playback/securing-stream-playback.md
@@ -14,7 +14,7 @@ To secure broadcast playback, you need to enable the **Secure Viewer** setting w
 
 Subscribe tokens are used to authenticate access to a "Secure stream". When enabled, streams that require a Subscribe token will block access to users not in possession of a valid token coming from a valid domain. Subscribe tokens also allow you to add time limits, specify IPs, and even set the token to only work from single or multiple specified domains. Even though restricting access to streamed content in selected geo-locations is possible using the publish token, the subscribe token lets you add additional geo-blocking rules.
 
-To create a Subscribe token, follow the[ Creating a Subscribe Token guide](/millicast/streaming-dashboard/subscribe-tokens.mdx), which outlines how to create a token in the OptiView Streaming Dashboard, or the [Token API](/millicast/streaming-dashboard/token-api.mdx) guide which outlines how to create tokens programmatically. Once created, your token will be a string of alphanumeric characters looking something like the following:
+To create a Subscribe token, follow the[ Creating a Subscribe Token guide](/millicast/streaming-dashboard/subscribe-tokens.mdx), which outlines how to create a token in the OptiView Real-time Streaming Dashboard, or the [Token API](/millicast/streaming-dashboard/token-api.mdx) guide which outlines how to create tokens programmatically. Once created, your token will be a string of alphanumeric characters looking something like the following:
 
 `fff04a5a1c02b2b8d48a9133e8461985aa482066cc3e9ed487baaac89588e26f`
 

--- a/millicast/playback/securing-stream-playback.md
+++ b/millicast/playback/securing-stream-playback.md
@@ -4,7 +4,7 @@ slug: /playback/securing-stream-playback
 sidebar_position: 2
 ---
 
-[Securing the playback of your Broadcast](/millicast/streaming-dashboard/managing-your-tokens.mdx#create-a-publish-token) is one of the most important features provided by the Dolby.io platform. Although securing your stream is _optional_, it is **highly recommended** for broadcasts that are non-public or paywalled.
+[Securing the playback of your Broadcast](/millicast/streaming-dashboard/managing-your-tokens.mdx#create-a-publish-token) is one of the most important features provided by the OptiView Real-time platform. Although securing your stream is _optional_, it is **highly recommended** for broadcasts that are non-public or paywalled.
 
 To view a secured stream you first need to create a Subscribe token. With your Subscribe token in hand, you can then use it to authenticate a connection and view the broadcast. This guide outlines [how to create a token](/millicast/playback/securing-stream-playback.md#creating-a-subscribe-token-to-playback-a-secure-stream) and [how to view a secure stream](/millicast/playback/securing-stream-playback.md#viewing-a-secured-stream).
 
@@ -14,7 +14,7 @@ To secure broadcast playback, you need to enable the **Secure Viewer** setting w
 
 Subscribe tokens are used to authenticate access to a "Secure stream". When enabled, streams that require a Subscribe token will block access to users not in possession of a valid token coming from a valid domain. Subscribe tokens also allow you to add time limits, specify IPs, and even set the token to only work from single or multiple specified domains. Even though restricting access to streamed content in selected geo-locations is possible using the publish token, the subscribe token lets you add additional geo-blocking rules.
 
-To create a Subscribe token, follow the[ Creating a Subscribe Token guide](/millicast/streaming-dashboard/subscribe-tokens.mdx), which outlines how to create a token in the Dolby.io dashboard, or the [Token API](/millicast/streaming-dashboard/token-api.mdx) guide which outlines how to create tokens programmatically. Once created, your token will be a string of alphanumeric characters looking something like the following:
+To create a Subscribe token, follow the[ Creating a Subscribe Token guide](/millicast/streaming-dashboard/subscribe-tokens.mdx), which outlines how to create a token in the OptiView Streaming Dashboard, or the [Token API](/millicast/streaming-dashboard/token-api.mdx) guide which outlines how to create tokens programmatically. Once created, your token will be a string of alphanumeric characters looking something like the following:
 
 `fff04a5a1c02b2b8d48a9133e8461985aa482066cc3e9ed487baaac89588e26f`
 
@@ -24,12 +24,12 @@ With your token in hand, proceed to [Viewing a Secured Stream](/millicast/playba
 
 There are **two** main ways you can use the Subscribe token:
 
-1. To view a stream via the [Dolby.io Hosted Viewer](/millicast/playback/hosted-player/index.md).
+1. To view a stream via the [OptiView Hosted Viewer](/millicast/playback/hosted-player/index.md).
 2. To view a stream via your own streaming app.
 
 ### Viewing a secured stream with the hosted viewer
 
-[Playing back with the Hosted Viewer](/millicast/playback/hosted-player/index.md) is a common way to test the Dolby.io platform. If you haven't already tested out the Hosted Viewer it is recommended you explore the [Hosted Viewer Playback guide](/millicast/playback/hosted-player/index.md).
+[Playing back with the Hosted Viewer](/millicast/playback/hosted-player/index.md) is a common way to test the OptiView Real-time platform. If you haven't already tested out the Hosted Viewer it is recommended you explore the [Hosted Viewer Playback guide](/millicast/playback/hosted-player/index.md).
 
 When an **unsecured** stream is live, you'll be able to view the broadcast at:
 
@@ -65,7 +65,7 @@ For both the Embedded Viewer and the Hosted Viewer the Subscribe token is expose
 
 #### Viewing a secured stream with the embedded viewer
 
-You can also embed the Dolby.io Hosted Viewer into your webpage as an `<iframe></iframe>`. To secure the embedded viewer, include the Subscribe token in the iframe:
+You can also embed the OptiView Hosted Viewer into your webpage as an `<iframe></iframe>`. To secure the embedded viewer, include the Subscribe token in the iframe:
 
 ```html
 <iframe
@@ -86,7 +86,7 @@ Whilst using the Hosted Viewer is a great option, you may have noticed the Subsc
 > `https://viewer.millicast.com?streamId=DevAcc/WorldCup2023&token=fff04a5a1c02b2b8d48a9133e84619889588e26f`  
 > which she uses to join the stream.
 >
-> Because this token has [Binds IP on Usage](/millicast/distribution/access-control/allowed-origins.md#bind-ip-on-usage) enabled and set to bind to the first IP address, her IP address is saved by the Dolby.io CDN. If Angelik were to then share the URL to Jayson, he would be unable to join the stream since his IP address doesn't match Angelik's.
+> Because this token has [Binds IP on Usage](/millicast/distribution/access-control/allowed-origins.md#bind-ip-on-usage) enabled and set to bind to the first IP address, her IP address is saved by the OptiView Real-time CDN. If Angelik were to then share the URL to Jayson, he would be unable to join the stream since his IP address doesn't match Angelik's.
 >
 > If Angelik were to leave the stream and return an hour later, she would still be able to join the stream because her IP address is associated with the token.
 
@@ -94,8 +94,8 @@ To learn more about other access control features you can enable for your Subscr
 
 ### Viewing secure streams with your own viewer app
 
-:::tip Building with the Dolby.io SDKs for the first time?
-Check out the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial for a quick and easy introduction to using the Dolby.io SDKs and platform.
+:::tip Building with the OptiView Real-time SDKs for the first time?
+Check out the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial for a quick and easy introduction to using the OptiView Real-time SDKs and platform.
 :::
 
 To view a secure stream in your own viewer app, you'll need to create a Subscribe token. Depending on the size of your platform, you may want to create these tokens programmatically using a token server and the [Token APIs](/millicast/streaming-dashboard/token-api.mdx). This part of the guide gives an example of how to programmatically create a Subscribe token, and how to use it to authenticate a connection to a viewer.
@@ -127,7 +127,7 @@ async function getToken(streamName, apiSecretKey) {
 
 Creating Subscribe tokens **should take place on a secure server, not in the client-side application**. You should create a "Token Server", which serves a Subscribe token to the client-side application, which uses it to connect.
 
-In this case, for demonstration purposes, `getToken` function will return a Subscribe token, which can then be used for authenticating a connection to Dolby.io along with the `streamName` and the `accID`.
+In this case, for demonstration purposes, `getToken` function will return a Subscribe token, which can then be used for authenticating a connection to OptiView Real-time Streaming along with the `streamName` and the `accID`.
 
 ```javascript
 const response = await getToken(streamName, apiSecretKey);

--- a/millicast/playback/source-and-layer-selection.md
+++ b/millicast/playback/source-and-layer-selection.md
@@ -4,9 +4,9 @@ slug: /playback/source-and-layer-selection
 sidebar_position: 3
 ---
 
-Dolby.io supports ingesting [Multi-source Streams](/millicast/broadcast/multi-source-broadcasting.mdx) and rendering multiple audio and video streams for building [Multi-view](multi-view.md) and [Audio Multiplexing](audio-multiplexing.md) experiences.
+OptiView Real-time Streaming supports ingesting [Multi-source Streams](/millicast/broadcast/multi-source-broadcasting.mdx) and rendering multiple audio and video streams for building [Multi-view](multi-view.md) and [Audio Multiplexing](audio-multiplexing.md) experiences.
 
-To get started building multi-stream experiences it's important to understand how Dolby.io handles multi-source playback. This guide outlines:
+To get started building multi-stream experiences it's important to understand how OptiView Real-time Streaming handles multi-source playback. This guide outlines:
 
 - [How to manage source selection](#managing-source-selection)
 - [How to project feeds](#projecting-feeds)
@@ -19,10 +19,10 @@ To get started building multi-stream experiences it's important to understand ho
 To manage multiple sources, you first must have a [Multi-source Stream](/millicast/broadcast/multi-source-broadcasting.mdx) broadcasting.
 :::
 
-Dolby.io streaming supports scalable WebRTC streaming thanks to a "smart" cascading node system that manages the peer-to-peer connections. These nodes are key to understanding how to manage multiple sources for playback and can be divided into two types:
+OptiView Real-time Streaming supports scalable WebRTC streaming thanks to a "smart" cascading node system that manages the peer-to-peer connections. These nodes are key to understanding how to manage multiple sources for playback and can be divided into two types:
 
 - **Publisher nodes**: These nodes manage [the ingest of multiple sources](/millicast/broadcast/multi-source-broadcasting.mdx) during the broadcast. They can then forward these feeds to the CDN for the Viewer node to manage.
-- **Viewer nodes**: Viewer nodes are created depending on the quantity and location of viewers, allowing Dolby.io to support large-scale global streams. When rendering streams in your app or platform, you can communicate with the viewer node to negotiate what feeds to project and simulcast layers to receive.
+- **Viewer nodes**: Viewer nodes are created depending on the quantity and location of viewers, allowing OptiView Real-time Streaming to support large-scale global streams. When rendering streams in your app or platform, you can communicate with the viewer node to negotiate what feeds to project and simulcast layers to receive.
 
 When the publisher node has a feed ready to be passed to a viewer node, it triggers a [broadcastEvent](/millicast/playback/players-sdks/viewer-events.md). This event can be listened to by taking the [millicast.View](https://millicast.github.io/millicast-sdk/View.html) object and [adding an event listener](/millicast/playback/players-sdks/viewer-events.md#using-events) to it:
 
@@ -95,10 +95,10 @@ viewer.unproject([videoTransceiver.mid]);
 ## Media layer forwarding
 
 :::tip Simulcast or SVC layer forwarding
-By default, the Dolby.io Real-time Streaming server chooses the best Simulcast or SVC layer to forward to the viewer based on the bandwidth estimation calculated by the server.
+By default, the OptiView Real-time Streaming server chooses the best Simulcast or SVC layer to forward to the viewer based on the bandwidth estimation calculated by the server.
 :::
 
-In addition to selecting the origin source for the media, it is also possible to choose a specific [Simulcast](/millicast/distribution/using-webrtc-simulcast) or SVC layer for each video track delivered by the Dolby.io Real-time Streaming server. You can do it either by specifying the `layer` attribute on the [project](https://millicast.github.io/millicast-sdk/View.html#project) command or using the [select](https://millicast.github.io/millicast-sdk/View.html#select) command for the main video track:
+In addition to selecting the origin source for the media, it is also possible to choose a specific [Simulcast](/millicast/distribution/using-webrtc-simulcast) or SVC layer for each video track delivered by the OptiView Real-time Streaming server. You can do it either by specifying the `layer` attribute on the [project](https://millicast.github.io/millicast-sdk/View.html#project) command or using the [select](https://millicast.github.io/millicast-sdk/View.html#select) command for the main video track:
 
 ```javascript title="Projecting with layer selection using project"
 viewer.project('mysource', [
@@ -132,7 +132,7 @@ millicastView.select({ encodingId: '1' });
 Where `millicastView` is the instance of the [View](https://millicast.github.io/millicast-sdk/View.html) class and `encodingId` is the field of the layer that you wan to force.
 
 :::info Track limits for viewer
-Dolby.io Real-time Streaming does not limit the number of tracks that a viewer can receive; it limits the maximum bitrate per viewer to a maximum of 12 Mbps across all media tracks. You should configure the Simulcast or SVC bitrate of all the sources carefully within your applications so they can receive the desired amount of video tracks in the viewer session.
+OptiView Real-time Streaming does not limit the number of tracks that a viewer can receive; it limits the maximum bitrate per viewer to a maximum of 12 Mbps across all media tracks. You should configure the Simulcast or SVC bitrate of all the sources carefully within your applications so they can receive the desired amount of video tracks in the viewer session.
 :::
 
 ### Managing layers

--- a/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx
+++ b/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx
@@ -13,7 +13,7 @@ import LiveBroadcast from '../assets/img/live-broadcast.png';
 </div>
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a Dolby.io application and start your first broadcast.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast.
 
 You can follow the steps in [Part 1](/millicast/getting-started/using-the-dashboard.mdx) to learn how to use the [Live Broadcast](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx) and [Hosted Viewer](/millicast/playback/hosted-player/index.md).
 :::
@@ -183,7 +183,7 @@ import AudioImg from '../assets/img/d6e73a5-Capture_decran_2023-07-29_a_4.55.29_
 
 <img src={AudioImg} width="120" />
 
-This feature enabled stereo audio with your Dolby.io Real-time Streaming streams, however, stereo-enabled microphone is required.In addition, echo cancellation must be disabled while using the stereo setting. Doing this may cause an audio feedback loop so it is best practice to use headphones while listening to your stream to prevent echo.
+This feature enabled stereo audio with your OptiView Real-time Streaming streams, however, stereo-enabled microphone is required.In addition, echo cancellation must be disabled while using the stereo setting. Doing this may cause an audio feedback loop so it is best practice to use headphones while listening to your stream to prevent echo.
 
 ### Picture-in-picture
 

--- a/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx
+++ b/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx
@@ -13,7 +13,7 @@ import LiveBroadcast from '../assets/img/live-broadcast.png';
 </div>
 
 :::tip Getting Started
-If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create a OptiView Real-time application and start your first broadcast.
+If you haven't already, begin by following the [Getting Started](/millicast/introduction-to-streaming-apis.mdx) tutorial to create an OptiView Real-time application and start your first broadcast.
 
 You can follow the steps in [Part 1](/millicast/getting-started/using-the-dashboard.mdx) to learn how to use the [Live Broadcast](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx) and [Hosted Viewer](/millicast/playback/hosted-player/index.md).
 :::

--- a/millicast/streaming-dashboard/index.mdx
+++ b/millicast/streaming-dashboard/index.mdx
@@ -3,7 +3,7 @@ title: 'Streaming Dashboard'
 slug: /about-dash
 ---
 
-The Dolby.io dashboard enables you to easily provision tokens, broadcast streams, and manage account settings.
+The OptiView Streaming Dashboard enables you to easily provision tokens, broadcast streams, and manage account settings.
 
 <div className="youtube-container">
   <iframe
@@ -29,7 +29,7 @@ import TokensMainLiveBroadcast from '../assets/img/tokens-main-live-broadcast.pn
 
 ## Broadcaster
 
-The broadcaster interface allows you to stream instantly from your account and gives you a link to share with your viewers. Your video is streamed via WebRTC to the Dolby.io Real-time Streaming service, which globally distributes the feed to all of your viewers with sub-second latency. For more information on how to navigate this interface, go to the [Live Broadcast Dashboard](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx) guide.
+The broadcaster interface allows you to stream instantly from your account and gives you a link to share with your viewers. Your video is streamed via WebRTC to the OptiView Real-time Streaming service, which globally distributes the feed to all of your viewers with sub-second latency. For more information on how to navigate this interface, go to the [Live Broadcast Dashboard](/millicast/streaming-dashboard/how-to-broadcast-in-dashboard.mdx) guide.
 
 import NewPublisher from '../assets/img/newpublisher.png';
 
@@ -133,7 +133,7 @@ The analytic information in this area has an access window of 7 days, after that
 
 ## Webhooks
 
-Webhooks are callbacks triggered by the platform to notify your application when an event occurs. As an alternative to polling solutions built with the [REST API](/millicast/api/webhooks-get.api.mdx), you can build asynchronous services and integrations that react only when real-time notifications are pushed from the Dolby.io platform to your application. For how to create a webhook, [check out its guide](/millicast/webhooks/index.mdx).
+Webhooks are callbacks triggered by the platform to notify your application when an event occurs. As an alternative to polling solutions built with the [REST API](/millicast/api/webhooks-get.api.mdx), you can build asynchronous services and integrations that react only when real-time notifications are pushed from the OptiView Real-time platform to your application. For how to create a webhook, [check out its guide](/millicast/webhooks/index.mdx).
 
 import DashWebhooks from '../assets/img/dashboard-webhooks.png';
 
@@ -151,7 +151,7 @@ import Billing1 from '../assets/img/billing_1.png';
   <img src={Billing1} width="600" />
 </div>
 
-Dolby.io Real-time Streaming plans include a monthly bandwidth allotment and a per GiB fee for bandwidth used over the amount included with your plan. Here you can see how much bandwidth you have used for your current billing cycle.
+OptiView Real-time Streaming plans include a monthly bandwidth allotment and a per GiB fee for bandwidth used over the amount included with your plan. Here you can see how much bandwidth you have used for your current billing cycle.
 
 import AcctBw from '../assets/img/a3a3e63-acct-bw.png';
 
@@ -181,7 +181,7 @@ import DashProfile from '../assets/img/dashboard-profile.png';
 
 Inside _Settings_, the account's _Token defaults_ are managed. Changes here are permanent across any existing and new tokens. Alternatively, you can alter [Geo-blocking](/millicast/distribution/access-control/geo-blocking.mdx) and [Cluster Regions](/millicast/distribution/multi-region-support/index.mdx) on a token-by-token basis instead of an account-wide change.
 
-On the _Security_ tab, users can create one or multiple API secrets to connect to [Dolby.io's Streaming API](/millicast/api/analytics-account-total/).
+On the _Security_ tab, users can create one or multiple API secrets to connect to [OptiView's Streaming API](/millicast/api/analytics-account-total/).
 
 import DashSettings from '../assets/img/dashboard-settings.png';
 
@@ -191,7 +191,7 @@ import DashSettings from '../assets/img/dashboard-settings.png';
 
 ## Users
 
-As a developer platform, we understand that you might not be working alone; therefore, **Users** allows you to add additional developers that might need access to the working streams. These users are managed across all of the Dolby.io platforms, meaning the invited **would also have access to the Media APIs**.
+As a developer platform, we understand that you might not be working alone; therefore, **Users** allows you to add additional developers that might need access to the working streams. These users are managed across all of the OptiView platforms, meaning the invited **would also have access to the Media APIs**.
 
 import DashUsers from '../assets/img/dashboard-users.png';
 
@@ -201,7 +201,7 @@ import DashUsers from '../assets/img/dashboard-users.png';
 
 ## Resources
 
-The Resources section of the dashboard is reserved as the space for tutorials, documentation, and examples which might serve as useful in exploring all of the integrations and SDKs. Additionally, it links to Dolby.io's WebRTC version of OBS. If you are beginning your journey, start your first stream with our [Getting Started](/millicast/introduction-to-streaming-apis.mdx) guide.
+The Resources section of the dashboard is reserved as the space for tutorials, documentation, and examples which might serve as useful in exploring all of the integrations and SDKs. Additionally, it links to the WebRTC version of OBS. If you are beginning your journey, start your first stream with our [Getting Started](/millicast/introduction-to-streaming-apis.mdx) guide.
 
 import DashResources from '../assets/img/dashboard-resources.png';
 
@@ -211,7 +211,7 @@ import DashResources from '../assets/img/dashboard-resources.png';
 
 ## Two-factor authentication
 
-Two-factor authentication provides an extra layer of security and helps to ensure only an authorized user has access to your account, even if the account password is exposed. The second factor of authentication is provided by a 3rd party authenticator application ([IOS](https://apps.apple.com/us/app/microsoft-authenticator/id983156458), [Android](https://play.google.com/store/apps/details?id=com.azure.authenticator)), which generates a single-use verification code. The two-factor authentication user will need to provide this code in order to log into the Dolby.io dashboard.
+Two-factor authentication provides an extra layer of security and helps to ensure only an authorized user has access to your account, even if the account password is exposed. The second factor of authentication is provided by a 3rd party authenticator application ([IOS](https://apps.apple.com/us/app/microsoft-authenticator/id983156458), [Android](https://play.google.com/store/apps/details?id=com.azure.authenticator)), which generates a single-use verification code. The two-factor authentication user will need to provide this code in order to log into the OptiView Streaming Dashboard.
 
 import TwoFaLoginCode from '../assets/img/2fa-login-code.png';
 
@@ -219,7 +219,7 @@ import TwoFaLoginCode from '../assets/img/2fa-login-code.png';
   <img src={TwoFaLoginCode} width="400" />
 </div>
 
-To enable this feature, navigate to the _Logging in_ section of the Dolby.io dashboard by clicking on your name in the top right corner and selecting _Profile_. Click Set Up to activate the two-factor authentication service. This button will take you through the setup process needed to register your authenticator application.
+To enable this feature, navigate to the _Logging in_ section of the OptiView Streaming Dashboard by clicking on your name in the top right corner and selecting _Profile_. Click Set Up to activate the two-factor authentication service. This button will take you through the setup process needed to register your authenticator application.
 
 import AcctButton from '../assets/img/8d27f2e-2fa_accnt_button.png';
 

--- a/millicast/streaming-dashboard/index.mdx
+++ b/millicast/streaming-dashboard/index.mdx
@@ -3,7 +3,7 @@ title: 'Streaming Dashboard'
 slug: /about-dash
 ---
 
-The OptiView Streaming Dashboard enables you to easily provision tokens, broadcast streams, and manage account settings.
+The OptiView Real-time Streaming Dashboard enables you to easily provision tokens, broadcast streams, and manage account settings.
 
 <div className="youtube-container">
   <iframe
@@ -211,7 +211,7 @@ import DashResources from '../assets/img/dashboard-resources.png';
 
 ## Two-factor authentication
 
-Two-factor authentication provides an extra layer of security and helps to ensure only an authorized user has access to your account, even if the account password is exposed. The second factor of authentication is provided by a 3rd party authenticator application ([IOS](https://apps.apple.com/us/app/microsoft-authenticator/id983156458), [Android](https://play.google.com/store/apps/details?id=com.azure.authenticator)), which generates a single-use verification code. The two-factor authentication user will need to provide this code in order to log into the OptiView Streaming Dashboard.
+Two-factor authentication provides an extra layer of security and helps to ensure only an authorized user has access to your account, even if the account password is exposed. The second factor of authentication is provided by a 3rd party authenticator application ([IOS](https://apps.apple.com/us/app/microsoft-authenticator/id983156458), [Android](https://play.google.com/store/apps/details?id=com.azure.authenticator)), which generates a single-use verification code. The two-factor authentication user will need to provide this code in order to log into the OptiView Real-time Streaming Dashboard.
 
 import TwoFaLoginCode from '../assets/img/2fa-login-code.png';
 
@@ -219,7 +219,7 @@ import TwoFaLoginCode from '../assets/img/2fa-login-code.png';
   <img src={TwoFaLoginCode} width="400" />
 </div>
 
-To enable this feature, navigate to the _Logging in_ section of the OptiView Streaming Dashboard by clicking on your name in the top right corner and selecting _Profile_. Click Set Up to activate the two-factor authentication service. This button will take you through the setup process needed to register your authenticator application.
+To enable this feature, navigate to the _Logging in_ section of the OptiView Real-time Streaming Dashboard by clicking on your name in the top right corner and selecting _Profile_. Click Set Up to activate the two-factor authentication service. This button will take you through the setup process needed to register your authenticator application.
 
 import AcctButton from '../assets/img/8d27f2e-2fa_accnt_button.png';
 

--- a/millicast/streaming-dashboard/managing-your-tokens.mdx
+++ b/millicast/streaming-dashboard/managing-your-tokens.mdx
@@ -4,7 +4,7 @@ slug: /managing-your-tokens
 sidebar_position: 1
 ---
 
-To [broadcast](/millicast/broadcast/index.mdx) a real-time stream the connection must be authenticated with a valid **publish token**. The Dolby.io platform uses token authentication for publishing to prevent unauthorized distribution of streaming content from your Dolby.io account. Without a valid token, publish requests will be rejected by the servers.
+To [broadcast](/millicast/broadcast/index.mdx) a real-time stream the connection must be authenticated with a valid **publish token**. The OptiView Real-time platform uses token authentication for publishing to prevent unauthorized distribution of streaming content from your OptiView Real-time account. Without a valid token, publish requests will be rejected by the servers.
 
 This guide outlines the following:
 
@@ -19,7 +19,7 @@ To restrict who may _view_ a stream, you would use a separate [subscribe token](
 
 ## Create a publish token
 
-Log into your [Dolby.io Streaming Account](https://dashboard.dolby.io/signin) and select **Live Broadcast** from the left menu. This is where you can view and manage all of your _Publish tokens_.
+Log into your [OptiView Real-time Streaming Account](https://dashboard.dolby.io/signin) and select **Live Broadcast** from the left menu. This is where you can view and manage all of your _Publish tokens_.
 
 import TokenMain from '../assets/img/tokens-main.png';
 
@@ -153,9 +153,9 @@ The publishing tab includes all information relating to [broadcasting](/millicas
   - RTMP multi-bitrate can be enabled from this section. When enabled, the dashboard will create three RTMP publish stream names for **low** bitrate, **medium** bitrate, and **high** bitrate.
 - [SRT](/millicast/broadcast/srt.mdx): The _SRT publish path_, _SRT stream ID_, and _SRT publish URL_ can be used for publishing with SRT-compatible software and hardware.
   - Passphrase encryption can be enabled from this section. When enabled, the dashboard will generate a passphrase for encrypting the SRT stream.
-- Publish token: The _Publishing token_ and _Stream name_ can be used to authenticate and start a broadcast from the [Dolby.io Streaming Client SDKs](/millicast/playback/players-sdks/index.mdx) or compatible [software](../broadcast/software-encoders/index.mdx) and [hardware encoders](../broadcast/hardware-encoders/index.mdx).
+- Publish token: The _Publishing token_ and _Stream name_ can be used to authenticate and start a broadcast from the [OptiView Real-time Streaming Client SDKs](/millicast/playback/players-sdks/index.mdx) or compatible [software](../broadcast/software-encoders/index.mdx) and [hardware encoders](../broadcast/hardware-encoders/index.mdx).
 
-To learn more about publishing and broadcasting with Dolby.io, check out the [Broadcast](/millicast/broadcast/index.mdx) guide, which provides more in-depth resources and examples on how to use the Publish token once it is created.
+To learn more about publishing and broadcasting with OptiView Real-time Streaming, check out the [Broadcast](/millicast/broadcast/index.mdx) guide, which provides more in-depth resources and examples on how to use the Publish token once it is created.
 
 ### 4\. Distribution
 
@@ -166,7 +166,7 @@ The Distribution tab includes settings that can modify how the CDN distributes t
 
 ### 5\. Playback
 
-The Playback tab includes all relevant information for playing back a live stream. Dolby.io provides an [out-of-the-box hosted player experience](https://viewer.millicast.com/?streamId=k9Mwad/multiview&multisource=true), which can be viewed at the **Hoster player path** URL or by embedding the **Hosted embedded player** as an `<iframe>` into your webpage.
+The Playback tab includes all relevant information for playing back a live stream. OptiView Real-time Streaming provides an [out-of-the-box hosted player experience](https://viewer.millicast.com/?streamId=k9Mwad/multiview&multisource=true), which can be viewed at the **Hoster player path** URL or by embedding the **Hosted embedded player** as an `<iframe>` into your webpage.
 
 From this tab, you can customize the player by altering settings such as the inclusion of the "Volume button" or if the stream is "Muted on start". To learn more about the hosted player or how you can build or use your own player, explore the [Playback](/millicast/playback/index.mdx) guide.
 
@@ -225,7 +225,7 @@ Once you've finished using a Publish token, it is **recommended that you retire 
 
 ## Using the Token API
 
-This guide provides a high-level understanding of managing your tokens via the Dolby.io dashboard. Whilst the dashboard is a great choice for managing Publish and [Subscribe](/millicast/streaming-dashboard/subscribe-tokens.mdx) tokens, **all aspects of token creation and management can be programmatically controlled via the Dolby.io Streaming Token REST APIs**. By utilizing the Token APIs to automate workflows, you can create scalable streaming solutions for your application or platform.
+This guide provides a high-level understanding of managing your tokens via the OptiView Streaming Dashboard. Whilst the dashboard is a great choice for managing Publish and [Subscribe](/millicast/streaming-dashboard/subscribe-tokens.mdx) tokens, **all aspects of token creation and management can be programmatically controlled via the OptiView Real-time Streaming Token REST APIs**. By utilizing the Token APIs to automate workflows, you can create scalable streaming solutions for your application or platform.
 
 To learn more about using the REST APIs for token creation and management, check out:
 

--- a/millicast/streaming-dashboard/managing-your-tokens.mdx
+++ b/millicast/streaming-dashboard/managing-your-tokens.mdx
@@ -19,7 +19,7 @@ To restrict who may _view_ a stream, you would use a separate [subscribe token](
 
 ## Create a publish token
 
-Log into your [OptiView Real-time Streaming Account](https://dashboard.dolby.io/signin) and select **Live Broadcast** from the left menu. This is where you can view and manage all of your _Publish tokens_.
+Log into your [OptiView Real-time Streaming Account](https://streaming.dolby.io/signin) and select **Live Broadcast** from the left menu. This is where you can view and manage all of your _Publish tokens_.
 
 import TokenMain from '../assets/img/tokens-main.png';
 

--- a/millicast/streaming-dashboard/managing-your-tokens.mdx
+++ b/millicast/streaming-dashboard/managing-your-tokens.mdx
@@ -225,7 +225,7 @@ Once you've finished using a Publish token, it is **recommended that you retire 
 
 ## Using the Token API
 
-This guide provides a high-level understanding of managing your tokens via the OptiView Streaming Dashboard. Whilst the dashboard is a great choice for managing Publish and [Subscribe](/millicast/streaming-dashboard/subscribe-tokens.mdx) tokens, **all aspects of token creation and management can be programmatically controlled via the OptiView Real-time Streaming Token REST APIs**. By utilizing the Token APIs to automate workflows, you can create scalable streaming solutions for your application or platform.
+This guide provides a high-level understanding of managing your tokens via the OptiView Real-time Streaming Dashboard. Whilst the dashboard is a great choice for managing Publish and [Subscribe](/millicast/streaming-dashboard/subscribe-tokens.mdx) tokens, **all aspects of token creation and management can be programmatically controlled via the OptiView Real-time Streaming Token REST APIs**. By utilizing the Token APIs to automate workflows, you can create scalable streaming solutions for your application or platform.
 
 To learn more about using the REST APIs for token creation and management, check out:
 

--- a/millicast/streaming-dashboard/multi-source-builder.mdx
+++ b/millicast/streaming-dashboard/multi-source-builder.mdx
@@ -32,7 +32,7 @@ The **source name** should be a short and descriptive text label. This name will
 
 The **streaming protocol** helps identify the configuration needed for the broadcast. The multi-source builder supports [RTMP](/millicast/broadcast/rtmp-and-rtmps.mdx), [SRT](/millicast/broadcast/srt.mdx), and [WHIP](/millicast/broadcast/webrtc-and-whip.mdx) broadcast protocols.
 
-By default, the first source you add will be labeled as the _Main_ source. Dolby.io Real-time Streaming limits the aggregate bitrate of all sources to 12 Mbps. The main source is prioritized and allowed to exceed the 12 Mbps limit, and the other sources share any remaining available bandwidth. See the [Multi-view](/millicast/playback/multi-view.md#limitations-of-multi-view) guide for examples of bandwidth allocation.
+By default, the first source you add will be labeled as the _Main_ source. OptiView Real-time Streaming limits the aggregate bitrate of all sources to 12 Mbps. The main source is prioritized and allowed to exceed the 12 Mbps limit, and the other sources share any remaining available bandwidth. See the [Multi-view](/millicast/playback/multi-view.md#limitations-of-multi-view) guide for examples of bandwidth allocation.
 
 import TestSources from '../assets/img/test-sources.png';
 
@@ -60,7 +60,7 @@ import RtmpSource from '../assets/img/rtmp-source.png';
   <img src={RtmpSource} width="600" />
 </div>
 
-To learn more about publishing and broadcasting with Dolby.io, check out the [Broadcast](/millicast/broadcast/index.mdx) guide, which provides more in-depth resources and examples on how to use the Publish token once it is created.
+To learn more about publishing and broadcasting with OptiView Real-time Streaming, check out the [Broadcast](/millicast/broadcast/index.mdx) guide, which provides more in-depth resources and examples on how to use the Publish token once it is created.
 
 ## Multi-source player
 

--- a/millicast/streaming-dashboard/subscribe-tokens.mdx
+++ b/millicast/streaming-dashboard/subscribe-tokens.mdx
@@ -22,7 +22,7 @@ This guide outlines the following:
 Before we can create a Subscribe token, we must first have a stream that requires a Subscribe token. These streams are referred to as **Secure streams** and need to be enabled within a Publish token by enabling "**Secure viewer**". To learn where to enable "Secure viewer", [check out this guide on creating a Publish token](/millicast/streaming-dashboard/managing-your-tokens.mdx).
 :::
 
-To get started, [login to your OptiView Real-time Streaming account](https://dashboard.dolby.io/) and select **Subscribe tokens** from the left menu. Here you can create and manage your subscribe tokens.
+To get started, [login to your OptiView Real-time Streaming account](https://streaming.dolby.io/) and select **Subscribe tokens** from the left menu. Here you can create and manage your subscribe tokens.
 
 import SubTokensEmpty from '../assets/img/subscribe-tokens-empty.png';
 

--- a/millicast/streaming-dashboard/subscribe-tokens.mdx
+++ b/millicast/streaming-dashboard/subscribe-tokens.mdx
@@ -196,7 +196,7 @@ Examples of self-singing a token can be found at this [GitHub repository](https:
 Using the Token API is great for producing a few tokens, but for true scalability and speed you should [self-sign your tokens](#self-signing-subscribe-tokens).
 :::
 
-This guide provides a high-level understanding of managing your tokens via the OptiView Streaming Dashboard. Whilst the dashboard is a great choice for managing publish and subscribe tokens, **all aspects of token creation and management can be programmatically controlled via the OptiView Real-time Streaming Token REST APIs**. By utilizing the Token APIs to automate workflows, you can create scalable streaming solutions for your application or platform.
+This guide provides a high-level understanding of managing your tokens via the OptiView Real-time Streaming Dashboard. Whilst the dashboard is a great choice for managing publish and subscribe tokens, **all aspects of token creation and management can be programmatically controlled via the OptiView Real-time Streaming Token REST APIs**. By utilizing the Token APIs to automate workflows, you can create scalable streaming solutions for your application or platform.
 
 To learn more about using the REST APIs for token creation and management, check out:
 

--- a/millicast/streaming-dashboard/subscribe-tokens.mdx
+++ b/millicast/streaming-dashboard/subscribe-tokens.mdx
@@ -4,7 +4,7 @@ slug: /subscribe-tokens
 sidebar_position: 2
 ---
 
-Unlike [publishing a broadcast](/millicast/broadcast/index.mdx), the subscriber (viewer), by default, **does not need a token** to view a stream. However, if you want to secure your feed from being viewed by non-authenticated users, Dolby.io Streaming provides the ability to use subscribe tokens.
+Unlike [publishing a broadcast](/millicast/broadcast/index.mdx), the subscriber (viewer), by default, **does not need a token** to view a stream. However, if you want to secure your feed from being viewed by non-authenticated users, OptiView Real-time Streaming provides the ability to use subscribe tokens.
 
 When enabled, streams that require a subscribe token will block access to users not in possession of a valid token coming from a valid domain. This makes subscribe tokens useful for protecting paywalled content or non-public content. Subscribe tokens also allow you to add time limits, specify IPs, and even set the token to only work from single or multiple specified domains.
 
@@ -22,7 +22,7 @@ This guide outlines the following:
 Before we can create a Subscribe token, we must first have a stream that requires a Subscribe token. These streams are referred to as **Secure streams** and need to be enabled within a Publish token by enabling "**Secure viewer**". To learn where to enable "Secure viewer", [check out this guide on creating a Publish token](/millicast/streaming-dashboard/managing-your-tokens.mdx).
 :::
 
-To get started, [login to your Dolby.io Real-time Streaming account](https://dashboard.dolby.io/) and select **Subscribe tokens** from the left menu. Here you can create and manage your subscribe tokens.
+To get started, [login to your OptiView Real-time Streaming account](https://dashboard.dolby.io/) and select **Subscribe tokens** from the left menu. Here you can create and manage your subscribe tokens.
 
 import SubTokensEmpty from '../assets/img/subscribe-tokens-empty.png';
 
@@ -121,9 +121,9 @@ import SubTokenDelete from '../assets/img/subscribe-token-delete.png';
 
 ## Self-signing subscribe tokens
 
-The Dolby.io Real-Time Streaming APIs support the ability to self-sign Subscribe tokens without having to make an API call. Self-signing the token locally allows you to generate your Subscribe token more efficiently. The self-signed token is a user-generated JSON Web Token (JWT) that is generated from an existing Subscribe token.
+The OptiView Real-time Streaming APIs support the ability to self-sign Subscribe tokens without having to make an API call. Self-signing the token locally allows you to generate your Subscribe token more efficiently. The self-signed token is a user-generated JSON Web Token (JWT) that is generated from an existing Subscribe token.
 
-The Subscribe token functions as a parent token, and any self-signed token generated from this **will inherit any restrictions or parameters** that are specified when the Subscribe token is created. The self-signed token can be passed to the Dolby.io Real-time Streaming service, the same as any regular Subscribe token, but is then validated against the Subscribe token that was originally used to sign it.
+The Subscribe token functions as a parent token, and any self-signed token generated from this **will inherit any restrictions or parameters** that are specified when the Subscribe token is created. The self-signed token can be passed to the OptiView Real-time Streaming service, the same as any regular Subscribe token, but is then validated against the Subscribe token that was originally used to sign it.
 
 Self-signing your Subscribe token allows you to:
 
@@ -131,7 +131,7 @@ Self-signing your Subscribe token allows you to:
   - `HMACSHA256`
   - `HMACSHA384`
   - `HMACSHA512`
-- Reduce the number of API calls to the Dolby.io Server
+- Reduce the number of API calls to the OptiView Real-time server
 - [Track bandwidth usage with each of the self-signed tokens](/millicast/distribution/syndication#how-to-track-syndication)
 
 ### Creating a self-signed token
@@ -196,7 +196,7 @@ Examples of self-singing a token can be found at this [GitHub repository](https:
 Using the Token API is great for producing a few tokens, but for true scalability and speed you should [self-sign your tokens](#self-signing-subscribe-tokens).
 :::
 
-This guide provides a high-level understanding of managing your tokens via the Dolby.io dashboard. Whilst the dashboard is a great choice for managing publish and subscribe tokens, **all aspects of token creation and management can be programmatically controlled via the Dolby.io Streaming Token REST APIs**. By utilizing the Token APIs to automate workflows, you can create scalable streaming solutions for your application or platform.
+This guide provides a high-level understanding of managing your tokens via the OptiView Streaming Dashboard. Whilst the dashboard is a great choice for managing publish and subscribe tokens, **all aspects of token creation and management can be programmatically controlled via the OptiView Real-time Streaming Token REST APIs**. By utilizing the Token APIs to automate workflows, you can create scalable streaming solutions for your application or platform.
 
 To learn more about using the REST APIs for token creation and management, check out:
 

--- a/millicast/streaming-dashboard/token-api.mdx
+++ b/millicast/streaming-dashboard/token-api.mdx
@@ -47,7 +47,7 @@ Review the [REST API](/millicast/getting-started/using-rest-apis.mdx) platform g
 
 To use the REST APIs, you must provide an API Secret to authenticate your application. Without a valid secret, API calls will be rejected with an Unauthorized error.
 
-To acquire an API Secret, log into the Dolby.io dashboard, and click on "_Settings_" in the left-side menu.
+To acquire an API Secret, log into the OptiView Streaming Dashboard, and click on "_Settings_" in the left-side menu.
 
 Navigate to the Security tab and click the `+ Create` button to add an API Secret.
 
@@ -255,7 +255,7 @@ curl --request GET \
 
 ### Self-sign subscribe tokens
 
-Depending on how secure you want your stream to be, you may need to create many subscribe tokens. Dolby.io Real-Time Streaming supports the ability to self-sign subscribe tokens without having to make an API call to the Dolby.io server. Self-signing subscribe tokens locally allows you to generate your subscribe token more efficiently. The self-signed token is a user-generated JSON Web Token (JWT) that is generated from an existing subscribe token.
+Depending on how secure you want your stream to be, you may need to create many subscribe tokens. OptiView Real-time Streaming supports the ability to self-sign subscribe tokens without having to make an API call to the OptiView Real-time server. Self-signing subscribe tokens locally allows you to generate your subscribe token more efficiently. The self-signed token is a user-generated JSON Web Token (JWT) that is generated from an existing subscribe token.
 
 To learn more about self-signing subscribe tokens, [check out this guide](/millicast/streaming-dashboard/subscribe-tokens.mdx#self-signing-subscribe-tokens).
 

--- a/millicast/streaming-dashboard/token-api.mdx
+++ b/millicast/streaming-dashboard/token-api.mdx
@@ -47,7 +47,7 @@ Review the [REST API](/millicast/getting-started/using-rest-apis.mdx) platform g
 
 To use the REST APIs, you must provide an API Secret to authenticate your application. Without a valid secret, API calls will be rejected with an Unauthorized error.
 
-To acquire an API Secret, log into the OptiView Streaming Dashboard, and click on "_Settings_" in the left-side menu.
+To acquire an API Secret, log into the OptiView Real-time Streaming Dashboard, and click on "_Settings_" in the left-side menu.
 
 Navigate to the Security tab and click the `+ Create` button to add an API Secret.
 

--- a/millicast/webhooks/index.mdx
+++ b/millicast/webhooks/index.mdx
@@ -2,7 +2,7 @@
 title: Webhooks
 ---
 
-**Webhooks** are callbacks triggered by the platform to notify your application when an event occurs. As an alternative to polling solutions built with the [REST API](/millicast/api/webhooks-get.api.mdx), you can build asynchronous services and integrations that react only when real-time notifications are pushed from the Dolby.io platform to your application.
+**Webhooks** are callbacks triggered by the platform to notify your application when an event occurs. As an alternative to polling solutions built with the [REST API](/millicast/api/webhooks-get.api.mdx), you can build asynchronous services and integrations that react only when real-time notifications are pushed from the OptiView Real-time platform to your application.
 
 ## Creating webhooks
 
@@ -18,7 +18,7 @@ You choose from several _types_ of events that can be sent to your service.
 
 Webhooks are not correlated with a specific publishing token. You can have one webhook that responds to all platform events for your account or separate endpoints that each receive only specific types.
 
-Each webhook generates a **Webhook Secret**. This secret can be used for signature verification that an incoming request to your endpoint originated from the Dolby.io Streaming service.
+Each webhook generates a **Webhook Secret**. This secret can be used for signature verification that an incoming request to your endpoint originated from the OptiView Real-time Streaming service.
 
 ### How-to add a webhook with the streaming dashboard
 
@@ -141,7 +141,7 @@ A JSON payload will be included in the body of the request so that you can proce
 
 Most webhooks will share the same base JSON structure:
 
-```json title="Common JSON format for Dolby.io Real-time Streaming Webhooks"
+```json title="Common JSON format for OptiView Real-time Streaming Webhooks"
 {
   "type": "...",              // Webhook type: "feeds", "recording", "thumbnail", "transcoder" or "viewerConnection"
   "event": "...",             // Event name: "started", "ended", etc.

--- a/millicast/webhooks/thumbnail.mdx
+++ b/millicast/webhooks/thumbnail.mdx
@@ -63,9 +63,9 @@ The thumbnail webhook is a POST request that will be sent to the webhook URL wit
 The following HTTP headers are on the request to identify stream details:
 
 - **X-Millicast-Timestamp**: timestamp of the generated thumbnail.
-- **X-Millicast-Feed-Id**: Dolby.io Real-time Streaming feed id.
-- **X-Millicast-Stream-Id**: Dolby.io Real-time Streaming stream id.
-- **X-Millicast-Token-Id**: Dolby.io Real-time Streaming publish token id.
+- **X-Millicast-Feed-Id**: OptiView Real-time Streaming feed id.
+- **X-Millicast-Stream-Id**: OptiView Real-time Streaming stream id.
+- **X-Millicast-Token-Id**: OptiView Real-time Streaming publish token id.
 - **X-Millicast-Signature**: SHA1 signature using the hook configured secret (The same signature mechanism used by the other webhooks).
 
 ## Troubleshooting

--- a/open-video-ui/android/getting-started.mdx
+++ b/open-video-ui/android/getting-started.mdx
@@ -8,12 +8,15 @@ sidebar_custom_props: { 'icon': '🚀' }
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
+
+<RebrandingNotice />
 
 ## Installation
 
 1.  Create a new Jetpack Compose app or set up Compose in your existing Android app by following [the Compose quick start guide](https://developer.android.com/jetpack/compose/setup).
-2.  Add the native THEOplayer Android SDK to your project by following [these installation instructions](https://github.com/THEOplayer/theoplayer-sdk-android#installation).
-3.  Add the THEOplayer Maven repository to your project-level `settings.gradle` file:
+2.  Add the native OptiView Player Android SDK to your project by following [these installation instructions](https://github.com/THEOplayer/theoplayer-sdk-android#installation).
+3.  Add the OptiView Player Maven repository to your project-level `settings.gradle` file:
     <Tabs queryString="lang">
        <!-- prettier-ignore-start -->
        <TabItem value="groovy" label="Groovy">

--- a/open-video-ui/android/index.mdx
+++ b/open-video-ui/android/index.mdx
@@ -5,7 +5,10 @@ sidebar_label: Introduction
 # Open Video UI for Android
 
 import Intro from '../shared/_intro.mdx';
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+
+<RebrandingNotice />
 
 <Intro />
 <SidebarDocCardList />

--- a/open-video-ui/callouts/_rebranding_notice.md
+++ b/open-video-ui/callouts/_rebranding_notice.md
@@ -1,0 +1,5 @@
+:::info OptiView Rebranding
+
+OptiView Player is the new name for THEOplayer as part of the OptiView product suite. During the transition, you may still see references to THEOplayer. OptiView Player and THEOplayer refer to the same product.
+
+:::

--- a/open-video-ui/index.mdx
+++ b/open-video-ui/index.mdx
@@ -6,9 +6,12 @@ sidebar_label: Introduction
 # Open Video UI
 
 import Intro from './shared/_intro.mdx';
+import RebrandingNotice from './callouts/_rebranding_notice.md';
 import DocCardList from '@theme/DocCardList';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { getPlatforms } from '@site/src/util/platform';
+
+<RebrandingNotice />
 
 <Intro />
 <DocCardList

--- a/open-video-ui/react-native/index.mdx
+++ b/open-video-ui/react-native/index.mdx
@@ -5,7 +5,10 @@ sidebar_label: Introduction
 # Open Video UI for React Native
 
 import Intro from '../shared/_intro.mdx';
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+
+<RebrandingNotice />
 
 <Intro />
 <SidebarDocCardList />

--- a/open-video-ui/react/index.mdx
+++ b/open-video-ui/react/index.mdx
@@ -5,7 +5,10 @@ sidebar_label: Introduction
 # Open Video UI for React
 
 import Intro from '../shared/_intro.mdx';
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+
+<RebrandingNotice />
 
 <Intro />
 <SidebarDocCardList />

--- a/open-video-ui/shared/_intro.mdx
+++ b/open-video-ui/shared/_intro.mdx
@@ -1,4 +1,4 @@
-The Open Video UI provides component libraries for building a world-class video player experience powered by the THEOplayer SDK.
+The Open Video UI provides component libraries for building a world-class video player experience powered by the OptiView Player SDK.
 
 - Use the default UI for a great out-of-the-box experience, or use the individual components to build your own custom UI.
 - Dedicated libraries for each platform, so your UI always feels native in your app.

--- a/open-video-ui/web/index.mdx
+++ b/open-video-ui/web/index.mdx
@@ -5,7 +5,10 @@ sidebar_label: Introduction
 # Open Video UI for Web
 
 import Intro from '../shared/_intro.mdx';
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+
+<RebrandingNotice />
 
 <Intro />
 <SidebarDocCardList />

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -59,8 +59,8 @@ const FeatureList: FeatureItem[] = [
       </>
     ),
     to: [
-      { link: '/millicast', text: 'Real-time (Millicast)' },
-      { link: '/theolive', text: 'Live (THEOlive)' },
+      { link: '/millicast', text: 'Real-time' },
+      { link: '/theolive', text: 'Live' },
     ],
   },
   {
@@ -76,7 +76,7 @@ const FeatureList: FeatureItem[] = [
     ),
     description: (
       <p>
-        Dolby OptiView Ads (formerly known as THEOads) enables you to deliver a seamless, less intrusive ad experience, designed to boost viewer
+        Dolby OptiView Ads enables you to deliver a seamless, less intrusive ad experience, designed to boost viewer
         engagement and maximize ad revenue.
       </p>
     ),

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -76,8 +76,8 @@ const FeatureList: FeatureItem[] = [
     ),
     description: (
       <p>
-        Dolby OptiView Ads enables you to deliver a seamless, less intrusive ad experience, designed to boost viewer
-        engagement and maximize ad revenue.
+        Dolby OptiView Ads enables you to deliver a seamless, less intrusive ad experience, designed to boost viewer engagement and maximize ad
+        revenue.
       </p>
     ),
     to: [{ link: '/ads', text: 'Get Started' }],

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -123,7 +123,7 @@ const openVideoUiPlatforms: readonly PlatformDescription[] = [
   },
   {
     platform: 'react-native',
-    label: 'React Native OptiView Player UI',
+    label: 'Open Video UI for React Native',
     shortLabel: 'React Native UI',
     description: 'For cross-platform apps using React Native components',
     gettingStartedDoc: 'react-native/getting-started',

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -33,7 +33,7 @@ interface PlatformDescriptionWithUrl extends PlatformDescription {
 const theoplayerPlatforms: readonly PlatformDescription[] = [
   {
     platform: 'web',
-    label: 'THEOplayer Web SDK',
+    label: 'OptiView Player Web SDK',
     shortLabel: 'Web SDK',
     description: 'For desktop and mobile web browsers, and smart TVs like Tizen and WebOS',
     gettingStartedDoc: 'getting-started/sdks/web/getting-started',
@@ -42,7 +42,7 @@ const theoplayerPlatforms: readonly PlatformDescription[] = [
   },
   {
     platform: 'android',
-    label: 'THEOplayer Android SDK',
+    label: 'OptiView Player Android SDK',
     shortLabel: 'Android SDK',
     description: 'For smartphones, tablets and Android TVs',
     gettingStartedDoc: 'getting-started/sdks/android/getting-started',
@@ -51,7 +51,7 @@ const theoplayerPlatforms: readonly PlatformDescription[] = [
   },
   {
     platform: 'ios',
-    label: 'THEOplayer iOS & tvOS SDK',
+    label: 'OptiView Player iOS & tvOS SDK',
     shortLabel: 'iOS & tvOS SDK',
     description: 'For iPhone, iPad and Apple TV',
     gettingStartedDoc: 'getting-started/sdks/ios/getting-started',
@@ -60,7 +60,7 @@ const theoplayerPlatforms: readonly PlatformDescription[] = [
   },
   {
     platform: 'react-native',
-    label: 'THEOplayer React Native SDK',
+    label: 'OptiView Player React Native SDK',
     shortLabel: 'React Native SDK',
     description: 'For cross-platform apps targeting web, Android and iOS',
     gettingStartedDoc: 'getting-started/frameworks/react-native/getting-started',
@@ -69,7 +69,7 @@ const theoplayerPlatforms: readonly PlatformDescription[] = [
   },
   {
     platform: 'flutter',
-    label: 'THEOplayer Flutter SDK',
+    label: 'OptiView Player Flutter SDK',
     shortLabel: 'Flutter SDK',
     description: 'For cross-platform apps targeting web, Android and iOS',
     gettingStartedDoc: 'getting-started/frameworks/flutter/getting-started',
@@ -78,7 +78,7 @@ const theoplayerPlatforms: readonly PlatformDescription[] = [
   },
   {
     platform: 'chromecast',
-    label: 'THEOplayer Chromecast SDK',
+    label: 'OptiView Player Chromecast SDK',
     shortLabel: 'Chromecast SDK',
     description: 'For custom Chromecast receiver apps',
     gettingStartedDoc: 'getting-started/sdks/chromecast/getting-started',
@@ -87,7 +87,7 @@ const theoplayerPlatforms: readonly PlatformDescription[] = [
   },
   {
     platform: 'roku',
-    label: 'THEOplayer Roku SDK',
+    label: 'OptiView Player Roku SDK',
     shortLabel: 'Roku SDK',
     description: 'For Roku smart TVs',
     gettingStartedDoc: 'getting-started/sdks/roku/getting-started',
@@ -123,7 +123,7 @@ const openVideoUiPlatforms: readonly PlatformDescription[] = [
   },
   {
     platform: 'react-native',
-    label: 'React Native THEOplayer UI',
+    label: 'React Native OptiView Player UI',
     shortLabel: 'React Native UI',
     description: 'For cross-platform apps using React Native components',
     gettingStartedDoc: 'react-native/getting-started',

--- a/theolive/api/full-example.mdx
+++ b/theolive/api/full-example.mdx
@@ -224,7 +224,7 @@ This starts all engines on the channel. The channel status will transition throu
 
 ## 7. Verify and play
 
-Use the distribution ID to play the stream. With [THEOplayer on web](../playback/optiview-player.mdx):
+Use the distribution ID to play the stream. With [OptiView player on web](../playback/optiview-player.mdx):
 
 ```javascript
 player.source = {

--- a/theolive/api/full-example.mdx
+++ b/theolive/api/full-example.mdx
@@ -224,7 +224,7 @@ This starts all engines on the channel. The channel status will transition throu
 
 ## 7. Verify and play
 
-Use the distribution ID to play the stream. With [OptiView player on web](../playback/optiview-player.mdx):
+Use the distribution ID to play the stream. With [OptiView Player on web](../playback/optiview-player.mdx):
 
 ```javascript
 player.source = {

--- a/theolive/callouts/_rebranding_notice.md
+++ b/theolive/callouts/_rebranding_notice.md
@@ -1,5 +1,5 @@
 :::info Dolby OptiView Rebranding
 
-Dolby OptiView Live Streaming is the new name for THEOlive Streaming as part of the OptiView product suite. During the transition, you may still see references to THEOlive. OptiView Live and THEOlive refer to the same product.
+Dolby OptiView Live Streaming is the new name for THEOlive as part of the OptiView product suite. During the transition, you may still see references to THEOlive. OptiView Live and THEOlive refer to the same product.
 
 :::

--- a/theolive/callouts/_rebranding_notice.md
+++ b/theolive/callouts/_rebranding_notice.md
@@ -1,5 +1,5 @@
-:::info OptiView Rebranding
+:::info Dolby OptiView Rebranding
 
-OptiView Live Streaming is the new name for THEOlive Streaming as part of the OptiView product suite. During the transition, you may still see references to THEOlive. OptiView Live and THEOlive refer to the same product.
+Dolby OptiView Live Streaming is the new name for THEOlive Streaming as part of the OptiView product suite. During the transition, you may still see references to THEOlive. OptiView Live and THEOlive refer to the same product.
 
 :::

--- a/theolive/callouts/_rebranding_notice.md
+++ b/theolive/callouts/_rebranding_notice.md
@@ -1,0 +1,5 @@
+:::info OptiView Rebranding
+
+OptiView Live Streaming is the new name for THEOlive Streaming as part of the OptiView product suite. During the transition, you may still see references to THEOlive. OptiView Live and THEOlive refer to the same product.
+
+:::

--- a/theolive/getting-started.mdx
+++ b/theolive/getting-started.mdx
@@ -55,7 +55,7 @@ A channel consists of three main components that need to be configured:
 Create a new ingest, give it a name, and select the protocol you want to use (RTMP or SRT) and which mode (pull or push).
 
 :::tip
-You only need a single ingest to start streaming but for high availability and redundancy multiple ingests and engines should be utilized.
+You only need a single ingest to start streaming but, for high availability and redundancy multiple ingests and engines should be utilized.
 :::
 
 <div className="center-container">![Create an ingest](assets/img/create-ingest.png)</div>

--- a/theolive/getting-started.mdx
+++ b/theolive/getting-started.mdx
@@ -6,8 +6,9 @@ sidebar_custom_props:
 description: Create your first stream, from setup to embedding the player.
 ---
 
-OptiView Live Streaming is the new name for THEOlive Streaming as part of the OptiView product suite. During the transition, you may still see references to THEOlive. OptiView Live and THEOlive refer to the same product.
+import RebrandingNotice from '@site/theolive/callouts/_rebranding_notice.md';
 
+<RebrandingNotice />
 # Getting started
 
 This guide walks you through creating your first stream, from setting up an account to embedding the player on your page.

--- a/theolive/getting-started.mdx
+++ b/theolive/getting-started.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 sidebar_label: Getting started
+title: 'Getting started'
 sidebar_custom_props:
   icon: 🚀
 description: Create your first stream, from setup to embedding the player.
@@ -9,7 +10,6 @@ description: Create your first stream, from setup to embedding the player.
 import RebrandingNotice from '@site/theolive/callouts/_rebranding_notice.md';
 
 <RebrandingNotice />
-# Getting started
 
 This guide walks you through creating your first stream, from setting up an account to embedding the player on your page.
 
@@ -40,7 +40,7 @@ A channel consists of three main components that need to be configured:
 
 - **Ingest** — where the media is retrieved from. This is the entry point for your content and multiple protocols are supported like RTMP and SRT.
 - **Engine** — processes the incoming media, handling transcoding and packaging.
-- **Distributions** — different output versions of an engine. Each distribution lets you enable or disable protocols, choose CDNs, and more.
+- **Distributions** — different output versions of an engine. Each distribution lets you enable or disable protocols, set security, choose latency targets, and more.
 
 <figure className="center-container">
 
@@ -55,7 +55,7 @@ A channel consists of three main components that need to be configured:
 Create a new ingest, give it a name, and select the protocol you want to use (RTMP or SRT) and which mode (pull or push).
 
 :::tip
-You only need a single ingest to start streaming but are free to create multiple ones for redundancy purposes for example.
+You only need a single ingest to start streaming but for high availablity and redundancy multiple ingests and engines should be utilized.
 :::
 
 <div className="center-container">![Create an ingest](assets/img/create-ingest.png)</div>
@@ -73,7 +73,7 @@ The engine is responsible for transcoding and packaging the incoming media. Crea
 </div>
 <div class="col col--8">
 
-- **Name** — a descriptive name for your engine.
+- **Name** — a human-readable, descriptive name for your engine.
 - **Priority** — determines which engine takes precedence when multiple engines are configured. A lower number means higher priority.
 - **Ingest** — select which ingest this engine should use as its source.
 - **Region** — the region where the transcoding takes place. Choose one close to your ingest location.
@@ -82,7 +82,7 @@ The engine is responsible for transcoding and packaging the incoming media. Crea
 - **Enable HESP** — output content in HESP format for low latency delivery.
 - **Enable HLS** — output content in HLS format for broad platform compatibility.
 - **Enable HLS MPEG-TS** — output content in HLS MPEG-TS format. Only recommended for very specific platforms that don't support HLS with CMAF segments. This feature needs to be explicitly enabled in your account by an admin and isn't compatible with some other features like DRM.
-- **DAI Asset Key** — asset key for OptiView ads. To learn more, contact your Dolby team.
+- **DAI Asset Key** — asset key for [OptiView Ads](/ads/getting-started/). To learn more, contact your Dolby team.
 
 </div>
 </div>
@@ -90,20 +90,20 @@ The engine is responsible for transcoding and packaging the incoming media. Crea
 
 ### 2.3 Distributions
 
-A distribution represents an output version of an engine. Create a new distribution, give it a name and a connected engine. The default properties are fine to get started, but a lot of properties can be configured:
+A distribution represents an output media stream from an engine. Create a new distribution, give it a name and a connected engine. The default properties are fine to get started, but a lot of properties can be configured:
 
 ![Configure a distribution](assets/img/configure-distribution.png)
 
 - **Endpoints** — the connected engines that feed into this distribution.
 - **Outputs** — enable or disable streaming protocols (HESP, HLS, HLS MPEG-TS).
 - **Player** — configure player settings such as target latency and max bitrate.
-- **WebRTC** — optional WebRTC configuration for real-time delivery.
+- **WebRTC** — optional WebRTC configuration for real-time delivery with [OptiView Real-time streaming](/millicast/getting-started/).
 - **Overrides** — add custom overrides for specific settings.
 - **Security** — configure access restrictions including geo blocking, IP blocking, referrer blocking and JWT security.
 
 ## 3. Start the channel
 
-When you're all set, you can start your channel from the channel details page by clicking the `Start all` button. This will start all engines at once. Starting your channel means your transcoding time will start counting for billing purposes.
+When you're all set, you can start your channel from the channel details page by clicking the `Start all` button. This will start all engines at once. Starting your channel means your transcoding time will start counting for billing purposes, even if a stream is not connected.
 
 For advanced use cases such as production updates, you can start and stop individual engines separately. However, for most use cases all engines will be started and stopped at the same time.
 

--- a/theolive/getting-started.mdx
+++ b/theolive/getting-started.mdx
@@ -55,7 +55,7 @@ A channel consists of three main components that need to be configured:
 Create a new ingest, give it a name, and select the protocol you want to use (RTMP or SRT) and which mode (pull or push).
 
 :::tip
-You only need a single ingest to start streaming but for high availablity and redundancy multiple ingests and engines should be utilized.
+You only need a single ingest to start streaming but for high availability and redundancy multiple ingests and engines should be utilized.
 :::
 
 <div className="center-container">![Create an ingest](assets/img/create-ingest.png)</div>

--- a/theolive/index.mdx
+++ b/theolive/index.mdx
@@ -17,7 +17,7 @@ The supported streaming protocols are:
 - **HESP**: Ideal for the 1–5 second latency range, delivering low latency at scale for sports betting and interactive experiences.
 - **HLS**: An industry standard targeting 8 seconds and up, with broad platform support, ensuring compatibility across a wide range of devices and players.
 
-On these pages, you'll learn how to get started with the THEOlive backend and player, how to use the various features,
+On these pages, you'll learn how to get started with the OptiView Live backend and OptiView player, how to use the various features,
 and explore examples.
 
 <SidebarDocCardList />

--- a/theolive/index.mdx
+++ b/theolive/index.mdx
@@ -17,7 +17,7 @@ The supported streaming protocols are:
 - **HESP**: Ideal for the 1–5 second latency range, delivering low latency at scale for sports betting and interactive experiences.
 - **HLS**: An industry standard targeting 8 seconds and up, with broad platform support, ensuring compatibility across a wide range of devices and players.
 
-On these pages, you'll learn how to get started with the OptiView Live backend and OptiView player, how to use the various features,
+On these pages, you'll learn how to get started with the OptiView Live backend and OptiView Player, how to use the various features,
 and explore examples.
 
 <SidebarDocCardList />

--- a/theolive/index.mdx
+++ b/theolive/index.mdx
@@ -6,6 +6,9 @@ sidebar_position: 1
 # OptiView live streaming
 
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+import RebrandingNotice from '@site/theolive/callouts/_rebranding_notice.md';
+
+<RebrandingNotice />
 
 OptiView live is a streaming solution perfect for use cases such as live sports, sports betting and interactivity, with support for all kinds of platforms and devices.
 

--- a/theoplayer/android/index.mdx
+++ b/theoplayer/android/index.mdx
@@ -4,10 +4,13 @@ sidebar_label: Introduction
 sidebar_position: 1
 ---
 
-# THEOplayer Android SDK
+# OptiView Player Android SDK
 
 import Intro from '../shared/_intro.mdx';
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+
+<RebrandingNotice />
 
 <Intro />
 <SidebarDocCardList />

--- a/theoplayer/callouts/_rebranding_notice.md
+++ b/theoplayer/callouts/_rebranding_notice.md
@@ -1,0 +1,5 @@
+:::info OptiView Rebranding
+
+OptiView Player is the new name for THEOplayer as part of the OptiView product suite. During the transition, you may still see references to THEOplayer. OptiView Player and THEOplayer refer to the same product.
+
+:::

--- a/theoplayer/changelog.md
+++ b/theoplayer/changelog.md
@@ -1,6 +1,10 @@
-# Changelog
+# OptiView Player Changelog
 
-These are the release notes for THEOplayer 10.0.0 and higher. For older versions, see:
+import RebrandingNotice from './callouts/_rebranding_notice.md';
+
+<RebrandingNotice />
+
+These are the release notes for OptiView Player 10.0.0 and higher. For older versions, see:
 * [Version 9.x](https://optiview.dolby.com/docs/theoplayer/v9/changelog/)
 * [Version 8.x](https://optiview.dolby.com/docs/theoplayer/v8/changelog/)
 * [Version 7.x](https://optiview.dolby.com/docs/theoplayer/v7/changelog/)

--- a/theoplayer/chromecast/index.mdx
+++ b/theoplayer/chromecast/index.mdx
@@ -4,10 +4,13 @@ sidebar_label: Introduction
 sidebar_position: 1
 ---
 
-# THEOplayer Chromecast SDK
+# OptiView Player Chromecast SDK
 
 import Intro from '../shared/_intro.mdx';
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+
+<RebrandingNotice />
 
 <Intro />
 <SidebarDocCardList />

--- a/theoplayer/flutter/index.mdx
+++ b/theoplayer/flutter/index.mdx
@@ -4,10 +4,13 @@ sidebar_label: Introduction
 sidebar_position: 1
 ---
 
-# THEOplayer Flutter SDK
+# OptiView Player Flutter SDK
 
 import Intro from '../shared/_intro.mdx';
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+
+<RebrandingNotice />
 
 <Intro />
 <SidebarDocCardList />

--- a/theoplayer/getting-started/01-sdks/01-web/00-getting-started.mdx
+++ b/theoplayer/getting-started/01-sdks/01-web/00-getting-started.mdx
@@ -1,8 +1,11 @@
 # Getting started on Web
 
 import styles from './shared.module.css';
+import RebrandingNotice from '../../../callouts/_rebranding_notice.md';
 
-Dolby OptiView Player (formerly THEOplayer) is the universal video player solution from Dolby.
+<RebrandingNotice />
+
+Dolby OptiView Player is the universal video player solution from Dolby.
 The HTML5/Tizen/webOS Player SDK offers support for HLS, MPEG-DASH, advertisements, DRM and much more.
 
 This article is your starting point if you are using Dolby OptiView Player for the first time.

--- a/theoplayer/getting-started/01-sdks/02-android/00-getting-started.mdx
+++ b/theoplayer/getting-started/01-sdks/02-android/00-getting-started.mdx
@@ -4,8 +4,11 @@ sidebar_position: 0.0
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import RebrandingNotice from '../../../callouts/_rebranding_notice.md';
 
 # Getting started on Android
+
+<RebrandingNotice />
 
 ## Add THEOplayer and Kotlin libraries to your application
 

--- a/theoplayer/getting-started/01-sdks/03-ios/00-getting-started.mdx
+++ b/theoplayer/getting-started/01-sdks/03-ios/00-getting-started.mdx
@@ -1,5 +1,9 @@
 # Getting started on iOS/tvOS
 
+import RebrandingNotice from '../../../callouts/_rebranding_notice.md';
+
+<RebrandingNotice />
+
 ## Introduction
 
 This guide covers the steps to obtain and set up the core Dolby OptiView Player SDK targeting a native iOS/tvOS application. It also provides information and usage of the commonly used APIs.

--- a/theoplayer/getting-started/01-sdks/06-chromecast/00-getting-started.md
+++ b/theoplayer/getting-started/01-sdks/06-chromecast/00-getting-started.md
@@ -1,6 +1,6 @@
 # Getting started on Chromecast
 
-import RebrandingNotice from '../../../callouts/_rebranding_notice.md';
+import RebrandingNotice from '../../../callouts/\_rebranding_notice.md';
 
 <RebrandingNotice />
 

--- a/theoplayer/getting-started/01-sdks/06-chromecast/00-getting-started.md
+++ b/theoplayer/getting-started/01-sdks/06-chromecast/00-getting-started.md
@@ -1,5 +1,9 @@
 # Getting started on Chromecast
 
+import RebrandingNotice from '../../../callouts/_rebranding_notice.md';
+
+<RebrandingNotice />
+
 This how-to guide describes how to set up a Chromecast Receiver application using the Dolby OptiView Player SDK.
 
 :::info

--- a/theoplayer/getting-started/01-sdks/09-roku/00-getting-started.mdx
+++ b/theoplayer/getting-started/01-sdks/09-roku/00-getting-started.mdx
@@ -1,5 +1,9 @@
 # Getting Started on Roku
 
+import RebrandingNotice from '../../../callouts/_rebranding_notice.md';
+
+<RebrandingNotice />
+
 This getting started guide gets you familiar with Roku and the Dolby OptiView Player Roku SDK.
 Upon completion of this guide, you'll have integrated the Player SDK in Roku's Hello World! sample project, configured a video, and used an event listener.
 

--- a/theoplayer/getting-started/index.mdx
+++ b/theoplayer/getting-started/index.mdx
@@ -4,7 +4,11 @@ displayed_sidebar: web
 
 # Getting started
 
-THEOplayer offers a rich portfolio of video SDKs for many platforms and frameworks across desktop, mobile and TV devices.
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
+
+<RebrandingNotice />
+
+OptiView Player offers a rich portfolio of video SDKs for many platforms and frameworks across desktop, mobile and TV devices.
 
 Our dedicated guides help you get started right away.
 

--- a/theoplayer/index.mdx
+++ b/theoplayer/index.mdx
@@ -4,11 +4,14 @@ sidebar_label: Introduction
 sidebar_position: 1
 ---
 
-# THEOplayer
+# OptiView Player
 
 import Intro from './shared/_intro.mdx';
+import RebrandingNotice from './callouts/_rebranding_notice.md';
 import DocCardList from '@theme/DocCardList';
 import { usePlatforms } from '@site/src/util/platform';
+
+<RebrandingNotice />
 
 <Intro />
 <DocCardList

--- a/theoplayer/ios/index.mdx
+++ b/theoplayer/ios/index.mdx
@@ -4,10 +4,13 @@ sidebar_label: Introduction
 sidebar_position: 1
 ---
 
-# THEOplayer iOS & tvOS SDK
+# OptiView Player iOS & tvOS SDK
 
 import Intro from '../shared/_intro.mdx';
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+
+<RebrandingNotice />
 
 <Intro />
 <SidebarDocCardList />

--- a/theoplayer/react-native/index.mdx
+++ b/theoplayer/react-native/index.mdx
@@ -4,10 +4,13 @@ sidebar_label: Introduction
 sidebar_position: 1
 ---
 
-# THEOplayer React Native SDK
+# OptiView Player React Native SDK
 
 import Intro from '../shared/_intro.mdx';
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+
+<RebrandingNotice />
 
 <Intro />
 <SidebarDocCardList />

--- a/theoplayer/roku/index.mdx
+++ b/theoplayer/roku/index.mdx
@@ -4,10 +4,13 @@ sidebar_label: Introduction
 sidebar_position: 1
 ---
 
-# THEOplayer Roku SDK
+# OptiView Player Roku SDK
 
 import Intro from '../shared/_intro.mdx';
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+
+<RebrandingNotice />
 
 <Intro />
 <SidebarDocCardList />

--- a/theoplayer/shared/_intro.mdx
+++ b/theoplayer/shared/_intro.mdx
@@ -1,3 +1,3 @@
-Dolby OptiView Player (formerly THEOplayer) is the universal video player solution from Dolby. It offers support for HLS, MPEG-DASH, advertisements, DRM and much more.
+Dolby OptiView Player is the universal video player solution from Dolby. It offers support for HLS, MPEG-DASH, advertisements, DRM and much more.
 
 On these pages, you'll learn how to get started with Dolby OptiView Player, how to use the various features, and explore the many examples.

--- a/theoplayer/web/index.mdx
+++ b/theoplayer/web/index.mdx
@@ -4,10 +4,13 @@ sidebar_label: Introduction
 sidebar_position: 1
 ---
 
-# THEOplayer Web SDK
+# OptiView Player Web SDK
 
 import Intro from '../shared/_intro.mdx';
+import RebrandingNotice from '../callouts/_rebranding_notice.md';
 import SidebarDocCardList from '@site/src/components/SidebarDocCardList';
+
+<RebrandingNotice />
 
 <Intro />
 <SidebarDocCardList />


### PR DESCRIPTION
Rebranding updates heading into NAB. Removed the announcement bar, added branding callouts, unified millicast/theoplayer/theolive/theoads/dolby.io -> OptiView.  Code and package names remain the original names.
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/documentation/pull/591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
