### PR TITLE
Group Open Video UI under Player

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -28,12 +28,21 @@ const FeatureList: FeatureItem[] = [
       />
     ),
     description: (
-      <p>
-        Dolby OptiView Player (formerly known as THEOplayer) enables you to deploy cutting-edge video playback experiences, efficiently and on any
-        device, including on web, mobile, smart TVs, set-top-boxes and gaming consoles.
-      </p>
+      <>
+        <p>
+          Dolby OptiView Player (formerly known as THEOplayer) enables you to deploy cutting-edge video playback experiences, efficiently and on any
+          device, including on web, mobile, smart TVs, set-top-boxes and gaming consoles.
+        </p>
+        <p>
+          Pair it with Open Video UI to easily build and customize your video player UI to match your branding style through a comprehensive library
+          of open-source UI components.
+        </p>
+      </>
     ),
-    to: [{ link: '/theoplayer', text: 'Get Started' }],
+    to: [
+      { link: '/theoplayer', text: 'OptiView Player' },
+      { link: '/open-video-ui', text: 'Open Video UI' },
+    ],
   },
   {
     title: 'Dolby OptiView Live',
@@ -100,25 +109,6 @@ const FeatureList: FeatureItem[] = [
       </p>
     ),
     to: [{ link: '/ad-engine', text: 'Get Started' }],
-  },
-  {
-    title: 'Open Video UI',
-    Image: (props) => (
-      <ThemedImage
-        {...props}
-        sources={{
-          light: useBaseUrl('/img/openvideoui-black-wordmark.svg'),
-          dark: useBaseUrl('/img/openvideoui-white-wordmark.svg'),
-        }}
-      />
-    ),
-    description: (
-      <p>
-        Paired with the OptiView Player, the Open Video UI enables you to easily build and customize your video player UI to match your branding style
-        through a comprehensive library of open-source UI components.
-      </p>
-    ),
-    to: [{ link: '/open-video-ui', text: 'Get Started' }],
   },
 ];
 


### PR DESCRIPTION
## Summary
- Move Open Video UI into the Player homepage card as a second CTA
- Remove the standalone Open Video UI homepage card
- Keep Open Video UI available as its own item in the Player navbar dropdown

## Testing
- npm run typecheck
- npm run lint
- verified locally at http://127.0.0.1:3000/docs/