### PR TITLE
docs(millicast): add videoTargetBitrate to multi-source MBR examples

### DIFF
--- a/millicast/broadcast/multi-source-broadcasting.mdx
+++ b/millicast/broadcast/multi-source-broadcasting.mdx
@@ -81,7 +81,7 @@ Steps to build a broadcast URL suitable for RTMP encoders:
 | :------------------------------------------ | :-------- | :------------------------ |
 | rtmps://rtmp-phx-1.millicast.com:443/v2/pub | /         | myStreamName?token=abc123 |
 
-3. Configure your _main_ source. Typically, this will be your highest-quality input in the case of MBR or or the source you want to be presented initially in multi-view. You will add the `sourceId` parameter and the `simulcastId` parameter. For the main source, the simulcastId will not have a value. When the source is one of several multi-bitrate quality layers, also add the [`videoTargetBitrate`](/millicast/broadcast/publishing-parameters.md) parameter set to the bitrate your encoder is configured to send, in kbps.
+3. Configure your _main_ source. Typically, this will be your highest-quality input in the case of MBR or or the source you want to be presented initially in multi-view. You will add the `sourceId` parameter and the `simulcastId` parameter. For the main source, the simulcastId will not have a value. When the source is one of several multi-bitrate quality layers, also add the [`videoTargetBitrate`](/millicast/broadcast/publishing-parameters.md) parameter set to the bitrate your encoder is configured to send, this informs the service to make more accurate bandwidth estimations.
 
 | RTMP publish stream name  | Separator | Source and Simulcast Parameters                |
 | :------------------------ | :-------- | :--------------------------------------------- |

--- a/millicast/broadcast/multi-source-broadcasting.mdx
+++ b/millicast/broadcast/multi-source-broadcasting.mdx
@@ -133,9 +133,9 @@ srt://srt-phx-1.millicast.com:10000?streamid=myStreamName%253Ft%253D4xd-...vvRrY
 ```
 
 :::warning Declare the bitrate of each multi-bitrate layer
-RTMP and SRT contributions do not signal their encoder bitrate to the platform, so without `videoTargetBitrate` the service has no way of knowing how the quality layers of a `simulcastId` rank against each other until it has measured them at playback time. In that case a viewer can start on an arbitrary layer, and the [ABR](/millicast/distribution/using-webrtc-simulcast) logic only converges on the appropriate quality after it has observed traffic on the layers, which is visible as a stream that starts at a low quality and climbs to the expected one.
+An RTMP or SRT encoder may declare its bitrate inside the contribution stream itself, but that information travels in the media path, so it only reaches the platform once media has started flowing. It is therefore not available at the moment a viewer subscribes and an initial quality layer has to be chosen. Until the layers of a `simulcastId` can be ranked, a viewer can start on an arbitrary layer and the [ABR](/millicast/distribution/using-webrtc-simulcast) logic only converges on the appropriate quality afterwards, which is visible as a stream that starts at a low quality and climbs to the expected one.
 
-Add `&videoTargetBitrate=<kbps>` to every layer of a multi-bitrate contribution so the platform can order the layers immediately and start viewers on the correct one.
+Add `&videoTargetBitrate=<kbps>` to every layer of a multi-bitrate contribution so the platform knows the ordering of the layers up front and can start viewers on the correct one.
 :::
 
 :::warning Multi-bitrate and Recordings
@@ -262,7 +262,7 @@ There are multiple ways to playback and consume a multi-view feed:
 
 - There is a 12Mbps total connection limit on the playback side. If you are using high-bitrate source feeds, we recommend sending at least a high-quality and a low-quality version of each source so that in a multi-view playback, the large image can be high-bitrate and the small thumbnail tiles can be set to the low-bitrate. For more information, see [Limitations of Multi-view](/millicast/playback/multi-view.md#limitations-of-multi-view). This is primarily for broadcasting with RTMP or SRT. If you are using WebRTC to publish and your publishing client supports Simulcast (such as our hosted broadcaster), this is handled automatically.
 - If broadcasting with Multi-Bitrate RTMP or SRT and recording is enabled, each quality rendition that you send into the service will be recorded unless you append the `&record=false` flag to your publishing endpoint.
-- If broadcasting with Multi-Bitrate RTMP or SRT, set `&videoTargetBitrate=<kbps>` on each layer to match your encoder configuration. Layers without a declared target bitrate cannot be ranked by the platform until their bitrate has been measured, which can make playback start on an unexpected quality layer and ramp up to the expected one.
+- If broadcasting with Multi-Bitrate RTMP or SRT, set `&videoTargetBitrate=<kbps>` on each layer to match your encoder configuration. Any bitrate signalled inside the contribution stream only reaches the platform once media flows, which is too late for choosing the initial layer, so playback can start on an unexpected quality layer and ramp up to the expected one.
 - If broadcasting with Multi-Bitrate RTMP or SRT, do not send duplicate audio to each layer. If you are unable to send video-only, you can add the `&videoOnly` parameter to have the service ignore the audio.
 
 ### Playback best practices

--- a/millicast/broadcast/multi-source-broadcasting.mdx
+++ b/millicast/broadcast/multi-source-broadcasting.mdx
@@ -133,9 +133,7 @@ srt://srt-phx-1.millicast.com:10000?streamid=myStreamName%253Ft%253D4xd-...vvRrY
 ```
 
 :::warning Declare the bitrate of each multi-bitrate layer
