### PR TITLE
Added notes about CAF applications and the addition of the MPL app.

### DIFF
--- a/theoplayer/getting-started/01-sdks/06-chromecast/01-chromecast-app-customization.md
+++ b/theoplayer/getting-started/01-sdks/06-chromecast/01-chromecast-app-customization.md
@@ -108,9 +108,9 @@ your application is buffering or paused.
 
 ### Default Receiver application
 
-If you are connected to THEOplayer's default Receiver application, you cannot modify its appearance.
+If you are connected to THEOplayer's default Receiver application, you cannot modify its appearance. It is an application with THEOplayer functionality that uses Shaka for media playback.
 
-If you want to change the UI, you need to [connect your sender application with a different Receiver application ID](../../../how-to-guides/03-cast/01-chromecast/01-connecting-from-custom-sender-applications.md).
+If you want to change the UI, you need to [connect your sender application with a different Receiver application ID](../../../how-to-guides/03-cast/01-chromecast/01-connecting-from-custom-sender-applications.md). Also if you need to use Google's legacy Media Player Library (MPL) for playback, you will need to change the Receiver application ID.
 
 ### Custom Receiver application with THEOplayer Chromecast SDK
 

--- a/theoplayer/getting-started/01-sdks/06-chromecast/01-chromecast-app-customization.md
+++ b/theoplayer/getting-started/01-sdks/06-chromecast/01-chromecast-app-customization.md
@@ -110,7 +110,7 @@ your application is buffering or paused.
 
 If you are connected to THEOplayer's default Receiver application, you cannot modify its appearance. It is an application with THEOplayer functionality that uses Shaka for media playback.
 
-If you want to change the UI, you need to [connect your sender application with a different Receiver application ID](../../../how-to-guides/03-cast/01-chromecast/01-connecting-from-custom-sender-applications.md). Also if you need to use Google's legacy Media Player Library (MPL) for playback, you will need to change the Receiver application ID.
+If you want to change the UI, you need to [connect your sender application with a different Receiver application ID](../../../how-to-guides/03-cast/01-chromecast/01-connecting-from-custom-sender-applications.md). Also if you need to use Google's legacy Media Player Library (MPL) for playback, you will need to change the Receiver application ID to `44BAE7D1`.
 
 ### Custom Receiver application with THEOplayer Chromecast SDK
 

--- a/theoplayer/getting-started/01-sdks/06-chromecast/01-chromecast-app-customization.md
+++ b/theoplayer/getting-started/01-sdks/06-chromecast/01-chromecast-app-customization.md
@@ -108,7 +108,7 @@ your application is buffering or paused.
 
 ### Default Receiver application
 
-If you are connected to THEOplayer's default Receiver application, you cannot modify its appearance. It is an application with THEOplayer functionality that uses Shaka for media playback.
+If you are connected to OptiView Player's default Receiver application, you cannot modify its appearance. It is an application with OptiView Player functionality that uses Shaka for media playback.
 
 If you want to change the UI, you need to [connect your sender application with a different Receiver application ID](../../../how-to-guides/03-cast/01-chromecast/01-connecting-from-custom-sender-applications.md). Also if you need to use Google's legacy Media Player Library (MPL) for playback, you will need to change the Receiver application ID to `44BAE7D1`.
 

--- a/theoplayer/how-to-guides/03-cast/01-chromecast/06-enable-chromecast-on-the-sender.md
+++ b/theoplayer/how-to-guides/03-cast/01-chromecast/06-enable-chromecast-on-the-sender.md
@@ -20,7 +20,7 @@ The JavaScript snippet below illustrates how you include this Sender SDK. You ca
 <script type="text/javascript" src="//www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
 ```
 
-Once this SDK is imported, THEOplayer will automatically add the Chromecast casting capability to your player (if you've enabled the Chromecast feature for your THEOplayer SDK).
+Once this SDK is imported, THEOplayer will automatically add the Chromecast casting capability to your player (if you've enabled the Chromecast feature for your THEOplayer SDK). THEOplayer will use its default Chromecast receiver application if you do not specify an `appID` value on the configuration.
 
 ### Android SDK
 
@@ -203,7 +203,7 @@ In order to enable Chromecast on the iOS SDK:
 ## Connect with custom Chromecast Receiver application {#custom-receiver-app}
 
 The THEOplayer SDK on your Sender application connects with THEO Chromecast Receiver application by default,
-but you can connect it to a custom Chromecast Receiver application instead.
+but you can connect it to a custom Chromecast Receiver application instead. The default THEO Chromecast Receiver application has THEOplayer functionality, but uses Shaka for media playback. If you want to use Google's legacy Media Player Library (MPL) for playback, you will need to use either a custom application or connect to THEO's MPL Receiver application. Note that the MPL receiver does not support HLS-CMAF streams.
 
 ### Web SDK
 
@@ -221,6 +221,8 @@ let player = new THEOplayer.Player(element, {
   },
 });
 ```
+
+If you do not specify an `appID` value, the player will cast to the default THEOplayer Chromecast application. This is a Receiver application that has THEOplayer functionality integrated into it, but uses the Shaka player for media playback. If you require a Receiver application that uses Google's legacy Media Player Library (MPL), there is a Receiver application with THEOplayer functionality that uses MPL. Note that the MPL receiver does not support HLS-CMAF streams.
 
 ### Android SDK
 

--- a/theoplayer/how-to-guides/03-cast/01-chromecast/06-enable-chromecast-on-the-sender.md
+++ b/theoplayer/how-to-guides/03-cast/01-chromecast/06-enable-chromecast-on-the-sender.md
@@ -203,7 +203,7 @@ In order to enable Chromecast on the iOS SDK:
 ## Connect with custom Chromecast Receiver application {#custom-receiver-app}
 
 The THEOplayer SDK on your Sender application connects with THEO Chromecast Receiver application by default,
