### PR TITLE
Add section on tracking protocols

### DIFF
--- a/theoplayer/how-to-guides/web/theolive/basic-playback-guide.mdx
+++ b/theoplayer/how-to-guides/web/theolive/basic-playback-guide.mdx
@@ -111,7 +111,7 @@ player.videoTracks[0].targetQuality = qualities[indexOfDesiredQualityLayer];
 
 ## Tracking Streaming Protocols
 
-In OptiView Live, an [`Endpoint`](https://optiview.dolby.com/docs/theoplayer/v11/api-reference/web/interfaces/Endpoint.html) can contain sources for multiple streaming protocols. For instance, it can be configured to load a WebRTC source for real time streaming but load a HLS source to allow seeking into a DVR window. Another use case is one where HESP is used as the primary streaming protocol, but the player could fall back to a HLS source if the platform doesn't support HESP playback.
+In OptiView Live, an [`Endpoint`](pathname:///theoplayer/v11/api-reference/web/interfaces/Endpoint.html) can contain sources for multiple streaming protocols. For instance, it can be configured to load a WebRTC source for real time streaming but load a HLS source to allow seeking into a DVR window. Another use case is one where HESP is used as the primary streaming protocol, but the player could fall back to a HLS source if the platform doesn't support HESP playback.
 
 To track switches between the possible streaming protocols, you can listen for the `currentsourcechange` event. The `currentSource` property in the payload shows which source is being used under the hood.
 

--- a/theoplayer/how-to-guides/web/theolive/basic-playback-guide.mdx
+++ b/theoplayer/how-to-guides/web/theolive/basic-playback-guide.mdx
@@ -116,7 +116,7 @@ In OptiView Live, an [`Endpoint`](https://optiview.dolby.com/docs/theoplayer/v11
 To track switches between the possible streaming protocols, you can listen for the `currentsourcechange` event. The `currentSource` property in the payload shows which source is being used under the hood.
 
 ```javascript
-player.addEventListener('currentsourcechange', console.log)
+player.addEventListener('currentsourcechange', console.log);
 ```
 
 ## More information

--- a/theoplayer/how-to-guides/web/theolive/basic-playback-guide.mdx
+++ b/theoplayer/how-to-guides/web/theolive/basic-playback-guide.mdx
@@ -109,6 +109,16 @@ Once you know what options you have available, you can set the stream to be a sp
 player.videoTracks[0].targetQuality = qualities[indexOfDesiredQualityLayer];
 ```
 
+## Tracking Streaming Protocols
+
+In OptiView Live, an [`Endpoint`](https://optiview.dolby.com/docs/theoplayer/v11/api-reference/web/interfaces/Endpoint.html) can contain sources for multiple streaming protocols. For instance, it can be configured to load a WebRTC source for real time streaming but load a HLS source to allow seeking into a DVR window. Another use case is one where HESP is used as the primary streaming protocol, but the player could fall back to a HLS source if the platform doesn't support HESP playback.
+
+To track switches between the possible streaming protocols, you can listen for the `currentsourcechange` event. The `currentSource` property in the payload shows which source is being used under the hood.
+
+```javascript
+player.addEventListener('currentsourcechange', console.log)
+```
+
 ## More information
 
 - [API references](pathname:///theoplayer/v11/api-reference/web/classes/Player.html)


### PR DESCRIPTION
Added a small section to explain how customers can track which src is being used under the hood for a `theolive` type source