### PR TITLE
Fix undeploy

### DIFF
--- a/.github/workflows/_undeploy.yml
+++ b/.github/workflows/_undeploy.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           aws cloudfront create-invalidation \
             --distribution-id ${CF_DISTRIBUTION_ID} \
-            --paths '/${S3_PREFIX}/*'
+            --paths ${PATH_TO_INVALIDATE}
         env:
           CF_DISTRIBUTION_ID: ${{ vars.CF_DISTRIBUTION_ID }}
-          S3_PREFIX: ${{ inputs.s3_prefix }}
+          PATH_TO_INVALIDATE: '/${{ inputs.s3_prefix }}*'


### PR DESCRIPTION
Fixes a small issue with #757 where the "Invalidate CloudFront" step would fail when undeploying a pull request preview, see [job #15](https://github.com/THEOplayer/documentation/actions/runs/29904747021/job/88873389577). This is basically the same fix as https://github.com/THEOplayer/documentation/pull/757/changes/68f24d25a17fc42320429f6d56f029965edb0c28.