### PR TITLE
Update metadata guide for OptiView Live to use ID3

### DIFF
--- a/theolive/channel/metadata-insertion.mdx
+++ b/theolive/channel/metadata-insertion.mdx
@@ -64,7 +64,7 @@ See the API reference for [Send instream metadata](../api/send-channel-instream-
 
 ## Consuming on the player
 
-All metadata payloads — whether pushed via the API or forwarded from SEI — surface on the player as cues on a text track. See the [metadata guide for OptiView Player on web](/theoplayer/how-to-guides/web/theolive/metadata/) for how to listen for and parse them in your application.
+All metadata payloads — whether pushed via the API or forwarded from SEI — surface on the player as cues on a text track. See the [metadata guide for OptiView Player on web](/theoplayer/how-to-guides/web/theolive/metadata/), [Android](/theoplayer/how-to-guides/android/theolive/metadata/) or [iOS](/theoplayer/how-to-guides/ios/theolive/metadata/) for how to listen for and parse them in your application.
 
 ## High Availability
 

--- a/theoplayer/how-to-guides/android/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/android/theolive/metadata.mdx
@@ -1,0 +1,124 @@
+---
+title: Metadata
+sidebar_position: 3
+---
+
+# Metadata
+
+import Intro from '../../shared/theolive/_metadata-intro.mdx';
+
+<Intro />
+
+## User-data-unregistered SEI and API push
+
+import SeiIntro from '../../shared/theolive/_metadata-sei-intro.mdx';
+
+<SeiIntro />
+
+The OptiView Player SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#type) equal to `'id3'`. Listen for the cue event that matches when you want to react:
+
+- `addcue` fires as soon as a cue becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time.
+- `entercue` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.
+
+The ID3 frame will be contained in `cue.content` as a [ID3PrivateFrame](pathname:///theoplayer/v11/api-reference/web/interfaces/ID3PrivateFrame.html) with `ownerIdentifier` equal to `optiview.live:meta:<your-uuid>`.
+
+:::important
+Make sure to always check the frame's `id` and `ownerIdentifier` before using it, to avoid processing unrelated ID3 frames.
+:::
+
+Suppose your UUID is `11111111-1111-1111-1111-111111111111`:
+
+```javascript
+player.textTracks.addEventListener('addtrack', function trackListener(event) {
+  const track = event.track;
+  if (track.type === 'id3') {
+    // ID3 track was added. Listen for incoming ID3 cues.
+    track.addEventListener('addcue' /* or 'entercue' */, (e) => {
+      const frame = e.cue.content;
+      if (frame.id === 'PRIV' && frame.ownerIdentifier === 'optiview.live:meta:11111111-1111-1111-1111-111111111111') {
+        console.log('metadata', frame.data);
+      }
+    });
+    track.removeEventListener('typechange', trackListener);
+  } else if (track.type === '') {
+    // Track type is not yet known. Check again when it becomes known.
+    track.addEventListener('typechange', trackListener);
+  } else {
+    // Track type is known, but is not ID3. Stop listening.
+    track.removeEventListener('typechange', trackListener);
+  }
+});
+```
+
+Here the `frame.data` carries the binary payload exactly as it was sent — your application is responsible for parsing it (for example UTF-8 JSON, protobuf, or your own format).
+
+<details>
+<summary>Using third-party players</summary>
+
+When using a third-party player SDK, please refer to their respective documentation on how to retrieve ID3 from the stream.
+
+For example, with [Shaka Player](https://github.com/shaka-project/shaka-player),
+you can listen for the [`metadata` event](https://shaka-player-demo.appspot.com/docs/api/shaka.Player.html#.event:MetadataEvent):
+
+```javascript
+player.addEventListener('metadata', (event) => {
+  if (event.metadataType === 'org.id3') {
+    const frame = event.payload; // see https://shaka-player-demo.appspot.com/docs/api/shaka.extern.html#.MetadataFrame
+    if (frame.key === 'PRIV' && frame.description === 'optiview.live:meta:11111111-1111-1111-1111-111111111111') {
+      console.log('metadata', frame.data);
+    }
+  }
+});
+```
+
+With [hls.js](https://github.com/video-dev/hls.js/), you can listen for the `FRAG_PARSING_METADATA` event.
+However, hls.js doesn't come with a built-in ID3 parser, so you'll need to parse the ID3 tag manually:
+
+```javascript
+hls.on(Hls.Events.FRAG_PARSING_METADATA, (event, data) => {
+  for (const sample of data.samples) {
+    if (sample.type === Hls.MetadataSchema.emsg) {
+      const tag = sample.data;
+      // TODO Parse ID3 tag and look for ID3 PRIV frame with correct owner identifier
+    }
+  }
+});
+```
+
+</details>
+
+## Picture timing SEI
+
+Picture timing SEI cues surface on a text track with [`TextTrack.id`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#id) equal to `'timecode'`. Each cue is anchored to a frame, so `entercue` is usually the most useful event: it fires when playback reaches the cue, letting you react in sync with the video.
+
+```javascript
+player.textTracks.addEventListener('addtrack', (event) => {
+  const track = event.track;
+  if (track.id === 'timecode') {
+    track.mode = 'showing'; // Setting the mode to showing will enable the entercue events
+    track.addEventListener('entercue', onTimeCode);
+  }
+});
+```
+
+The cue `content` is a structured `TimeCode` object:
+
+```typescript
+export interface TimeCode {
+  readonly hours: number;
+  readonly minutes: number;
+  readonly seconds: number;
+  readonly frames: number;
+}
+```
+
+A handler can then turn that timecode into whatever action your app needs:
+
+```javascript
+const onTimeCode = (event) => {
+  const timeCode = event.cue.content;
+  // Insert other code here
+};
+```
+
+A full example could be as follows: you distribute sports matches and want to display an overlay on the player when the score changes. Every time a score change happens, you add a picture timing SEI message to the stream and store in your backend that this time corresponds with this score. (You could also just add the timing message to all frames if this is easier, but this requires more processing both server and player side.) This information can then be retrieved by the application running on the device of a viewer. You then add the event listener and listen for the `entercue` events. In the listener you check whether the `TimeCode` corresponds with a score change event you recorded earlier and if so, display an overlay over the player.

--- a/theoplayer/how-to-guides/android/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/android/theolive/metadata.mdx
@@ -49,36 +49,39 @@ Here the `frame.data` carries the binary payload exactly as it was sent — your
 
 ## Picture timing SEI
 
-Picture timing SEI cues surface on a text track with [`TextTrack.id`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#id) equal to `'timecode'`. Each cue is anchored to a frame, so `entercue` is usually the most useful event: it fires when playback reaches the cue, letting you react in sync with the video.
+Picture timing SEI cues surface on a text track with [`TextTrack.type`](<pathname:///theoplayer/v11/api-reference/android/com/theoplayer/android/api/player/track/texttrack/TextTrack.html#getType()>) equal to `TextTrackType.TIMECODE`. Each cue is anchored to a frame, so `entercue` is usually the most useful event: it fires when playback reaches the cue, letting you react in sync with the video.
 
-```javascript
-player.textTracks.addEventListener('addtrack', (event) => {
-  const track = event.track;
-  if (track.id === 'timecode') {
-    track.mode = 'showing'; // Setting the mode to showing will enable the entercue events
-    track.addEventListener('entercue', onTimeCode);
-  }
-});
+```kotlin
+theoplayerView.player.textTracks.addEventListener(TextTrackListEventTypes.ADDTRACK) { event ->
+    val track = event.track as TextTrack
+    if (track.type == TextTrackType.TIMECODE) {
+        // Timecode track was added. Listen for incoming timecode cues.
+        track.addEventListener(TextTrackEventTypes.ENTERCUE, onTimeCode)
+    }
+}
 ```
 
-The cue `content` is a structured `TimeCode` object:
+The cue `content` is a `TimeCode` object encoded as a `JSONObject`:
 
-```typescript
-export interface TimeCode {
-  readonly hours: number;
-  readonly minutes: number;
-  readonly seconds: number;
-  readonly frames: number;
-}
+```kotlin
+@Serializable
+data class TimeCode(
+    val hours: Int,
+    val minutes: Int,
+    val seconds: Int,
+    val frames: Int
+)
 ```
 
 A handler can then turn that timecode into whatever action your app needs:
 
-```javascript
-const onTimeCode = (event) => {
-  const timeCode = event.cue.content;
-  // Insert other code here
-};
+```kotlin
+val onTimeCode = EventListener<EnterCueEvent> { event ->
+    val cue = event.cue
+    val content = checkNotNull(cue.content)
+    val timeCode = Json.decodeFromString<TimeCode>(content.toString())
+    Log.d("MyApp", "Timecode: ${timeCode.hours}h ${timeCode.minutes}m ${timeCode.seconds}s ${timeCode.frames}f")
+}
 ```
 
 A full example could be as follows: you distribute sports matches and want to display an overlay on the player when the score changes. Every time a score change happens, you add a picture timing SEI message to the stream and store in your backend that this time corresponds with this score. (You could also just add the timing message to all frames if this is easier, but this requires more processing both server and player side.) This information can then be retrieved by the application running on the device of a viewer. You then add the event listener and listen for the `entercue` events. In the listener you check whether the `TimeCode` corresponds with a score change event you recorded earlier and if so, display an overlay over the player.

--- a/theoplayer/how-to-guides/android/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/android/theolive/metadata.mdx
@@ -15,77 +15,37 @@ import SeiIntro from '../../shared/theolive/_metadata-sei-intro.mdx';
 
 <SeiIntro />
 
-The OptiView Player SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#type) equal to `'id3'`. Listen for the cue event that matches when you want to react:
+The OptiView Player Android SDK exposes these ID3 frames on a text track with [`TextTrack.type`](<pathname:///theoplayer/v11/api-reference/android/com/theoplayer/android/api/player/track/texttrack/TextTrack.html#getType()>) equal to `TextTrackType.ID3`. Listen for the cue event that matches when you want to react:
 
-- `addcue` fires as soon as a cue becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time.
-- `entercue` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.
+- `TextTrackEventTypes.ADDCUE` fires as soon as a cue becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time.
+- `TextTrackEventTypes.ENTERCUE` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.
 
-The ID3 frame will be contained in `cue.content` as a [ID3PrivateFrame](pathname:///theoplayer/v11/api-reference/web/interfaces/ID3PrivateFrame.html) with `ownerIdentifier` equal to `optiview.live:meta:<your-uuid>`.
+The ID3 frame will be contained in `cue.frame` as a [ID3Frame.Private](pathname:///theoplayer/v11/api-reference/android/com/theoplayer/android/api/player/track/texttrack/id3/ID3Frame.Private.html) with `ownerIdentifier` equal to `optiview.live:meta:<your-uuid>`.
 
 :::important
-Make sure to always check the frame's `id` and `ownerIdentifier` before using it, to avoid processing unrelated ID3 frames.
+Make sure to always check the frame's type and `ownerIdentifier` before using it, to avoid processing unrelated ID3 frames.
 :::
 
 Suppose your UUID is `11111111-1111-1111-1111-111111111111`:
 
-```javascript
-player.textTracks.addEventListener('addtrack', function trackListener(event) {
-  const track = event.track;
-  if (track.type === 'id3') {
-    // ID3 track was added. Listen for incoming ID3 cues.
-    track.addEventListener('addcue' /* or 'entercue' */, (e) => {
-      const frame = e.cue.content;
-      if (frame.id === 'PRIV' && frame.ownerIdentifier === 'optiview.live:meta:11111111-1111-1111-1111-111111111111') {
-        console.log('metadata', frame.data);
-      }
-    });
-    track.removeEventListener('typechange', trackListener);
-  } else if (track.type === '') {
-    // Track type is not yet known. Check again when it becomes known.
-    track.addEventListener('typechange', trackListener);
-  } else {
-    // Track type is known, but is not ID3. Stop listening.
-    track.removeEventListener('typechange', trackListener);
-  }
-});
+```kotlin
+val addCueListener = EventListener<AddCueEvent> { event ->
+    val cue = event.cue as? ID3Cue ?: return@EventListener
+    val frame = cue.frame as? ID3Frame.Private ?: return@EventListener
+    if (frame.ownerIdentifier == "optiview.live:meta:11111111-1111-1111-1111-111111111111") {
+        Log.d("MyApp", "Metadata: ${frame.data.decodeToString()}")
+    }
+}
+theoplayerView.player.textTracks.addEventListener(TextTrackListEventTypes.ADDTRACK) { event ->
+    val track = event.track as TextTrack
+    if (track.type == TextTrackType.ID3) {
+        // ID3 track was added. Listen for incoming ID3 cues.
+        track.addEventListener(TextTrackEventTypes.ADDCUE /* or TextTrackEventTypes.ENTERCUE */, addCueListener)
+    }
+}
 ```
 
 Here the `frame.data` carries the binary payload exactly as it was sent — your application is responsible for parsing it (for example UTF-8 JSON, protobuf, or your own format).
-
-<details>
-<summary>Using third-party players</summary>
-
-When using a third-party player SDK, please refer to their respective documentation on how to retrieve ID3 from the stream.
-
-For example, with [Shaka Player](https://github.com/shaka-project/shaka-player),
-you can listen for the [`metadata` event](https://shaka-player-demo.appspot.com/docs/api/shaka.Player.html#.event:MetadataEvent):
-
-```javascript
-player.addEventListener('metadata', (event) => {
-  if (event.metadataType === 'org.id3') {
-    const frame = event.payload; // see https://shaka-player-demo.appspot.com/docs/api/shaka.extern.html#.MetadataFrame
-    if (frame.key === 'PRIV' && frame.description === 'optiview.live:meta:11111111-1111-1111-1111-111111111111') {
-      console.log('metadata', frame.data);
-    }
-  }
-});
-```
-
-With [hls.js](https://github.com/video-dev/hls.js/), you can listen for the `FRAG_PARSING_METADATA` event.
-However, hls.js doesn't come with a built-in ID3 parser, so you'll need to parse the ID3 tag manually:
-
-```javascript
-hls.on(Hls.Events.FRAG_PARSING_METADATA, (event, data) => {
-  for (const sample of data.samples) {
-    if (sample.type === Hls.MetadataSchema.emsg) {
-      const tag = sample.data;
-      // TODO Parse ID3 tag and look for ID3 PRIV frame with correct owner identifier
-    }
-  }
-});
-```
-
-</details>
 
 ## Picture timing SEI
 

--- a/theoplayer/how-to-guides/ios/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/ios/theolive/metadata.mdx
@@ -1,0 +1,124 @@
+---
+title: Metadata
+sidebar_position: 3
+---
+
+# Metadata
+
+import Intro from '../../shared/theolive/_metadata-intro.mdx';
+
+<Intro />
+
+## User-data-unregistered SEI and API push
+
+import SeiIntro from '../../shared/theolive/_metadata-sei-intro.mdx';
+
+<SeiIntro />
+
+The OptiView Player Web SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#type) equal to `'id3'`. Listen for the cue event that matches when you want to react:
+
+- `addcue` fires as soon as a cue becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time.
+- `entercue` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.
+
+The ID3 frame will be contained in `cue.content` as a [ID3PrivateFrame](pathname:///theoplayer/v11/api-reference/web/interfaces/ID3PrivateFrame.html) with `ownerIdentifier` equal to `optiview.live:meta:<your-uuid>`.
+
+:::important
+Make sure to always check the frame's `id` and `ownerIdentifier` before using it, to avoid processing unrelated ID3 frames.
+:::
+
+Suppose your UUID is `11111111-1111-1111-1111-111111111111`:
+
+```javascript
+player.textTracks.addEventListener('addtrack', function trackListener(event) {
+  const track = event.track;
+  if (track.type === 'id3') {
+    // ID3 track was added. Listen for incoming ID3 cues.
+    track.addEventListener('addcue' /* or 'entercue' */, (e) => {
+      const frame = e.cue.content;
+      if (frame.id === 'PRIV' && frame.ownerIdentifier === 'optiview.live:meta:11111111-1111-1111-1111-111111111111') {
+        console.log('metadata', frame.data);
+      }
+    });
+    track.removeEventListener('typechange', trackListener);
+  } else if (track.type === '') {
+    // Track type is not yet known. Check again when it becomes known.
+    track.addEventListener('typechange', trackListener);
+  } else {
+    // Track type is known, but is not ID3. Stop listening.
+    track.removeEventListener('typechange', trackListener);
+  }
+});
+```
+
+Here the `frame.data` carries the binary payload exactly as it was sent — your application is responsible for parsing it (for example UTF-8 JSON, protobuf, or your own format).
+
+<details>
+<summary>Using third-party players</summary>
+
+When using a third-party player SDK, please refer to their respective documentation on how to retrieve ID3 from the stream.
+
+For example, with [Shaka Player](https://github.com/shaka-project/shaka-player),
+you can listen for the [`metadata` event](https://shaka-player-demo.appspot.com/docs/api/shaka.Player.html#.event:MetadataEvent):
+
+```javascript
+player.addEventListener('metadata', (event) => {
+  if (event.metadataType === 'org.id3') {
+    const frame = event.payload; // see https://shaka-player-demo.appspot.com/docs/api/shaka.extern.html#.MetadataFrame
+    if (frame.key === 'PRIV' && frame.description === 'optiview.live:meta:11111111-1111-1111-1111-111111111111') {
+      console.log('metadata', frame.data);
+    }
+  }
+});
+```
+
+With [hls.js](https://github.com/video-dev/hls.js/), you can listen for the `FRAG_PARSING_METADATA` event.
+However, hls.js doesn't come with a built-in ID3 parser, so you'll need to parse the ID3 tag manually:
+
+```javascript
+hls.on(Hls.Events.FRAG_PARSING_METADATA, (event, data) => {
+  for (const sample of data.samples) {
+    if (sample.type === Hls.MetadataSchema.emsg) {
+      const tag = sample.data;
+      // TODO Parse ID3 tag and look for ID3 PRIV frame with correct owner identifier
+    }
+  }
+});
+```
+
+</details>
+
+## Picture timing SEI
+
+Picture timing SEI cues surface on a text track with [`TextTrack.id`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#id) equal to `'timecode'`. Each cue is anchored to a frame, so `entercue` is usually the most useful event: it fires when playback reaches the cue, letting you react in sync with the video.
+
+```javascript
+player.textTracks.addEventListener('addtrack', (event) => {
+  const track = event.track;
+  if (track.id === 'timecode') {
+    track.mode = 'showing'; // Setting the mode to showing will enable the entercue events
+    track.addEventListener('entercue', onTimeCode);
+  }
+});
+```
+
+The cue `content` is a structured `TimeCode` object:
+
+```typescript
+export interface TimeCode {
+  readonly hours: number;
+  readonly minutes: number;
+  readonly seconds: number;
+  readonly frames: number;
+}
+```
+
+A handler can then turn that timecode into whatever action your app needs:
+
+```javascript
+const onTimeCode = (event) => {
+  const timeCode = event.cue.content;
+  // Insert other code here
+};
+```
+
+A full example could be as follows: you distribute sports matches and want to display an overlay on the player when the score changes. Every time a score change happens, you add a picture timing SEI message to the stream and store in your backend that this time corresponds with this score. (You could also just add the timing message to all frames if this is easier, but this requires more processing both server and player side.) This information can then be retrieved by the application running on the device of a viewer. You then add the event listener and listen for the `entercue` events. In the listener you check whether the `TimeCode` corresponds with a score change event you recorded earlier and if so, display an overlay over the player.

--- a/theoplayer/how-to-guides/ios/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/ios/theolive/metadata.mdx
@@ -15,7 +15,7 @@ import SeiIntro from '../../shared/theolive/_metadata-sei-intro.mdx';
 
 <SeiIntro />
 
-The OptiView Player iOS SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/ios/Protocols/TextTrack.html) equal to `TextTrackType.id3`. Listen for the cue event that matches when you want to react:
+The OptiView Player iOS SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/ios/Protocols/TextTrack.html) equal to `"id3"`. Listen for the cue event that matches when you want to react:
 
 - `TextTrackEventTypes.ADD_CUE` fires as soon as a cue becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time.
 - `TextTrackEventTypes.ENTER_CUE` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.

--- a/theoplayer/how-to-guides/ios/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/ios/theolive/metadata.mdx
@@ -15,12 +15,12 @@ import SeiIntro from '../../shared/theolive/_metadata-sei-intro.mdx';
 
 <SeiIntro />
 
-The OptiView Player Web SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#type) equal to `'id3'`. Listen for the cue event that matches when you want to react:
+The OptiView Player iOS SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/api-reference/ios/Protocols/TextTrack.html) equal to `TextTrackType.id3`. Listen for the cue event that matches when you want to react:
 
-- `addcue` fires as soon as a cue becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time.
-- `entercue` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.
+- `TextTrackEventTypes.ADD_CUE` fires as soon as a cue becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time.
+- `TextTrackEventTypes.ENTER_CUE` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.
 
-The ID3 frame will be contained in `cue.content` as a [ID3PrivateFrame](pathname:///theoplayer/v11/api-reference/web/interfaces/ID3PrivateFrame.html) with `ownerIdentifier` equal to `optiview.live:meta:<your-uuid>`.
+The ID3 frame will be contained in `cue.contentDictionary` with `id` equal to `"PRIV"` and `ownerIdentifier` equal to `optiview.live:meta:<your-uuid>`.
 
 :::important
 Make sure to always check the frame's `id` and `ownerIdentifier` before using it, to avoid processing unrelated ID3 frames.
@@ -28,62 +28,20 @@ Make sure to always check the frame's `id` and `ownerIdentifier` before using it
 
 Suppose your UUID is `11111111-1111-1111-1111-111111111111`:
 
-```javascript
-player.textTracks.addEventListener('addtrack', function trackListener(event) {
-  const track = event.track;
-  if (track.type === 'id3') {
-    // ID3 track was added. Listen for incoming ID3 cues.
-    track.addEventListener('addcue' /* or 'entercue' */, (e) => {
-      const frame = e.cue.content;
-      if (frame.id === 'PRIV' && frame.ownerIdentifier === 'optiview.live:meta:11111111-1111-1111-1111-111111111111') {
-        console.log('metadata', frame.data);
-      }
-    });
-    track.removeEventListener('typechange', trackListener);
-  } else if (track.type === '') {
-    // Track type is not yet known. Check again when it becomes known.
-    track.addEventListener('typechange', trackListener);
-  } else {
-    // Track type is known, but is not ID3. Stop listening.
-    track.removeEventListener('typechange', trackListener);
-  }
-});
+```swift
+_ = theoplayer.textTracks.addEventListener(type: TextTrackListEventTypes.ADD_TRACK, listener: { (addTrackEvent) in
+  let track = addTrackEvent.track
+  guard track.type == TextTrackType.ID3.rawValue else { return }
+  // ID3 track was added. Listen for incoming ID3 cues.
+  _ = track.addEventListener(type: TextTrackEventTypes.ADD_CUE, listener: { (addCueEvent) in
+      guard let cue = addCueEvent.cue as? Id3Cue,
+            let frame = cue.contentDictionary else { return }
+      guard frame["id"] == "PRIV",
+            frame["ownerIdentifier"] == "optiview.live:meta:11111111-1111-1111-1111-111111111111"
+            else { return }
+      print("Metadata: \(frame["data"])")
+  })
+})
 ```
 
-Here the `frame.data` carries the binary payload exactly as it was sent — your application is responsible for parsing it (for example UTF-8 JSON, protobuf, or your own format).
-
-<details>
-<summary>Using third-party players</summary>
-
-When using a third-party player SDK, please refer to their respective documentation on how to retrieve ID3 from the stream.
-
-For example, with [Shaka Player](https://github.com/shaka-project/shaka-player),
-you can listen for the [`metadata` event](https://shaka-player-demo.appspot.com/docs/api/shaka.Player.html#.event:MetadataEvent):
-
-```javascript
-player.addEventListener('metadata', (event) => {
-  if (event.metadataType === 'org.id3') {
-    const frame = event.payload; // see https://shaka-player-demo.appspot.com/docs/api/shaka.extern.html#.MetadataFrame
-    if (frame.key === 'PRIV' && frame.description === 'optiview.live:meta:11111111-1111-1111-1111-111111111111') {
-      console.log('metadata', frame.data);
-    }
-  }
-});
-```
-
-With [hls.js](https://github.com/video-dev/hls.js/), you can listen for the `FRAG_PARSING_METADATA` event.
-However, hls.js doesn't come with a built-in ID3 parser, so you'll need to parse the ID3 tag manually:
-
-```javascript
-hls.on(Hls.Events.FRAG_PARSING_METADATA, (event, data) => {
-  for (const sample of data.samples) {
-    if (sample.type === Hls.MetadataSchema.emsg) {
-      const tag = sample.data;
-      // TODO Parse ID3 tag and look for ID3 PRIV frame with correct owner identifier
-    }
-  }
-});
-```
-
-</details>
-
+Here the `frame["data"]` carries the binary payload exactly as it was sent — your application is responsible for parsing it (for example UTF-8 JSON, protobuf, or your own format).

--- a/theoplayer/how-to-guides/ios/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/ios/theolive/metadata.mdx
@@ -87,38 +87,3 @@ hls.on(Hls.Events.FRAG_PARSING_METADATA, (event, data) => {
 
 </details>
 
-## Picture timing SEI
-
-Picture timing SEI cues surface on a text track with [`TextTrack.id`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#id) equal to `'timecode'`. Each cue is anchored to a frame, so `entercue` is usually the most useful event: it fires when playback reaches the cue, letting you react in sync with the video.
-
-```javascript
-player.textTracks.addEventListener('addtrack', (event) => {
-  const track = event.track;
-  if (track.id === 'timecode') {
-    track.mode = 'showing'; // Setting the mode to showing will enable the entercue events
-    track.addEventListener('entercue', onTimeCode);
-  }
-});
-```
-
-The cue `content` is a structured `TimeCode` object:
-
-```typescript
-export interface TimeCode {
-  readonly hours: number;
-  readonly minutes: number;
-  readonly seconds: number;
-  readonly frames: number;
-}
-```
-
-A handler can then turn that timecode into whatever action your app needs:
-
-```javascript
-const onTimeCode = (event) => {
-  const timeCode = event.cue.content;
-  // Insert other code here
-};
-```
-
-A full example could be as follows: you distribute sports matches and want to display an overlay on the player when the score changes. Every time a score change happens, you add a picture timing SEI message to the stream and store in your backend that this time corresponds with this score. (You could also just add the timing message to all frames if this is easier, but this requires more processing both server and player side.) This information can then be retrieved by the application running on the device of a viewer. You then add the event listener and listen for the `entercue` events. In the listener you check whether the `TimeCode` corresponds with a score change event you recorded earlier and if so, display an overlay over the player.

--- a/theoplayer/how-to-guides/ios/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/ios/theolive/metadata.mdx
@@ -31,7 +31,7 @@ Suppose your UUID is `11111111-1111-1111-1111-111111111111`:
 ```swift
 _ = theoplayer.textTracks.addEventListener(type: TextTrackListEventTypes.ADD_TRACK, listener: { (addTrackEvent) in
   let track = addTrackEvent.track
-  guard track.type == TextTrackType.ID3.rawValue else { return }
+  guard track.type == TextTrackType.id3.rawValue else { return }
   // ID3 track was added. Listen for incoming ID3 cues.
   _ = track.addEventListener(type: TextTrackEventTypes.ADD_CUE, listener: { (addCueEvent) in
       guard let cue = addCueEvent.cue as? Id3Cue,

--- a/theoplayer/how-to-guides/ios/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/ios/theolive/metadata.mdx
@@ -30,8 +30,9 @@ Suppose your UUID is `11111111-1111-1111-1111-111111111111`:
 
 ```swift
 _ = theoplayer.textTracks.addEventListener(type: TextTrackListEventTypes.ADD_TRACK, listener: { (addTrackEvent) in
-  let track = addTrackEvent.track
-  guard track.type == TextTrackType.id3.rawValue else { return }
+  guard let track = addTrackEvent.track as? TextTrack,
+        track.type == "id3"
+        else { return }
   // ID3 track was added. Listen for incoming ID3 cues.
   _ = track.addEventListener(type: TextTrackEventTypes.ADD_CUE, listener: { (addCueEvent) in
       guard let cue = addCueEvent.cue as? Id3Cue,

--- a/theoplayer/how-to-guides/ios/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/ios/theolive/metadata.mdx
@@ -15,7 +15,7 @@ import SeiIntro from '../../shared/theolive/_metadata-sei-intro.mdx';
 
 <SeiIntro />
 
-The OptiView Player iOS SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/api-reference/ios/Protocols/TextTrack.html) equal to `TextTrackType.id3`. Listen for the cue event that matches when you want to react:
+The OptiView Player iOS SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/ios/Protocols/TextTrack.html) equal to `TextTrackType.id3`. Listen for the cue event that matches when you want to react:
 
 - `TextTrackEventTypes.ADD_CUE` fires as soon as a cue becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time.
 - `TextTrackEventTypes.ENTER_CUE` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.

--- a/theoplayer/how-to-guides/shared/theolive/_metadata-intro.mdx
+++ b/theoplayer/how-to-guides/shared/theolive/_metadata-intro.mdx
@@ -1,0 +1,8 @@
+Metadata that travels through your OptiView Live stream — whether [pushed via the API or embedded as SEI](/theolive/channel/metadata-insertion/) — surfaces on the player as cues on a text track. The general approach is the same in every case:
+
+1. Listen for `addtrack` on `player.textTracks` so you find out when a new metadata track shows up.
+2. Subscribe to a cue event on that track.
+3. Inspect the cue to make sure it carries the metadata you care about.
+4. Read the payload from `cue.content`.
+
+The properties you match on, the cue event you subscribe to, and the shape of `cue.content` all depend on which kind of metadata is being delivered.

--- a/theoplayer/how-to-guides/shared/theolive/_metadata-sei-intro.mdx
+++ b/theoplayer/how-to-guides/shared/theolive/_metadata-sei-intro.mdx
@@ -1,0 +1,6 @@
+UDU SEI and API-pushed payloads surface as ID3 `PRIV` frames inside an ID3 v2.4 tag embedded in an `emsg` box, carried by the CMAF segments of the stream.
+
+- The owner identifier of the `PRIV` frame will be set to: `optiview.live:meta:<your-uuid>`
+- The frame's private data will contain your metadata as raw binary data.
+
+(See [section 4.27 of the ID3 v2.4 Native Frames specification](https://id3.org/id3v2.4.0-frames) and [ID3 in CMAF](https://aomediacodec.github.io/id3-emsg/) for more details.)

--- a/theoplayer/how-to-guides/web/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/web/theolive/metadata.mdx
@@ -15,7 +15,7 @@ import SeiIntro from '../../shared/theolive/_metadata-sei-intro.mdx';
 
 <SeiIntro />
 
-The OptiView Player SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#type) equal to `'id3'`. Listen for the cue event that matches when you want to react:
+The OptiView Player Web SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#type) equal to `'id3'`. Listen for the cue event that matches when you want to react:
 
 - `addcue` fires as soon as a cue becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time.
 - `entercue` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.

--- a/theoplayer/how-to-guides/web/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/web/theolive/metadata.mdx
@@ -16,12 +16,19 @@ The properties you match on, the cue event you subscribe to, and the shape of `c
 
 ## User-data-unregistered SEI and API push
 
-UDU SEI and API-pushed payloads surface on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#type) equal to `'id3'`. Listen for the cue event that matches when you want to react:
+UDU SEI and API-pushed payloads surface as ID3 `PRIV` frames inside an ID3 v2.4 tag embedded in an `emsg` box, carried by the CMAF segments of the stream.
+
+- The owner identifier of the `PRIV` frame will be set to: `optiview.live:meta:<your-uuid>`
+- The frame's private data will contain your metadata as raw binary data.
+
+(See [section 4.27 of the ID3 v2.4 Native Frames specification](https://id3.org/id3v2.4.0-frames) and [ID3 in CMAF](https://aomediacodec.github.io/id3-emsg/) for more details.)
+
+The OptiView Player SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#type) equal to `'id3'`. Listen for the cue event that matches when you want to react:
 
 - `addcue` fires as soon as a cue becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time.
 - `entercue` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.
 
-The metadata will be contained in `cue.content` as an ID3 `PRIV` frame (represented by an [ID3PrivateFrame](pathname:///theoplayer/v11/api-reference/web/interfaces/ID3PrivateFrame.html)) with `ownerIdentifier` equal to `optiview.live:meta:<your-uuid>`.
+The ID3 frame will be contained in `cue.content` as a [ID3PrivateFrame](pathname:///theoplayer/v11/api-reference/web/interfaces/ID3PrivateFrame.html) with `ownerIdentifier` equal to `optiview.live:meta:<your-uuid>`.
 
 :::important
 Make sure to always check the frame's `id` and `ownerIdentifier` before using it, to avoid processing unrelated ID3 frames.

--- a/theoplayer/how-to-guides/web/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/web/theolive/metadata.mdx
@@ -52,6 +52,41 @@ player.textTracks.addEventListener('addtrack', (event) => {
 
 Here the `frame.data` carries the binary payload exactly as it was sent — your application is responsible for parsing it (for example UTF-8 JSON, protobuf, or your own format).
 
+<details>
+<summary>Using third-party players</summary>
+
+When using a third-party player SDK, please refer to their respective documentation on how to retrieve ID3 from the stream.
+
+For example, with [Shaka Player](https://github.com/shaka-project/shaka-player),
+you can listen for the [`metadata` event](https://shaka-player-demo.appspot.com/docs/api/shaka.Player.html#.event:MetadataEvent):
+
+```javascript
+player.addEventListener('metadata', (event) => {
+  if (event.metadataType === 'org.id3') {
+    const frame = event.payload; // see https://shaka-player-demo.appspot.com/docs/api/shaka.extern.html#.MetadataFrame
+    if (frame.key === 'PRIV' && frame.description === 'optiview.live:meta:11111111-1111-1111-1111-111111111111') {
+      console.log('metadata', frame.data);
+    }
+  }
+});
+```
+
+With [hls.js](https://github.com/video-dev/hls.js/), you can listen for the `FRAG_PARSING_METADATA` event.
+However, hls.js doesn't come with a built-in ID3 parser, so you'll need to parse the ID3 tag manually:
+
+```javascript
+hls.on(Hls.Events.FRAG_PARSING_METADATA, (event, data) => {
+  for (const sample of data.samples) {
+    if (sample.type === Hls.MetadataSchema.emsg) {
+      const tag = sample.data;
+      // TODO Parse ID3 tag and look for ID3 PRIV frame with correct owner identifier
+    }
+  }
+});
+```
+
+</details>
+
 ## Picture timing SEI
 
 Picture timing SEI cues surface on a text track with [`TextTrack.id`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#id) equal to `'timecode'`. Each cue is anchored to a frame, so `entercue` is usually the most useful event: it fires when playback reaches the cue, letting you react in sync with the video.

--- a/theoplayer/how-to-guides/web/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/web/theolive/metadata.mdx
@@ -37,15 +37,23 @@ Make sure to always check the frame's `id` and `ownerIdentifier` before using it
 Suppose your UUID is `11111111-1111-1111-1111-111111111111`:
 
 ```javascript
-player.textTracks.addEventListener('addtrack', (event) => {
+player.textTracks.addEventListener('addtrack', function trackListener(event) {
   const track = event.track;
   if (track.type === 'id3') {
+    // ID3 track was added. Listen for incoming ID3 cues.
     track.addEventListener('addcue' /* or 'entercue' */, (e) => {
       const frame = e.cue.content;
       if (frame.id === 'PRIV' && frame.ownerIdentifier === 'optiview.live:meta:11111111-1111-1111-1111-111111111111') {
         console.log('metadata', frame.data);
       }
     });
+    track.removeEventListener('typechange', trackListener);
+  } else if (track.type === '') {
+    // Track type is not yet known. Check again when it becomes known.
+    track.addEventListener('typechange', trackListener);
+  } else {
+    // Track type is known, but is not ID3. Stop listening.
+    track.removeEventListener('typechange', trackListener);
   }
 });
 ```

--- a/theoplayer/how-to-guides/web/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/web/theolive/metadata.mdx
@@ -21,7 +21,7 @@ UDU SEI and API-pushed payloads surface on a text track with [`TextTrack.type`](
 - `addcue` fires as soon as a cue becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time.
 - `entercue` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.
 
-The metadata will be contained in `cue.content` as an ID3 `PRIV` frame (represented by an [ID3PrivateFrame](pathname:///theoplayer/v11/api-reference/web/interfaces/ID3PrivateFrame.html)) with `ownerIdentifier` equal to `urn:uuid:<your-uuid>`.
+The metadata will be contained in `cue.content` as an ID3 `PRIV` frame (represented by an [ID3PrivateFrame](pathname:///theoplayer/v11/api-reference/web/interfaces/ID3PrivateFrame.html)) with `ownerIdentifier` equal to `optiview.live:meta:<your-uuid>`.
 
 :::important
 Make sure to always check the frame's `id` and `ownerIdentifier` before using it, to avoid processing unrelated ID3 frames.
@@ -35,7 +35,7 @@ player.textTracks.addEventListener('addtrack', (event) => {
   if (track.type === 'id3') {
     track.addEventListener('addcue' /* or 'entercue' */, (e) => {
       const frame = e.cue.content;
-      if (frame.id === 'PRIV' && frame.ownerIdentifier === 'urn:uuid:11111111-1111-1111-1111-111111111111') {
+      if (frame.id === 'PRIV' && frame.ownerIdentifier === 'optiview.live:meta:11111111-1111-1111-1111-111111111111') {
         console.log('metadata', frame.data);
       }
     });

--- a/theoplayer/how-to-guides/web/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/web/theolive/metadata.mdx
@@ -5,23 +5,15 @@ sidebar_position: 3
 
 # Metadata
 
-Metadata that travels through your OptiView Live stream — whether [pushed via the API or embedded as SEI](/theolive/channel/metadata-insertion/) — surfaces on the player as cues on a text track. The general approach is the same in every case:
+import Intro from '../../shared/theolive/_metadata-intro.mdx';
 
-1. Listen for `addtrack` on `player.textTracks` so you find out when a new metadata track shows up.
-2. Subscribe to a cue event on that track.
-3. Inspect the cue to make sure it carries the metadata you care about.
-4. Read the payload from `cue.content`.
-
-The properties you match on, the cue event you subscribe to, and the shape of `cue.content` all depend on which kind of metadata is being delivered.
+<Intro />
 
 ## User-data-unregistered SEI and API push
 
-UDU SEI and API-pushed payloads surface as ID3 `PRIV` frames inside an ID3 v2.4 tag embedded in an `emsg` box, carried by the CMAF segments of the stream.
+import SeiIntro from '../../shared/theolive/_metadata-sei-intro.mdx';
 
-- The owner identifier of the `PRIV` frame will be set to: `optiview.live:meta:<your-uuid>`
-- The frame's private data will contain your metadata as raw binary data.
-
-(See [section 4.27 of the ID3 v2.4 Native Frames specification](https://id3.org/id3v2.4.0-frames) and [ID3 in CMAF](https://aomediacodec.github.io/id3-emsg/) for more details.)
+<SeiIntro />
 
 The OptiView Player SDK exposes these ID3 frames on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#type) equal to `'id3'`. Listen for the cue event that matches when you want to react:
 

--- a/theoplayer/how-to-guides/web/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/web/theolive/metadata.mdx
@@ -8,29 +8,42 @@ sidebar_position: 3
 Metadata that travels through your OptiView Live stream — whether [pushed via the API or embedded as SEI](/theolive/channel/metadata-insertion/) — surfaces on the player as cues on a text track. The general approach is the same in every case:
 
 1. Listen for `addtrack` on `player.textTracks` so you find out when a new metadata track shows up.
-2. Inspect the track to make sure it carries the metadata you care about.
-3. Subscribe to a cue event on that track and read the payload from `cue.content`.
+2. Subscribe to a cue event on that track.
+3. Inspect the cue to make sure it carries the metadata you care about.
+4. Read the payload from `cue.content`.
 
 The properties you match on, the cue event you subscribe to, and the shape of `cue.content` all depend on which kind of metadata is being delivered.
 
 ## User-data-unregistered SEI and API push
 
-UDU SEI and API-pushed payloads surface on a text track with `type === 'emsg'` and an `inBandMetadataTrackDispatchType` of `urn:uuid:<your-uuid>`. Pick the cue event that matches when you want to react: `addcue` fires as soon as a payload becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time. `entercue` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.
+UDU SEI and API-pushed payloads surface on a text track with [`TextTrack.type`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#type) equal to `'id3'`. Listen for the cue event that matches when you want to react:
+
+- `addcue` fires as soon as a cue becomes available on the track, before playback reaches it — useful when you want to prefetch data or update application state ahead of time.
+- `entercue` fires when playback enters the cue — useful when you want to act in sync with the video, for example to render an overlay at the moment the cue was inserted.
+
+The metadata will be contained in `cue.content` as an ID3 `PRIV` frame (represented by an [ID3PrivateFrame](pathname:///theoplayer/v11/api-reference/web/interfaces/ID3PrivateFrame.html)) with `ownerIdentifier` equal to `urn:uuid:<your-uuid>`.
+
+:::important
+Make sure to always check the frame's `id` and `ownerIdentifier` before using it, to avoid processing unrelated ID3 frames.
+:::
 
 Suppose your UUID is `11111111-1111-1111-1111-111111111111`:
 
 ```javascript
 player.textTracks.addEventListener('addtrack', (event) => {
   const track = event.track;
-  if (track.type === 'emsg' && track.inBandMetadataTrackDispatchType === 'urn:uuid:11111111-1111-1111-1111-111111111111') {
-    track.addEventListener('addcue', (e) => {
-      console.log('cue', e.cue.content);
+  if (track.type === 'id3') {
+    track.addEventListener('addcue' /* or 'entercue' */, (e) => {
+      const frame = e.cue.content;
+      if (frame.id === 'PRIV' && frame.ownerIdentifier === 'urn:uuid:11111111-1111-1111-1111-111111111111') {
+        console.log('metadata', frame.data);
+      }
     });
   }
 });
 ```
 
-Here the cue `content` carries the binary payload exactly as it was sent — your application is responsible for parsing it (for example UTF-8 JSON, protobuf, or your own format).
+Here the `frame.data` carries the binary payload exactly as it was sent — your application is responsible for parsing it (for example UTF-8 JSON, protobuf, or your own format).
 
 ## Picture timing SEI
 

--- a/theoplayer/how-to-guides/web/theolive/metadata.mdx
+++ b/theoplayer/how-to-guides/web/theolive/metadata.mdx
@@ -47,14 +47,14 @@ Here the `frame.data` carries the binary payload exactly as it was sent — your
 
 ## Picture timing SEI
 
-Picture timing SEI cues surface on a text track with `id === 'timecode'`. Each cue is anchored to a frame, so `entercue` is usually the most useful event: it fires when playback reaches the cue, letting you react in sync with the video.
+Picture timing SEI cues surface on a text track with [`TextTrack.id`](pathname:///theoplayer/v11/api-reference/web/interfaces/TextTrack.html#id) equal to `'timecode'`. Each cue is anchored to a frame, so `entercue` is usually the most useful event: it fires when playback reaches the cue, letting you react in sync with the video.
 
 ```javascript
 player.textTracks.addEventListener('addtrack', (event) => {
   const track = event.track;
   if (track.id === 'timecode') {
     track.mode = 'showing'; // Setting the mode to showing will enable the entercue events
-    track.addEventListener('entercue', this.onTimeCode);
+    track.addEventListener('entercue', onTimeCode);
   }
 });
 ```


### PR DESCRIPTION
We changed UDU SEI and API-pushed metadata to surface as ID3 instead of EMSG.