### PR TITLE
Fix noIndex being enabled on production builds

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -24,6 +24,7 @@ fs.writeFileSync(path.join(__dirname, 'static/theoplayer-license.txt'), theoplay
 
 const PR_NUMBER = Number(process.env.DOCUSAURUS_PR_NUMBER ?? -1);
 const isProductionDeployment = process.env.NODE_ENV === 'production' && PR_NUMBER <= 0;
+const NO_INDEX = ['1', 'true'].includes((process.env.DOCUSAURUS_NO_INDEX ?? '').trim().toLowerCase());
 
 const docsConfigBase = {
   include: [
@@ -108,7 +109,7 @@ const config: Config = {
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: process.env.DOCUSAURUS_BASE_URL || '/docs/',
   trailingSlash: true,
-  noIndex: !!process.env.DOCUSAURUS_NO_INDEX,
+  noIndex: NO_INDEX,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
## Summary

Production builds were silently marked `noIndex`, which makes `@docusaurus/plugin-sitemap` skip writing `sitemap.xml` entirely (and adds `<meta name="robots" content="noindex, nofollow">` to every page — currently live on https://optiview.dolby.com/docs/).

Cause: the workflow passes `docusaurus_no_index: 0` for production, which reaches the config as the *string* `"0"`, and `!!'0' === true`.

```diff
-  noIndex: !!process.env.DOCUSAURUS_NO_INDEX,
+  noIndex: NO_INDEX,   // ['1', 'true'].includes(DOCUSAURUS_NO_INDEX.trim().toLowerCase())
```

PR previews (`docusaurus_no_index: 1`) keep `noIndex: true`.

Verified with a local `DOCUSAURUS_NO_INDEX=0 npm run build`: `build/sitemap.xml` is now generated and no page contains a `noindex` robots tag.


Link to Devin session: https://dolby.devinenterprise.com/sessions/b3059def9f1642a3bc87a647c751cdce
Requested by: @MattiasBuelens