### PR TITLE
Add redirects for old links to v1 OptiView Live API

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -408,6 +408,8 @@ const config: Config = {
         createRedirects(existingPath) {
           if (existingPath.startsWith('/theoplayer/how-to-guides/web/uplynk/')) {
             return [existingPath.replace('/theoplayer/how-to-guides/web/uplynk/', '/theoplayer/how-to-guides/miscellaneous/verizon-media/')];
+          } else if (existingPath.startsWith('/theolive/v1/api/')) {
+            return [existingPath.replace('/theolive/v1/api/', '/theolive/api/')];
           }
           return undefined;
         },


### PR DESCRIPTION
Old links to the v1 OptiView Live API are currently broken. For example, this link *used* to work:
```
https://optiview.dolby.com/docs/theolive/api/channels/get-channel-status/
```
This PR adds redirects so all v1 APIs are still accessible with their old "unversioned" URL.