### PR TITLE
Add media server 3.5.0 release notes

### DIFF
--- a/millicast/changelog/changelog-dolbyio-platform-media-server.md
+++ b/millicast/changelog/changelog-dolbyio-platform-media-server.md
@@ -2,7 +2,7 @@
 
 Updates to Dolby OptiView's Real-time Streaming Platform and Media Server.
 
-## 2026-08-06
+## 2026-08-13
 
 ### Media Server
 

--- a/millicast/changelog/changelog-dolbyio-platform-media-server.md
+++ b/millicast/changelog/changelog-dolbyio-platform-media-server.md
@@ -2,6 +2,22 @@
 
 Updates to Dolby OptiView's Real-time Streaming Platform and Media Server.
 
+## 2026-08-06
+
+### Media Server
+
+<!-- 3.5.0 -->
+
+#### Features
+
+- Added UTC timestamp insertion for H.264 broadcasts. When enabled, the platform stamps each video frame with the server's UTC receive time as frame metadata (an unregistered SEI message, in Unix-epoch milliseconds), so players and downstream tools can measure end-to-end latency, align multiple feeds, or correlate media with external events. It is available for RTMP, RTMPS, and SRT contribution, applies to both passthrough and transcoded layers, and does not re-encode passthrough video. Enable it on a publish token, or for an individual broadcast with the `enableUTCInsertion` publishing parameter. Frames that already carry an `onFi`/AMF sender timestamp are never overwritten, so this is intended for sources that do not already send timecodes.
+
+#### Fixes
+
+- Fixed an issue where a broadcast that stopped immediately after it started could continue to be reported as active, so the stream appeared to still be publishing after it had ended.
+- Applied operating system and dependency security updates to the media server images.
+- General stability and reliability improvements.
+
 ## 2026-07-16
 
 ### Media Server


### PR DESCRIPTION
## Summary

Adds the Media Server 3.5.0 entry to `millicast/changelog/changelog-dolbyio-platform-media-server.md`, same shape as the 3.4.3 entry (#741). Dated `2026-08-13`, the production rollout date.

Only customer-visible changes from `v3.4.3...v3.5.0` are included:

- **Feature — UTC timestamp insertion.** The server can stamp each H.264 frame with its UTC receive time as frame metadata (unregistered SEI, epoch ms) for RTMP/RTMPS/SRT contribution, passthrough and transcoded layers, without re-encoding. Enabled per publish token or per broadcast via `enableUTCInsertion`. Frames that already carry an `onFi`/AMF sender time are not overwritten — the note says so explicitly, because enabling it on a source that emits `onFi` on only *some* frames produces timestamps that alternate between the encoder clock and the server clock.
- **Fix** — a broadcast that stopped immediately after starting could stay reported as active (stream looked like it was still publishing after it ended).
- **Fix** — OS/dependency security updates in the media server images, plus general stability.

The rest of the release (per-subsystem EventLoop metrics + Grafana dashboard, a Redis key-growth fix, packer/CI and base-image work, internal tooling) has no customer-visible surface and is deliberately excluded.

One thing for the reviewer: `enableUTCInsertion` is **not yet documented** in the [Publishing Parameters](https://docs.dolby.io/millicast/broadcast/publishing-parameters) table, so the release note describes the parameter without linking to it. Adding that row (plus a short "reading the timestamp in the player" section) is left as a separate change so it can be reviewed on its own.

`prettier --check` passes on the modified file.


Link to Devin session: https://dolby.devinenterprise.com/sessions/129703589f184ee59a13ec158d646653
Requested by: @bcostdolby
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/documentation/pull/797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->