### PR TITLE
Improve THEOlive changelog update

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.THEOPLAYER_BOT_APP_ID }}
+          client-id: ${{ vars.THEOPLAYER_BOT_CLIENT_ID }}
           private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/theoplayer-release.yml
+++ b/.github/workflows/theoplayer-release.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.THEOPLAYER_BOT_APP_ID }}
+          client-id: ${{ vars.THEOPLAYER_BOT_CLIENT_ID }}
           private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.THEOPLAYER_BOT_APP_ID }}
+          client-id: ${{ vars.THEOPLAYER_BOT_CLIENT_ID }}
           private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/update-theolive-changelog.yml
+++ b/.github/workflows/update-theolive-changelog.yml
@@ -36,6 +36,7 @@ jobs:
             'https://engine-changelog.s3.eu-west-3.amazonaws.com/CHANGELOG.md'
       - name: Check for changes
         id: check_changes
+        # language=bash
         run: |
           if git diff --quiet theolive/changelog.md; then
             echo "No changelog changes detected."
@@ -44,6 +45,7 @@ jobs:
           fi
       - name: Commit and push changes
         if: ${{ steps.check_changes.outputs.changed }}
+        # language=bash
         run: |
           git checkout -b $UPDATE_BRANCH
           git add theolive/changelog.md
@@ -52,6 +54,7 @@ jobs:
       - name: Check if pull request already exists
         if: ${{ steps.check_changes.outputs.changed }}
         id: check_pr_exists
+        # language=bash
         run: |
           pr_count=$(gh pr list --base main --head "$UPDATE_BRANCH" --state open --limit 1 --json number --jq length)
           if ((pr_count > 0)); then
@@ -61,6 +64,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Create pull request
         if: ${{ steps.check_changes.outputs.changed && !steps.check_pr_exists.outputs.exists }}
+        # language=bash
         run: |
           gh pr create \
             --base main \

--- a/.github/workflows/update-theolive-changelog.yml
+++ b/.github/workflows/update-theolive-changelog.yml
@@ -30,6 +30,14 @@ jobs:
         run: |
           git config user.name 'theoplayer-bot[bot]'
           git config user.email '873105+theoplayer-bot[bot]@users.noreply.github.com'
+      - name: Create or checkout update branch
+        # language=bash
+        run: |
+          if git fetch --depth 1 origin refs/heads/$UPDATE_BRANCH ; then
+            git checkout -b $UPDATE_BRANCH FETCH_HEAD
+          else
+            git checkout -b $UPDATE_BRANCH HEAD
+          fi
       - name: Fetch THEOlive changelog
         run: |
           curl -fsSL -o theolive/changelog.md \
@@ -47,7 +55,6 @@ jobs:
         if: ${{ steps.check_changes.outputs.changed }}
         # language=bash
         run: |
-          git checkout -b $UPDATE_BRANCH
           git add theolive/changelog.md
           git commit -m 'Update THEOlive changelog'
           git push --force origin HEAD:$UPDATE_BRANCH

--- a/.github/workflows/update-theolive-changelog.yml
+++ b/.github/workflows/update-theolive-changelog.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.THEOPLAYER_BOT_APP_ID }}
+          client-id: ${{ vars.THEOPLAYER_BOT_CLIENT_ID }}
           private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Right now, the workflow checks whether the THEOlive changelog has changed compared to `main`. However, if there is already an open `update-theolive-changelog` branch, then there *were* already changes, and it always force-pushes a new commit with the (same) changes. For example, on https://github.com/THEOplayer/documentation/pull/615, there have been 100+ force pushes so far.

Fix it by first trying to check out an existing `update-theolive-changelog` branch.
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/documentation/pull/623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
