### PR TITLE
docs: add media-server 3.4.0 and 3.4.1 release notes

### DIFF
--- a/millicast/changelog/changelog-dolbyio-platform-media-server.md
+++ b/millicast/changelog/changelog-dolbyio-platform-media-server.md
@@ -10,8 +10,7 @@ Updates to Dolby OptiView's Real-time Streaming Platform and Media Server.
 
 #### Fixes
 
-- Applied the latest security patches by updating the operating system kernel, Node.js packages, and third-party dependencies.
-- Improved connection stability by preventing idle internal connections from timing out unexpectedly.
+- Improved connection stability by preventing idle internal connections from timing out.
 
 ## 2026-07-03
 

--- a/millicast/changelog/changelog-dolbyio-platform-media-server.md
+++ b/millicast/changelog/changelog-dolbyio-platform-media-server.md
@@ -2,6 +2,34 @@
 
 Updates to Dolby OptiView's Real-time Streaming Platform and Media Server.
 
+## 2026-07-08
+
+### Media Server
+
+<!-- 3.4.1 -->
+
+#### Fixes
+
+- Applied the latest security patches by updating the operating system kernel, Node.js packages, and third-party dependencies.
+- Improved connection stability by preventing idle internal connections from timing out unexpectedly.
+
+## 2026-07-03
+
+### Media Server
+
+<!-- 3.4.0 -->
+
+#### Features
+
+- Added support for H265 (HEVC) video when [re-streaming](/millicast/distribution/re-streaming) over SRT.
+- RTMP re-streams now automatically generate silent audio when the source stream has no audio track, improving compatibility with destinations that require an audio track.
+
+#### Fixes
+
+- Improved [re-stream](/millicast/distribution/re-streaming) error messages to make issues easier to diagnose.
+- Fixed an issue where some media statistics were missing for re-streams.
+- General stability and reliability improvements.
+
 ## 2026-06-22
 
 ### Media Server

--- a/millicast/distribution/re-streaming.mdx
+++ b/millicast/distribution/re-streaming.mdx
@@ -31,6 +31,7 @@ Support is available for:
 <ul class="checkBoxList">
   <li>WebRTC sources using H.264 and Opus codecs</li>
   <li>SRT and RTMP(S) sources using H.264 and AAC codecs</li>
+  <li>H.265 (HEVC) video when re-streaming to SRT destinations</li>
   <li>Up to ten (10) RTMP(S) or SRT output destinations</li>
 </ul>
 
@@ -112,7 +113,7 @@ The re-stream feed is only showing audio or video. This may be because you are u
 
 ### Re-Stream codec support
 
-_Note: Only the h264 codec is currently supported for re-streaming._
+_Note: H.264 is supported for all re-stream destinations. H.265 (HEVC) is additionally supported when re-streaming to SRT destinations._
 
 :::tip We're Here to Help
 For any other issues not covered here, please reach out to your sales and solutions team who can review server logs that may help identify any configuration issues.


### PR DESCRIPTION
## Summary

Adds public changelog entries for the media-server 3.4.0 (2026-07-03) and 3.4.1 (2026-07-08) releases to `millicast/changelog/changelog-dolbyio-platform-media-server.md`. Release dates match the `v3.4.0`/`v3.4.1` tags in `millicast/media-server`.

Internal-only items (Redis client upgrade + streams migration, cert-updater/disk-space/CI/logrotation/Kafka-schema infra work, internal stability fixes) were intentionally excluded from the public changelog. Curated customer-facing entries:

**3.4.1**
- Security patches: OS kernel, Node.js packages, and third-party dependencies.
- Connection stability fix for idle internal connections timing out (from the Redis xread ping-interval fix, #556).

**3.4.0**
- Features: H265 (HEVC) over SRT re-stream; native silent audio generation for RTMP re-stream when the source has no audio track.
- Fixes: improved re-stream error messages; fixed missing re-stream media stats; general stability/reliability improvements.

Prettier `check-format` passes on the edited file.


Link to Devin session: https://dolby.devinenterprise.com/sessions/990834b1b4d2478e9f7184c7bf5448f9
Requested by: @bcostdolby
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/documentation/pull/728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->