-An RTMP or SRT encoder may declare its bitrate inside the contribution stream itself, but that information travels in the media path, so it only reaches the platform once media has started flowing. It is therefore not available at the moment a viewer subscribes and an initial quality layer has to be chosen. Until the layers of a `simulcastId` can be ranked, a viewer can start on an arbitrary layer and the [ABR](/millicast/distribution/using-webrtc-simulcast) logic only converges on the appropriate quality afterwards, which is visible as a stream that starts at a low quality and climbs to the expected one.
-
-Add `&videoTargetBitrate=<kbps>` to every layer of a multi-bitrate contribution so the platform knows the ordering of the layers up front and can start viewers on the correct one.
+Add `&videoTargetBitrate=<kbps>` to every layer of a multi-bitrate contribution. The target bitrate lets the platform order the quality layers of a `simulcastId` before playback begins, so a viewer starts on the appropriate layer instead of an arbitrary one and then having [ABR](/millicast/distribution/using-webrtc-simulcast) climb to the expected quality.
 :::
 
 :::warning Multi-bitrate and Recordings
@@ -262,7 +260,7 @@ There are multiple ways to playback and consume a multi-view feed:
 
 - There is a 12Mbps total connection limit on the playback side. If you are using high-bitrate source feeds, we recommend sending at least a high-quality and a low-quality version of each source so that in a multi-view playback, the large image can be high-bitrate and the small thumbnail tiles can be set to the low-bitrate. For more information, see [Limitations of Multi-view](/millicast/playback/multi-view.md#limitations-of-multi-view). This is primarily for broadcasting with RTMP or SRT. If you are using WebRTC to publish and your publishing client supports Simulcast (such as our hosted broadcaster), this is handled automatically.
 - If broadcasting with Multi-Bitrate RTMP or SRT and recording is enabled, each quality rendition that you send into the service will be recorded unless you append the `&record=false` flag to your publishing endpoint.
-- If broadcasting with Multi-Bitrate RTMP or SRT, set `&videoTargetBitrate=<kbps>` on each layer to match your encoder configuration. Any bitrate signalled inside the contribution stream only reaches the platform once media flows, which is too late for choosing the initial layer, so playback can start on an unexpected quality layer and ramp up to the expected one.
+- If broadcasting with Multi-Bitrate RTMP or SRT, set `&videoTargetBitrate=<kbps>` on each layer to match your encoder configuration, so that the layers can be ordered and playback starts on the appropriate quality layer instead of ramping up to it.
 - If broadcasting with Multi-Bitrate RTMP or SRT, do not send duplicate audio to each layer. If you are unable to send video-only, you can add the `&videoOnly` parameter to have the service ignore the audio.
 
 ### Playback best practices

--- a/millicast/broadcast/multi-source-broadcasting.mdx
+++ b/millicast/broadcast/multi-source-broadcasting.mdx
@@ -81,21 +81,21 @@ Steps to build a broadcast URL suitable for RTMP encoders:
 | :------------------------------------------ | :-------- | :------------------------ |
 | rtmps://rtmp-phx-1.millicast.com:443/v2/pub | /         | myStreamName?token=abc123 |
 
-3. Configure your _main_ source. Typically, this will be your highest-quality input in the case of MBR or or the source you want to be presented initially in multi-view. You will add the `sourceId` parameter and the `simulcastId` parameter. For the main source, the simulcastId will not have a value.
+3. Configure your _main_ source. Typically, this will be your highest-quality input in the case of MBR or or the source you want to be presented initially in multi-view. You will add the `sourceId` parameter and the `simulcastId` parameter. For the main source, the simulcastId will not have a value. When the source is one of several multi-bitrate quality layers, also add the [`videoTargetBitrate`](/millicast/broadcast/publishing-parameters.md) parameter set to the bitrate your encoder is configured to send, in kbps.
 
-| RTMP publish stream name  | Separator | Source and Simulcast Parameters |
-| :------------------------ | :-------- | :------------------------------ |
-| myStreamName?token=abc123 | &         | sourceId=1&simulcastId          |
+| RTMP publish stream name  | Separator | Source and Simulcast Parameters                |
+| :------------------------ | :-------- | :--------------------------------------------- |
+| myStreamName?token=abc123 | &         | sourceId=1&simulcastId&videoTargetBitrate=4000 |
 
 4. For each additional source, you'll use a unique `sourceId` and `simulcastId` to distinguish between the various encoders.
 
 In the hosted player, the `simulcastId` is used to set the video source's on-screen label.
 
-| Encoder | Source Id   | Simulcast Id (label) |
-| :------ | :---------- | :------------------- |
-| 1       | &sourceId=1 | &simulcastId         |
-| 2       | &sourceId=2 | &simulcastId=source2 |
-| 3       | &sourceId=3 | &simulcastId=source3 |
+| Encoder | Source Id   | Simulcast Id (label) | Target bitrate           |
+| :------ | :---------- | :------------------- | :----------------------- |
+| 1       | &sourceId=1 | &simulcastId         | &videoTargetBitrate=4000 |
+| 2       | &sourceId=2 | &simulcastId=source2 | &videoTargetBitrate=2000 |
+| 3       | &sourceId=3 | &simulcastId=source3 | &videoTargetBitrate=1000 |
 
 #### Multi-source SRT
 
@@ -110,27 +110,33 @@ Steps to build a broadcast URL suitable for SRT encoders:
 
 There is also a combined **SRT publish URL**. The SRT stream ID includes a compressed token and uses the `t` as the parameter.
 
-3. Configure your _main_ source. Typically, this will be your highest-quality input in the case of MBR or or the source you want to be presented initially in multi-view. You will add the `sourceId` parameter and the `simulcastId` parameter. For the main source, the simulcastId will not have a value.
+3. Configure your _main_ source. Typically, this will be your highest-quality input in the case of MBR or or the source you want to be presented initially in multi-view. You will add the `sourceId` parameter and the `simulcastId` parameter. For the main source, the simulcastId will not have a value. When the source is one of several multi-bitrate quality layers, also add the [`videoTargetBitrate`](/millicast/broadcast/publishing-parameters.md) parameter set to the bitrate your encoder is configured to send, in kbps.
 
-| SRT publish stream name | Separator | Source and Simulcast Parameters |
-| :---------------------- | :-------- | :------------------------------ |
-| myStreamName?t=abc123   | &         | sourceId=1&simulcastId          |
+| SRT publish stream name | Separator | Source and Simulcast Parameters                |
+| :---------------------- | :-------- | :--------------------------------------------- |
+| myStreamName?t=abc123   | &         | sourceId=1&simulcastId&videoTargetBitrate=4000 |
 
 4. For each additional source, you'll use a unique `sourceId` and `simulcastId` to distinguish between the various encoders.
 
 In the hosted player, the `simulcastId` is used to set the video source's on-screen label.
 
-| Encoder | Source Id   | Simulcast Id (label) |
-| :------ | :---------- | :------------------- |
-| 1       | &sourceId=1 | &simulcastId         |
-| 2       | &sourceId=2 | &simulcastId=source2 |
-| 3       | &sourceId=3 | &simulcastId=source3 |
+| Encoder | Source Id   | Simulcast Id (label) | Target bitrate           |
+| :------ | :---------- | :------------------- | :----------------------- |
+| 1       | &sourceId=1 | &simulcastId         | &videoTargetBitrate=4000 |
+| 2       | &sourceId=2 | &simulcastId=source2 | &videoTargetBitrate=2000 |
+| 3       | &sourceId=3 | &simulcastId=source3 | &videoTargetBitrate=1000 |
 
 5. Finally, with SRT you will need to make sure all of the parameters together are URL escaped. This is distinct to SRT workflows. The full combined URL might look similar to:
 
 ```
 srt://srt-phx-1.millicast.com:10000?streamid=myStreamName%253Ft%253D4xd-...vvRrYTeftQPvsCSE%2526sourceId%253D3%2526simulcastId%253DSRT
 ```
+
+:::warning Declare the bitrate of each multi-bitrate layer
+RTMP and SRT contributions do not signal their encoder bitrate to the platform, so without `videoTargetBitrate` the service has no way of knowing how the quality layers of a `simulcastId` rank against each other until it has measured them at playback time. In that case a viewer can start on an arbitrary layer, and the [ABR](/millicast/distribution/using-webrtc-simulcast) logic only converges on the appropriate quality after it has observed traffic on the layers, which is visible as a stream that starts at a low quality and climbs to the expected one.
+
+Add `&videoTargetBitrate=<kbps>` to every layer of a multi-bitrate contribution so the platform can order the layers immediately and start viewers on the correct one.
+:::
 
 :::warning Multi-bitrate and Recordings
 If you are sending multi-bitrate contributions, you can further optimize your parameters by only sending video and disabling any recordings for the additional layers.
@@ -256,6 +262,7 @@ There are multiple ways to playback and consume a multi-view feed:
 
 - There is a 12Mbps total connection limit on the playback side. If you are using high-bitrate source feeds, we recommend sending at least a high-quality and a low-quality version of each source so that in a multi-view playback, the large image can be high-bitrate and the small thumbnail tiles can be set to the low-bitrate. For more information, see [Limitations of Multi-view](/millicast/playback/multi-view.md#limitations-of-multi-view). This is primarily for broadcasting with RTMP or SRT. If you are using WebRTC to publish and your publishing client supports Simulcast (such as our hosted broadcaster), this is handled automatically.
 - If broadcasting with Multi-Bitrate RTMP or SRT and recording is enabled, each quality rendition that you send into the service will be recorded unless you append the `&record=false` flag to your publishing endpoint.
+- If broadcasting with Multi-Bitrate RTMP or SRT, set `&videoTargetBitrate=<kbps>` on each layer to match your encoder configuration. Layers without a declared target bitrate cannot be ranked by the platform until their bitrate has been measured, which can make playback start on an unexpected quality layer and ramp up to the expected one.
 - If broadcasting with Multi-Bitrate RTMP or SRT, do not send duplicate audio to each layer. If you are unable to send video-only, you can add the `&videoOnly` parameter to have the service ignore the audio.
 
 ### Playback best practices

--- a/millicast/broadcast/multi-source-broadcasting.mdx
+++ b/millicast/broadcast/multi-source-broadcasting.mdx
@@ -110,7 +110,7 @@ Steps to build a broadcast URL suitable for SRT encoders:
 
 There is also a combined **SRT publish URL**. The SRT stream ID includes a compressed token and uses the `t` as the parameter.
 
-3. Configure your _main_ source. Typically, this will be your highest-quality input in the case of MBR or or the source you want to be presented initially in multi-view. You will add the `sourceId` parameter and the `simulcastId` parameter. For the main source, the simulcastId will not have a value. When the source is one of several multi-bitrate quality layers, also add the [`videoTargetBitrate`](/millicast/broadcast/publishing-parameters.md) parameter set to the bitrate your encoder is configured to send, in kbps.
+3. Configure your _main_ source. Typically, this will be your highest-quality input in the case of MBR or or the source you want to be presented initially in multi-view. You will add the `sourceId` parameter and the `simulcastId` parameter. For the main source, the simulcastId will not have a value. When the source is one of several multi-bitrate quality layers, also add the [`videoTargetBitrate`](/millicast/broadcast/publishing-parameters.md) parameter set to the bitrate your encoder is configured to send, this informs the service to make more accurate bandwidth estimations.
 
 | SRT publish stream name | Separator | Source and Simulcast Parameters                |
 | :---------------------- | :-------- | :--------------------------------------------- |


### PR DESCRIPTION
## Summary

The Multi-Source Broadcasting URL examples only show `sourceId`/`simulcastId`, so a customer following them for multi-bitrate RTMP/SRT publishes never sets `videoTargetBitrate` — even though it is the only way an RTMP/SRT contribution can tell the platform its encoder bitrate (it is documented in Publishing Parameters, but nothing points MBR users at it).

Consequence seen in production on a multi-bitrate multi-view stream: all layers of a `simulcastId` arrive with no target bitrate, so the bandwidth ABR strategy cannot rank them, playback starts on an arbitrary (low) layer, and the quality climbs only once traffic on the layers has been measured.

Changes to `millicast/broadcast/multi-source-broadcasting.mdx`:

- RTMP and SRT "main source" steps now mention `videoTargetBitrate` and link to Publishing Parameters.
- The RTMP and SRT parameter tables gain a target-bitrate column, e.g. `&sourceId=2&simulcastId=source2&videoTargetBitrate=2000`.
- New admonition explaining why every MBR layer needs `&videoTargetBitrate=<kbps>` (layer ordering / initial layer selection).
- Added a matching bullet under Broadcasting best practices.


Link to Devin session: https://dolby.devinenterprise.com/sessions/b03c121724f74f5787091f857bd6a28b
Requested by: @bcostdolby
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/documentation/pull/831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->