### PR TITLE
OptiView Player 11.5.2

### DIFF
--- a/theoplayer/changelog.md
+++ b/theoplayer/changelog.md
@@ -235,6 +235,14 @@ These are the release notes for THEOplayer 11.0.0 and higher. For older versions
 
 - Fixed an issue where during fallback on an OptiView Live stream the wrong endpoint was selected.
 
+## 🚀 11.5.2 (2026/08/10)
+
+### iOS
+
+#### 🐛 Issues
+
+- Fixed an issue where legacy `CachingTask`s encoded without `bytes` and `bytesCached` properties would fail to restore.
+
 ## 🚀 11.5.1 (2026/07/03)
 
 ### iOS


### PR DESCRIPTION
Adds the SDK release notes for version 11.5.2.

Link to Devin session: https://dolby.devinenterprise.com/sessions/64bebf74491f4f0a8c0b927aace99c2d
Requested by: @MattiasBuelens