### PR TITLE
docs: add media-server 3.3.4 release notes

### DIFF
--- a/millicast/changelog/changelog-dolbyio-platform-media-server.md
+++ b/millicast/changelog/changelog-dolbyio-platform-media-server.md
@@ -2,6 +2,16 @@
 
 Updates to Dolby OptiView's Real-time Streaming Platform and Media Server.
 
+## 2026-06-22
+
+### Media Server
+
+<!-- 3.3.4 -->
+
+#### Fixes
+
+- Fixed a bug where `maxBitrate` in the view request was ignored for non-legacy ABR strategies.
+
 ## 2026-05-28
 
 ### Media Server


### PR DESCRIPTION
## Summary

Adds changelog entry for media-server 3.3.4 release to `millicast/changelog/changelog-dolbyio-platform-media-server.md`.

The only externally facing change in this release:
- Fixed a bug where `maxBitrate` in the view request was ignored for non-legacy ABR strategies.

Link to Devin session: https://dolby.devinenterprise.com/sessions/fcb89cf16994483387b5a05b3cfc9f63
Requested by: @bcostdolby
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/documentation/pull/704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->