### PR TITLE
docs(hosted-player): add cdn.optiview.dolby.com to whitelist source domains

### DIFF
--- a/theoplayer/web/hosted-player.md
+++ b/theoplayer/web/hosted-player.md
@@ -32,6 +32,7 @@ The following parameters can be provided used to configure the hosted player. _N
     - `sbp.optiview.dolby.com`
     - _Note: at this time it is not possible to whitelist the end-application domain for whitelisted page domains in the license. If you wish to secure your streams by page domain, please contact Dolby to get your own license and player implementation._
   - _Whitelist Source Domains_
+    - `cdn.optiview.dolby.com`
     - `cdn.theo.live`
     - `cdn.anywhere.theo.live`
     - `cdn.tla-prd.theostream.live`


### PR DESCRIPTION
## Summary
- Add `cdn.optiview.dolby.com` to the _Whitelist Source Domains_ list in the OptiView/THEOplayer hosted player docs (`/docs/theoplayer/web/hosted-player/`).

#### Test plan
- [ ] Verify the new domain renders correctly in the rendered docs page

Generated with [Devin](https://devin.ai)