-but you can connect it to a custom Chromecast Receiver application instead. The default THEO Chromecast Receiver application has THEOplayer functionality, but uses Shaka for media playback. If you want to use Google's legacy Media Player Library (MPL) for playback, you will need to use either a custom application or connect to THEO's MPL Receiver application. Note that the MPL receiver does not support HLS-CMAF streams.
+but you can connect it to a custom Chromecast Receiver application instead. The default THEO Chromecast Receiver application has THEOplayer functionality, but uses Shaka for media playback. If you want to use Google's legacy Media Player Library (MPL) for playback, you will need to use either a custom application or connect to THEO's MPL Receiver application, using the `appID` value of `44BAE7D1`. Note that the MPL receiver does not support HLS-CMAF streams.
 
 ### Web SDK
 
@@ -222,7 +222,7 @@ let player = new THEOplayer.Player(element, {
 });
 ```
 
-If you do not specify an `appID` value, the player will cast to the default THEOplayer Chromecast application. This is a Receiver application that has THEOplayer functionality integrated into it, but uses the Shaka player for media playback. If you require a Receiver application that uses Google's legacy Media Player Library (MPL), there is a Receiver application with THEOplayer functionality that uses MPL. Note that the MPL receiver does not support HLS-CMAF streams.
+If you do not specify an `appID` value, the player will cast to the default THEOplayer Chromecast application. This is a Receiver application that has THEOplayer functionality integrated into it, but uses the Shaka player for media playback. If you require a Receiver application that uses Google's legacy Media Player Library (MPL), there is a Receiver application with THEOplayer functionality that uses MPL. Its `appID` is `44BAE7D1`. Note that the MPL receiver does not support HLS-CMAF streams.
 
 ### Android SDK
 

--- a/theoplayer/how-to-guides/03-cast/01-chromecast/06-enable-chromecast-on-the-sender.md
+++ b/theoplayer/how-to-guides/03-cast/01-chromecast/06-enable-chromecast-on-the-sender.md
@@ -20,7 +20,7 @@ The JavaScript snippet below illustrates how you include this Sender SDK. You ca
 <script type="text/javascript" src="//www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
 ```
 
-Once this SDK is imported, THEOplayer will automatically add the Chromecast casting capability to your player (if you've enabled the Chromecast feature for your THEOplayer SDK). THEOplayer will use its default Chromecast receiver application if you do not specify an `appID` value on the configuration.
+Once this SDK is imported, OptiView Player will automatically add the Chromecast casting capability to your player (if you've enabled the Chromecast feature for your OptiView Player SDK). OptiView Player will use its default Chromecast receiver application if you do not specify an `appID` value on the configuration.
 
 ### Android SDK
 

--- a/theoplayer/how-to-guides/03-cast/01-chromecast/06-enable-chromecast-on-the-sender.md
+++ b/theoplayer/how-to-guides/03-cast/01-chromecast/06-enable-chromecast-on-the-sender.md
@@ -222,7 +222,7 @@ let player = new THEOplayer.Player(element, {
 });
 ```
 
-If you do not specify an `appID` value, the player will cast to the default THEOplayer Chromecast application. This is a Receiver application that has THEOplayer functionality integrated into it, but uses the Shaka player for media playback. If you require a Receiver application that uses Google's legacy Media Player Library (MPL), there is a Receiver application with THEOplayer functionality that uses MPL. Its `appID` is `44BAE7D1`. Note that the MPL receiver does not support HLS-CMAF streams.
+If you do not specify an `appID` value, the player will cast to the default OptiView Player Chromecast application. This is a Receiver application that has OptiView Player functionality integrated into it, but uses the Shaka player for media playback. If you require a Receiver application that uses Google's legacy Media Player Library (MPL), there is a Receiver application with OptiView Player functionality that uses MPL. Its `appID` is `44BAE7D1`. Note that the MPL receiver does not support HLS-CMAF streams.
 
 ### Android SDK
 

--- a/theoplayer/how-to-guides/03-cast/01-chromecast/06-enable-chromecast-on-the-sender.md
+++ b/theoplayer/how-to-guides/03-cast/01-chromecast/06-enable-chromecast-on-the-sender.md
@@ -203,7 +203,7 @@ In order to enable Chromecast on the iOS SDK:
 ## Connect with custom Chromecast Receiver application {#custom-receiver-app}
 
 The THEOplayer SDK on your Sender application connects with THEO Chromecast Receiver application by default,
-but you can connect it to a custom Chromecast Receiver application instead. The default THEO Chromecast Receiver application has THEOplayer functionality, but uses Shaka for media playback. If you want to use Google's legacy Media Player Library (MPL) for playback, you will need to use either a custom application or connect to THEO's MPL Receiver application, using the `appID` value of `44BAE7D1`. Note that the MPL receiver does not support HLS-CMAF streams.
+but you can connect it to a custom Chromecast Receiver application instead. The default Dolby OptiView Chromecast Receiver application has OptiView Player functionality, but uses Shaka for media playback. If you want to use Google's legacy Media Player Library (MPL) for playback, you will need to use either a custom application or connect to Dolby OptiView's MPL Receiver application, using the `appID` value of `44BAE7D1`. Note that the MPL receiver does not support HLS-CMAF streams.
 
 ### Web SDK
 


### PR DESCRIPTION
Added documentation around the switch to using Shaka for all our default applications, and also the introduction of the new MPL-only application.

This needs to be updated with the app ID for the MPL only application ID when that has been created.