### PR TITLE
Make preview comment sticky

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -37,6 +37,7 @@ jobs:
       url: ${{ inputs.environment_url }}
     permissions:
       id-token: write
+      pull-requests: write
     steps:
       - name: Create app token
         uses: actions/create-github-app-token@v3
@@ -77,21 +78,19 @@ jobs:
           CF_DISTRIBUTION_ID: ${{ vars.CF_DISTRIBUTION_ID }}
           PATH_TO_INVALIDATE: ${{ inputs.cf_invalidate_path }}
 
+      - name: Get deployment timestamp 🕰️
+        id: timestamp
+        if: ${{ inputs.environment_name == 'preview' }}
+        run: echo "time=$(date -u '+%Y-%m-%d %H:%M %Z')" >> "$GITHUB_OUTPUT"
+
       - name: Add comment to Pull Request with link to preview 🕸️
-        uses: actions/github-script@v9
+        uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ inputs.environment_name == 'preview' }}
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const body = `| Preview |
-            |---|
-            | :rocket: View preview at: ${{ inputs.environment_url }} |
-            | <h6>Deployed on ${new Date(Date.now()).toGMTString()}</h6> |
-            <!-- Sticky Pull Request comment-pr-preview -->`;
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            })
+          header: pr-preview
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          message: |
+            Documentation preview
+            :---:
+            | :rocket: View preview at <br> ${{ inputs.environment_url }} <br><br>
+            | <h6>Deployed from commit ${{ github.event.pull_request.head.sha }} at ${{ steps.timestamp.outputs.time }}. <br> Preview will be ready once the [deployment](${{ github.server_url }}/${{ github.repository }}/deployments/${{ inputs.environment_name }}) is complete. <br><br> </h6>

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -93,4 +93,4 @@ jobs:
             Documentation preview
             :---:
             | :rocket: View preview at <br> ${{ inputs.environment_url }} <br><br>
-            | <h6>Deployed from commit ${{ github.event.pull_request.head.sha }} at ${{ steps.timestamp.outputs.time }}. <br> Preview will be ready once the [deployment](${{ github.server_url }}/${{ github.repository }}/deployments/${{ inputs.environment_name }}) is complete. <br><br> </h6>
+            | <h6>Deployed from commit ${{ github.event.pull_request.head.sha }} at ${{ steps.timestamp.outputs.time }}.</h6>

--- a/.github/workflows/_undeploy.yml
+++ b/.github/workflows/_undeploy.yml
@@ -25,7 +25,15 @@ jobs:
       deployment: false
     permissions:
       id-token: write
+      pull-requests: write
     steps:
+      - name: Create app token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.THEOPLAYER_BOT_APP_ID }}
+          private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
+
       - name: Configure AWS credentials ☁️
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -50,3 +58,28 @@ jobs:
         env:
           CF_DISTRIBUTION_ID: ${{ vars.CF_DISTRIBUTION_ID }}
           PATH_TO_INVALIDATE: ${{ inputs.cf_invalidate_path }}
+
+      - name: Get undeployment timestamp 🕰️
+        id: timestamp
+        if: ${{ inputs.environment_name == 'preview' }}
+        run: echo "time=$(date -u '+%Y-%m-%d %H:%M %Z')" >> "$GITHUB_OUTPUT"
+
+      - name: Update comment on Pull Request 🕸️
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ inputs.environment_name == 'preview' }}
+        with:
+          header: pr-preview
+          only_update: true
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          message: |
+            Documentation preview
+            :---:
+            | <h6>Preview removed at ${{ steps.timestamp.outputs.time }} because the pull request was closed.</h6>
+
+      - name: Hide comment on Pull Request 🙈
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ inputs.environment_name == 'preview' }}
+        with:
+          header: pr-preview
+          hide: true
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,6 +48,7 @@ jobs:
     name: undeploy
     if: ${{ github.event.action == 'closed' && github.triggering_actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/_undeploy.yml
+    secrets: inherit
     with:
       environment_name: preview
       s3_prefix: 'pr-${{ github.event.number }}'


### PR DESCRIPTION
Follow-up on #786: replace the `actions/github-script` step that calls `issues.createComment()` (a new comment on every push) with [`marocchino/sticky-pull-request-comment@v2`](https://github.com/marketplace/actions/sticky-pull-request-comment) using `header: pr-preview`, so each new deployment updates the same comment.

The message is modelled on [rossjrw/pr-preview-action](https://github.com/rossjrw/pr-preview-action)'s comment, which this repo used before, e.g.

> Documentation preview
> :---:
> | :rocket: View preview at <br> https://docs-preview.optiview.dolby.com/pr-786/ <br><br>
> | &lt;h6&gt;Deployed from commit `abc123…` at 2026-08-10 12:00 UTC.&lt;/h6&gt;

There's no "preview will be ready once the deployment completes" line: the comment is posted after the S3 sync and CloudFront invalidation, so the preview is already live.

`_undeploy.yml` now updates the same sticky comment to say the preview was removed, then hides it (minimized as outdated). That takes two steps because the action ignores `message` when `hide: true`: one step with `only_update: true` (a no-op if there is no existing comment) and one with `hide: true`.

The timestamp comes from a small `date -u` step (the sticky action takes a plain string, not JS). Both jobs get `pull-requests: write`, the undeploy job gets the app token (and `secrets: inherit` in `pull-request.yml`) so the comment is posted by the bot.


Link to Devin session: https://dolby.devinenterprise.com/sessions/5dd3c46c6c65412c8954ba72ef6d43db
Requested by: @MattiasBuelens