### PR TITLE
Update GitHub Actions only on major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    version-update: semver-major
     schedule:
       interval: weekly
     cooldown:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           submodules: true
@@ -32,7 +32,7 @@ jobs:
       # Deploy to S3
       # See https://github.com/aws-actions/configure-aws-credentials
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.1.3
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::823129359776:role/optiview-docs-github
           aws-region: us-west-2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           submodules: true
@@ -35,7 +35,7 @@ jobs:
       # Deploy to S3
       # See https://github.com/aws-actions/configure-aws-credentials
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.1.3
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::548863597864:role/optiview-docs-github
           aws-region: us-west-2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           submodules: true

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.fork || github.triggering_actor == 'dependabot[bot]' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           submodules: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -14,13 +14,13 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork && github.triggering_actor != 'dependabot[bot]' }}
     steps:
       - name: Create app token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           client-id: ${{ vars.THEOPLAYER_BOT_CLIENT_ID }}
           private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1

--- a/.github/workflows/theoplayer-release.yml
+++ b/.github/workflows/theoplayer-release.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create app token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           client-id: ${{ vars.THEOPLAYER_BOT_CLIENT_ID }}
           private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -17,13 +17,13 @@ jobs:
       UPDATE_BRANCH: update-submodules
     steps:
       - name: Create app token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           client-id: ${{ vars.THEOPLAYER_BOT_CLIENT_ID }}
           private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1

--- a/.github/workflows/update-theolive-changelog.yml
+++ b/.github/workflows/update-theolive-changelog.yml
@@ -16,13 +16,13 @@ jobs:
       UPDATE_BRANCH: update-theolive-changelog
     steps:
       - name: Create app token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           client-id: ${{ vars.THEOPLAYER_BOT_CLIENT_ID }}
           private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1


### PR DESCRIPTION
GitHub Actions already use the latest version automatically when you only specify a major version in the tag, e.g. `actions/checkout@v6`. So we don't need Dependabot updating these on every patch release.