### PR TITLE
docs(theolive): update viewer tracking to V2 optiview claim (tid/cvd)

### DIFF
--- a/theolive/platform/viewer-tracking.mdx
+++ b/theolive/platform/viewer-tracking.mdx
@@ -18,26 +18,23 @@ The following is an example workflow for setting up stream tracking:
 
 1. Create a channel.
 2. Enable [token security](../distribution/security/token-based-security.mdx) on the channel or alias.
-3. When you create your self-signed token, add one or both of the following parameters to the `streaming` object in the payload of your JWT:
-   - **`tracking.trackingId`** — Groups viewers of the same channel, allows you to get the aggregated bandwidth usage of all viewers. This is useful for billing a single channel or alias if you use multiple distribution partners and want aggregated billing metrics back or viewer reports for groups of viewers. The maximum size is 128 characters.
-   - **`customViewerData`** — Access the bandwidth consumption of each viewer for analytics purposes and pass through metadata from your CMS for a viewer and be able to retrieve it in a viewer report. This data is not parsed by our system and can be a series of key-value pairs for you to extract later. The maximum size is 1024 characters.
+3. When you create your self-signed token, add one or both of the following properties to the `optiview` claim in the payload of your JWT:
+   - **`tid`** (Tracking ID) — Groups viewers of the same channel, allows you to get the aggregated bandwidth usage of all viewers. This is useful for billing a single channel or alias if you use multiple distribution partners and want aggregated billing metrics back or viewer reports for groups of viewers. The maximum size is 128 characters.
+   - **`cvd`** (Custom viewer data) — Access the bandwidth consumption of each viewer for analytics purposes and pass through metadata from your CMS for a viewer and be able to retrieve it in a viewer report. This data is not parsed by our system and can be a series of key-value pairs for you to extract later. The maximum size is 1024 characters.
 4. Pass the JWT through to the player as described in the [token security](../distribution/security/token-based-security.mdx) section.
 5. To get Advanced Reports, including user-reports, please contact your Dolby representative for access.
 
 :::note
-Either or both `trackingId` and/or `customViewerData` may be used depending on what kind of tracking you need to achieve.
+Either or both `tid` and/or `cvd` may be used depending on what kind of tracking you need to achieve.
 :::
 
-Here is an example `payload` for a JWT that includes sample `trackingId` and `customViewerData`:
+Here is an example `payload` for a JWT that includes sample `tid` and `cvd`:
 
 ```json
 {
-  "streaming": {
-    "tracking": {
-      "trackingId": "groupAbc"
-    },
-    "customViewerData": "user=user123;appVersion=x.y.x",
-    "tokenType": "Subscribe"
+  "optiview": {
+    "tid": "groupAbc",
+    "cvd": "user=user123;appVersion=x.y.x"
   },
   "iat": 1750813271,
   "exp": 1750813871
@@ -47,7 +44,7 @@ Here is an example `payload` for a JWT that includes sample `trackingId` and `cu
 Here is the JWT that is generated from this payload. You can paste it into [jwt.io](https://jwt.io/) to inspect it:
 
 ```
-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdHJlYW1pbmciOnsidHJhY2tpbmciOnsidHJhY2tpbmdJZCI6Imdyb3VwQWJjIn0sImN1c3RvbVZpZXdlckRhdGEiOiJ1c2VyPXVzZXIxMjM7YXBwVmVyc2lvbj14LnkueCIsInRva2VuVHlwZSI6IlN1YnNjcmliZSJ9LCJpYXQiOjE3NTA4MTMyNzEsImV4cCI6MTc1MDgxMzg3MX0.OvIZAvs6XL4KQ8YTtIdjdJNZ5oS6Jkosj3mq274gdrw
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcHRpdmlldyI6eyJ0aWQiOiJncm91cEFiYyIsImN2ZCI6InVzZXI9dXNlcjEyMzthcHBWZXJzaW9uPXgueS54In0sImlhdCI6MTc1MDgxMzI3MSwiZXhwIjoxNzUwODEzODcxfQ.Klc8E7TO7cugxMWB_hQ6BX9_aMLMklsDEJQZCUDln1s
 ```
 
 To validate the token, use the following secret: `d2e166fdda89824a6c493d8a2af7a0754199eff9e38c579cba8783767a44039c`.
@@ -56,4 +53,4 @@ To validate the token, use the following secret: `d2e166fdda89824a6c493d8a2af7a0
 
 - Tracking can be used independently of secure channels. You can pass the same payload parameters in a JWT, however, the token must be "valid" — the required date fields must be valid or the token will be ignored. If a channel does not have token security enabled, be aware that anyone can view the channel with or without a JWT. Without secure channels, the signature is not validated, so there is a risk that a user could change the values.
 - If you are combining the OptiView real-time streaming solution and the live streaming solution, you may use the secret from the real-time subscriber token as the secret you provide to OptiView live streaming and use the same JWTs across both streaming products.
-- `tokenType` should be set to `Subscribe`.
+- For the full list of supported `optiview` claim properties, see [token-based security](../distribution/security/token-based-security.mdx).


### PR DESCRIPTION
Updates the Viewer tracking page to the V2 API format, aligning with the token-based security docs.

## Changes
- Replaces the legacy `streaming` object (`tracking.trackingId`, `customViewerData`, `tokenType`) with the `optiview` claim using `tid` and `cvd`.
- Updates the workflow steps, note callout, and JSON example payload accordingly.
- Regenerates the example JWT so it validates against the listed secret (HS256, secret as UTF-8 string).
- Adds a cross-reference to the token-based security page for the full list of `optiview` claim properties.

## Source of truth
Formats for `tid` and `cvd` taken from the token-based security page (V2).