### PR TITLE
Remove channel.stopping from webhooks

### DIFF
--- a/theolive/platform/real-time-update-with-webhooks.mdx
+++ b/theolive/platform/real-time-update-with-webhooks.mdx
@@ -35,7 +35,6 @@ Events are grouped by resource type:
 | `channel.created`   | A channel is created        |
 | `channel.updated`   | A channel is updated        |
 | `channel.deploying` | A channel starts deploying  |
-| `channel.stopping`  | A channel begins stopping   |
 | `channel.stopped`   | A channel has fully stopped |
 | `channel.deleted`   | A channel is deleted        |
 


### PR DESCRIPTION
* Remove `channel.stopping` from list of webhooks events to subscribe to (removed in v2)