### PR TITLE
Only create app token when deploying preview

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Create app token
         uses: actions/create-github-app-token@v3
         id: app-token
+        if: ${{ inputs.environment_name == 'preview' }}
         with:
           client-id: ${{ vars.THEOPLAYER_BOT_APP_ID }}
           private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}

--- a/.github/workflows/_undeploy.yml
+++ b/.github/workflows/_undeploy.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Create app token
         uses: actions/create-github-app-token@v3
         id: app-token
+        if: ${{ inputs.environment_name == 'preview' }}
         with:
           client-id: ${{ vars.THEOPLAYER_BOT_APP_ID }}
           private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

#803 added a `Create app token` step to `_deploy.yml`/`_undeploy.yml` unconditionally, but `THEOPLAYER_BOT_PRIVATE_KEY` is only available for the `preview` environment, so the production deploy failed immediately.

The token is only used by the `sticky-pull-request-comment` steps, which already have `if: inputs.environment_name == 'preview'`, so the token step gets the same condition.


Link to Devin session: https://dolby.devinenterprise.com/sessions/6aca0af0eb1b47a6960942be081fcb46
Requested by: @MattiasBuelens