### PR TITLE
docs(theolive): note that DVR and DRM are not currently compatible

### DIFF
--- a/theolive/channel/dvr.mdx
+++ b/theolive/channel/dvr.mdx
@@ -15,7 +15,7 @@ DVR must be explicitly enabled on your account by a Dolby administrator, as it h
 :::
 
 :::warning[Not compatible with DRM]
-DVR is currently not compatible with [DRM](../media-engine/drm.mdx). If DRM is enabled, DVR will not function properly, so avoid combining the two.
+DVR is currently not compatible with [DRM](../media-engine/drm.mdx). If DRM is enabled, DVR will not function properly.
 :::
 
 ## Configuration

--- a/theolive/channel/dvr.mdx
+++ b/theolive/channel/dvr.mdx
@@ -15,7 +15,7 @@ DVR must be explicitly enabled on your account by a Dolby administrator, as it h
 :::
 
 :::warning[Not compatible with DRM]
-DVR is currently not compatible with [DRM](../media-engine/drm.mdx). A channel cannot use DVR and DRM at the same time: if DRM is enabled on an engine, time-shifted playback is not available for that stream.
+DVR is currently not compatible with [DRM](../media-engine/drm.mdx). If DRM is enabled, DVR will not function properly, so avoid combining the two.
 :::
 
 ## Configuration

--- a/theolive/channel/dvr.mdx
+++ b/theolive/channel/dvr.mdx
@@ -14,6 +14,10 @@ DVR (Digital Video Recording) enables viewers to pause, rewind, and replay your 
 DVR must be explicitly enabled on your account by a Dolby administrator, as it has a cost impact. Contact your account manager to get started.
 :::
 
+:::warning[Not compatible with DRM]
+DVR is currently not compatible with [DRM](../media-engine/drm.mdx). A channel cannot use DVR and DRM at the same time: if DRM is enabled on an engine, time-shifted playback is not available for that stream.
+:::
+
 ## Configuration
 
 To enable DVR, set a **window size** in seconds on your channel. This determines the length of the rewindable buffer available to viewers. For example, a window size of 3600 seconds allows viewers to seek up to one hour back in the live stream.

--- a/theolive/media-engine/drm.mdx
+++ b/theolive/media-engine/drm.mdx
@@ -14,6 +14,10 @@ Digital Rights Management (DRM) protects live video content by encrypting the st
 DRM is a fully managed, premium feature. Contact your account representative to learn more and get started.
 :::
 
+:::warning[Not compatible with DVR]
+DRM is currently not compatible with the [DVR window](../channel/dvr.mdx). A channel cannot use DRM and DVR at the same time.
+:::
+
 DRM is essential for content that requires legal or contractual protection, such as premium sports broadcasts, pay-per-view events, or licensed entertainment. It ensures that content owners retain control over who can access their streams and under what conditions.
 
 ## Enabling DRM

--- a/theolive/media-engine/drm.mdx
+++ b/theolive/media-engine/drm.mdx
@@ -15,7 +15,7 @@ DRM is a fully managed, premium feature. Contact your account representative to 
 :::
 
 :::warning[Not compatible with DVR]
-DRM is currently not compatible with the [DVR window](../channel/dvr.mdx). If both are enabled, DVR will not function properly, so avoid combining the two.
+DRM is currently not compatible with the [DVR window](../channel/dvr.mdx). If both are enabled, DVR will not function properly.
 :::
 
 DRM is essential for content that requires legal or contractual protection, such as premium sports broadcasts, pay-per-view events, or licensed entertainment. It ensures that content owners retain control over who can access their streams and under what conditions.

--- a/theolive/media-engine/drm.mdx
+++ b/theolive/media-engine/drm.mdx
@@ -15,7 +15,7 @@ DRM is a fully managed, premium feature. Contact your account representative to 
 :::
 
 :::warning[Not compatible with DVR]
-DRM is currently not compatible with the [DVR window](../channel/dvr.mdx). A channel cannot use DRM and DVR at the same time.
+DRM is currently not compatible with the [DVR window](../channel/dvr.mdx). If both are enabled, DVR will not function properly, so avoid combining the two.
 :::
 
 DRM is essential for content that requires legal or contractual protection, such as premium sports broadcasts, pay-per-view events, or licensed entertainment. It ensures that content owners retain control over who can access their streams and under what conditions.


### PR DESCRIPTION
## Summary

Customers hit an undocumented limitation: THEOlive DVR cannot be used together with DRM. Adds a `:::warning` admonition to both sides so it's visible wherever a user starts:

- `theolive/channel/dvr.mdx` — warning near the top stating DVR is not currently compatible with DRM, linking to the DRM page.
- `theolive/media-engine/drm.mdx` — matching warning linking back to the DVR window page.

Docs-only; no other content changed.


Link to Devin session: https://dolby.devinenterprise.com/sessions/415d06e2b6cb4f6cb03e8c454b27e4f4
Open in Devin Desktop: https://dolby.devinenterprise.com/desktop/session/415d06e2b6cb4f6cb03e8c454b27e4f4?variant=devin
Requested by: @dcoffey3296