### PR TITLE
docs: dashboard v6.20.0 release notes (2026-07-14)

### DIFF
--- a/millicast/changelog/changelog-dolbyio-dashboard.md
+++ b/millicast/changelog/changelog-dolbyio-dashboard.md
@@ -2,6 +2,12 @@
 
 Updates to the Dolby.io Dashboard and Applications.
 
+## 2026-07-14 | Dashboard
+
+- Added new Analytics usage tabs for Clipping, Storage, and Transcoder. Each tab shows a time-series chart with a Day/Month view toggle and up to ~12 months of history. Clipping and Transcoder appear for accounts with those features enabled; Storage is available to all accounts.
+- The Bandwidth and DRM analytics tabs now show up to ~12 months of history. For date ranges longer than 90 days, usage is aggregated into a monthly view.
+- Fixed page navigation on the Live Monitoring stream list, where the pager listed every page instead of a compact range with ellipsis and clicking a page number had no effect.
+
 ## 2026-04-29 | Dashboard
 
 Updated the dashboard branding to Dolby OptiView, including a new logo.


### PR DESCRIPTION
## Summary

Adds a `2026-07-14 | Dashboard` entry to the dashboard changelog for the v6.20.0 release:

- New Analytics usage tabs (Clipping, Storage, Transcoder) with Day/Month toggle and ~12 months of history.
- Bandwidth and DRM tabs extended to ~12 months of history (monthly aggregation over 90 days).
- Fixed Live Monitoring stream-list pagination (compact range with ellipsis + working page clicks).

Only user-facing changes are included. Internal changes (Segment removal, TypeScript/vue-tsc upgrade, e2e test modernization, security/dependency work) are intentionally omitted.

Generated with [Devin](https://devin.ai)

<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/documentation/pull/736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->