### PR TITLE
Point to versioned guides in older changelogs

### DIFF
--- a/theoplayer/changelog.md
+++ b/theoplayer/changelog.md
@@ -564,7 +564,7 @@ For more info on navigating our breaking changes, take a look at our migration g
 #### 💥 Breaking Changes
 
 - All methods on `Player` and `THEOplayerView` must only be called from the main thread and are annotated with `@MainThread`. Calling these methods from a different thread will throw an `IllegalStateException`.
-- The Google IMA SDK integration now requires [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) to be enabled. See [our updated guide for Google IMA](/theoplayer/how-to-guides/android/ads/google-ima/) for instructions.
+- The Google IMA SDK integration now requires [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) to be enabled. See [our updated guide for Google IMA](/theoplayer/how-to-guides/android/ads/google-ima/#updating-the-google-ima-sdk) for instructions.
 - Removed `preloadChannels` in THEOlive API.
 - Changed `MediaTailorAdAvail.id` to return a `String` instead of an `Int`, to align with `AdBreak.id`.
 - Removed `TheoAdsErrorEvent`, use `AdErrorEvent` instead.

--- a/theoplayer_versioned_docs/version-v10/changelog.md
+++ b/theoplayer_versioned_docs/version-v10/changelog.md
@@ -478,7 +478,7 @@
 
 #### 👎 Deprecations
 
-- Deprecated `DeveloperSettings` & `ManifestInterceptor` in favor of `NetworkAPI`. You can access the network API from `player.network` or `cachingTask.network`. For a comprehensive guide, please refer to [our documentation](./how-to-guides/08-network/03-ios-hls-media-playlist-interceptor.md).
+- Deprecated `DeveloperSettings` & `ManifestInterceptor` in favor of `NetworkAPI`. You can access the network API from `player.network` or `cachingTask.network`. For a comprehensive guide, please refer to [our documentation](/theoplayer/v10/how-to-guides/network/ios-hls-media-playlist-interceptor/).
 
 ### Roku
 
@@ -1080,7 +1080,7 @@ We are happy to announce the tenth major version of THEOplayer, releasing all th
 
 THEOplayer 10.0 includes **some breaking changes per SDK**. Please review them carefully in the respective changelog for your SDK.
 
-- On Android, THEOplayer now always uses the Media3 pipeline for all playback, bringing bug fixes, performance improvements and increased stability across a wider range of devices! Check out our [Media3 guide](/theoplayer/how-to-guides/android/media3/getting-started/) for more information.
+- On Android, THEOplayer now always uses the Media3 pipeline for all playback, bringing bug fixes, performance improvements and increased stability across a wider range of devices! Check out our [Media3 guide](/theoplayer/v10/how-to-guides/android/media3/getting-started/) for more information.
 
 - The Android SDK will now automatically use modern network stacks with HTTP/2 and HTTP/3 support when available, optimizing media delivery to your viewers.
 

--- a/theoplayer_versioned_docs/version-v7/changelog.md
+++ b/theoplayer_versioned_docs/version-v7/changelog.md
@@ -150,8 +150,8 @@
 
 #### 👎 Deprecations
 
-- Deprecated the Conviva pre-integration in favor of the new [Conviva web connector](/theoplayer/connectors/web/conviva/).
-- Deprecated the Yospace pre-integration in favor of the new [Yospace web connector](/theoplayer/connectors/web/yospace/).
+- Deprecated the Conviva pre-integration in favor of the new [Conviva web connector](/theoplayer/v7/connectors/web/conviva/).
+- Deprecated the Yospace pre-integration in favor of the new [Yospace web connector](/theoplayer/v7/connectors/web/yospace/).
 
 ### Android
 

--- a/theoplayer_versioned_docs/version-v8/changelog.md
+++ b/theoplayer_versioned_docs/version-v8/changelog.md
@@ -134,7 +134,7 @@
 
 - Added support for caching sources using the Media3 integration by setting `CachingParameters.storageType` to `CacheStorageType.MEDIA3`. Sources cached with this method will only be playable using the Media3 integration.
 - Added `TextTrackCue.getTrack()` getter.
-- Added support for CMCD in THEOplayer. This is only supported with the Media3 integration. Read more about it [on our Android CMCD docs](/theoplayer/how-to-guides/android/cmcd/getting-started/).
+- Added support for CMCD in THEOplayer. This is only supported with the Media3 integration. Read more about it [on our Android CMCD docs](/theoplayer/v8/how-to-guides/android/cmcd/getting-started/).
 - Added support for automatically adding all available integrations to a new `THEOplayerView` instance. This can be enabled with `THEOplayerConfig.Builder.autoIntegrations()`, and will be enabled by default starting with THEOplayer version 9.0.
 - Added support for the Latency Manager API (`player.latency`) in the Media3 integration.
 - Added support for THEOlive and HESP streams with the Media3 integration.
@@ -165,7 +165,7 @@
 
 #### ✨ Features
 
-- Added support for CMCD in THEOplayer. This is only supported on iOS 18.0+. Read more about it [on our iOS CMCD docs](/theoplayer/how-to-guides/ios/cmcd/getting-started/).
+- Added support for CMCD in THEOplayer. This is only supported on iOS 18.0+. Read more about it [on our iOS CMCD docs](/theoplayer/v8/how-to-guides/ios/cmcd/getting-started/).
 - Added `player.theoLive` API for THEOlive-specific features
 
 #### 🐛 Issues
@@ -259,7 +259,7 @@
 
 #### 💥 Breaking Changes
 
-- Updated the LCEVC integration compatibility for the new LCEVCdecJS SDK version 1.2.0. This breaks compatibility with prior versions. For more info check our [LCEVC doc page](/theoplayer/getting-started/sdks/web/how-to-play-an-lcevc-source-with-theoplayer/).
+- Updated the LCEVC integration compatibility for the new LCEVCdecJS SDK version 1.2.0. This breaks compatibility with prior versions. For more info check our [LCEVC doc page](/theoplayer/v8/getting-started/sdks/web/how-to-play-an-lcevc-source-with-theoplayer/).
 
 #### ✨ Features
 
@@ -951,7 +951,7 @@ THEOplayer 8.0 is **backwards compatible for most features but includes some bre
 
 - THEOplayer 8.0 is the first official release with support for [THEOads](https://www.theoplayer.com/product/theoads), our new product for delivering seamless and novel ad experiences through Server Guided Ad Insertion.  
 
-- The Custom Server Side Ad Insertion API allows custom SSAI integrations to control the player Ad API, and forms the basis for our new Yospace connectors for [Web](/theoplayer/connectors/web/yospace/), [Android](/theoplayer/connectors/android/yospace/) and [iOS](/theoplayer/connectors/ios/yospace/) as well as our upcoming Edgio Uplynk connectors.
+- The Custom Server Side Ad Insertion API allows custom SSAI integrations to control the player Ad API, and forms the basis for our new Yospace connectors for [Web](/theoplayer/v8/connectors/web/yospace/), [Android](/theoplayer/v8/connectors/android/yospace/) and [iOS](/theoplayer/v8/connectors/ios/yospace/) as well as our upcoming Edgio Uplynk connectors.
 
 - The Latency Manager API allows fine-tuned control over live and low-latency playback for DASH, HLS and HESP, available on Web and Android.
 
@@ -967,8 +967,8 @@ For more info on navigating our breaking changes, take a look at our migration g
 
 #### 💥 Breaking Changes
 
-- Removed the Yospace pre-integration in favor of the new [Yospace web connector](/theoplayer/connectors/web/yospace/).
-- Removed the Conviva pre-integration in favor of the new [Conviva web connector](/theoplayer/connectors/web/conviva/).
+- Removed the Yospace pre-integration in favor of the new [Yospace web connector](/theoplayer/v8/connectors/web/yospace/).
+- Removed the Conviva pre-integration in favor of the new [Conviva web connector](/theoplayer/v8/connectors/web/conviva/).
 - Removed the empty `player.analytics` API.
 - Renamed the default integration for client-side VAST and VMAP ads from `'theo'` to `'csai'`. Ad descriptions that don't specify an [integration](https://optiview.dolby.com/docs/theoplayer/v8/api-reference/web/interfaces/AdDescription.html#integration) or use the old name will continue to work, but will have their integration replaced with `'csai'` in the API. The new name was chosen to avoid confusion with our new THEOads solution for server-guided ad insertion.
 

--- a/theoplayer_versioned_docs/version-v9/changelog.md
+++ b/theoplayer_versioned_docs/version-v9/changelog.md
@@ -880,7 +880,7 @@
 
 - Added `suppressCaptions` functionality based on `textTracks` `mode` field.  Captions are automatically suppressed when `textTracks` `mode` is `"disabled"`.
 - Added the `muted` API to control the video node's mute state.
-- Added support for Client Side Ad Insertion using the player `Ads` API. Check out the [getting started with ads on Roku](/theoplayer/getting-started/sdks/roku/displaying-ads/) docs for more information.
+- Added support for Client Side Ad Insertion using the player `Ads` API. Check out the [getting started with ads on Roku](/theoplayer/v9/getting-started/sdks/roku/displaying-ads/) docs for more information.
 
 #### 🐛 Issues
 
@@ -892,7 +892,7 @@
 
 #### 💥 Breaking Changes
 
-- Updated the LCEVC integration compatibility to LCEVCdecJS SDK version 1.2.1. This breaks compatibility with prior versions. For more info check our [LCEVC doc page](/theoplayer/getting-started/sdks/web/how-to-play-an-lcevc-source-with-theoplayer/).
+- Updated the LCEVC integration compatibility to LCEVCdecJS SDK version 1.2.1. This breaks compatibility with prior versions. For more info check our [LCEVC doc page](/theoplayer/v9/getting-started/sdks/web/how-to-play-an-lcevc-source-with-theoplayer/).
 
 #### ✨ Features
 
@@ -1008,13 +1008,13 @@ Introducing a major version bump to THEOplayer 9.0. This version officially rele
 
 THEOplayer 9.0 is **backwards compatible for most features but includes some breaking changes per SDK**. Please review them carefully in the respective changelog for your SDK.
 
-- Starting from THEOplayer 9.0, the new Media3 Playback pipeline is now the default for all Android SDK playback, bringing bug fixes, performance improvements and increased stability across a wider range of devices for the Android SDK! Check out our [Getting started with Media3 guide](/theoplayer/how-to-guides/android/media3/getting-started/) for more information.
+- Starting from THEOplayer 9.0, the new Media3 Playback pipeline is now the default for all Android SDK playback, bringing bug fixes, performance improvements and increased stability across a wider range of devices for the Android SDK! Check out our [Getting started with Media3 guide](/theoplayer/v9/how-to-guides/android/media3/getting-started/) for more information.
 
-- THEOplayer 9.0 supports playback of Dolby's real time streaming solution Millicast across all of our major SDKs, including React Native! Check out our Getting started with Millicast guides for [Web](https://optiview.dolby.com/docs/millicast/playback/players-sdks/web/player/), [Android](https://optiview.dolby.com/docs/millicast/playback/players-sdks/android/player/), [iOS](https://optiview.dolby.com/docs/millicast/playback/players-sdks/ios/player/) and [React Native](/theoplayer/getting-started/frameworks/react-native/millicast/) for more information. 
+- THEOplayer 9.0 supports playback of Dolby's real time streaming solution Millicast across all of our major SDKs, including React Native! Check out our Getting started with Millicast guides for [Web](https://optiview.dolby.com/docs/millicast/playback/players-sdks/web/player/), [Android](https://optiview.dolby.com/docs/millicast/playback/players-sdks/android/player/), [iOS](https://optiview.dolby.com/docs/millicast/playback/players-sdks/ios/player/) and [React Native](/theoplayer/v9/getting-started/frameworks/react-native/millicast/) for more information. 
 
-- With THEOplayer 9.0 we are also bumping and upgrading our THEOplayer Roku SDK to 9.0, bringing API and stability improvements along with new connectors for Conviva and Comscore, with more new feature development and connectors to follow! Check out our [Roku docs](/theoplayer/roku/) for more information.
+- With THEOplayer 9.0 we are also bumping and upgrading our THEOplayer Roku SDK to 9.0, bringing API and stability improvements along with new connectors for Conviva and Comscore, with more new feature development and connectors to follow! Check out our [Roku docs](/theoplayer/v9/roku/) for more information.
 
-- THEOplayer 9.0 now comes with cross platform support for CMCD! We've added CMCD support for our Media3 pipeline as well as for iOS 18+, and made it available cross-platform through React Native too! Check out our CMCD docs for [Web](/theoplayer/connectors/web/cmcd/getting-started), [Android](/theoplayer/how-to-guides/android/cmcd/getting-started/), [iOS](/theoplayer/how-to-guides/android/cmcd/getting-started/) and [React Native](/theoplayer/getting-started/frameworks/react-native/cmcd/) for more information.
+- THEOplayer 9.0 now comes with cross platform support for CMCD! We've added CMCD support for our Media3 pipeline as well as for iOS 18+, and made it available cross-platform through React Native too! Check out our CMCD docs for [Web](/theoplayer/v9/connectors/web/cmcd/getting-started), [Android](/theoplayer/v9/how-to-guides/android/cmcd/getting-started/), [iOS](/theoplayer/v9/how-to-guides/ios/cmcd/getting-started/) and [React Native](/theoplayer/v9/getting-started/frameworks/react-native/cmcd/) for more information.
 
 For more info on navigating our breaking changes, take a look at our migration guides for [Web](https://optiview.dolby.com/docs/theoplayer/v9/getting-started/sdks/web/migrating-to-theoplayer-9/), [Android](https://optiview.dolby.com/docs/theoplayer/v9/getting-started/sdks/android/migrating-to-theoplayer-9/), [iOS](https://optiview.dolby.com/docs/theoplayer/v9/getting-started/sdks/ios/migrating-to-theoplayer-9/) and [React Native](https://optiview.dolby.com/docs/theoplayer/v9/getting-started/frameworks/react-native/migrating-to-react-native-theoplayer-9).
 


### PR DESCRIPTION
The "how-to guides" section was recently split into per-platform guides (e.g. `/how-to-guides/ads/google-ima/` moved to `/how-to-guides/{platform}/ads/google-ima/`), which left several changelog links pointing at pages that moved or no longer exist.

While fixing those, also make the versioned changelogs (version-v7/v8/v9/v10) consistently link to the guide as it existed for that version, instead of the current/unversioned guide:

- `theoplayer/changelog.md`: link the Google IMA "core library desugaring" note directly to the relevant section on the Android-specific guide.
- `version-v10/changelog.md`: point the network interceptor and Media3 guide links to their /v10/ counterparts.
- `version-v9/changelog.md`: point the Roku, LCEVC, Media3, Millicast, and CMCD connector/guide links to their /v9/ counterparts, and fix the iOS CMCD link that mistakenly pointed to the Android guide.
- `version-v8/changelog.md`: point the CMCD, LCEVC and connector guide links to their /v8/ counterparts.
- `version-v7/changelog.md`: point the connector guide links to their /v7/ counterparts.