### PR TITLE
Migrate to Algolia DocSearch v5 (Docusaurus adapter)

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,6 +3,7 @@ import { themes as prismThemes } from 'prism-react-renderer';
 import type { Config } from '@docusaurus/types';
 import { GlobExcludeDefault } from '@docusaurus/utils';
 import type * as Preset from '@docusaurus/preset-classic';
+import type { ThemeConfig as DocSearchThemeConfig } from '@docsearch/docusaurus-adapter';
 import type * as DocsPlugin from '@docusaurus/plugin-content-docs';
 import type * as ClientRedirectsPlugin from '@docusaurus/plugin-client-redirects';
 import type * as OpenApiPlugin from 'docusaurus-plugin-openapi-docs/src/types';
@@ -462,6 +463,7 @@ const config: Config = {
         }),
       },
     ],
+    '@docsearch/docusaurus-adapter',
   ],
 
   themes: ['docusaurus-theme-openapi-docs'],
@@ -673,10 +675,10 @@ const config: Config = {
       darkTheme: prismThemes.oneDark,
       additionalLanguages: ['java', 'groovy', 'objectivec', 'brightscript', 'dart', 'bash', 'diff', 'json', 'ruby'],
     },
-    algolia: {
+    docsearch: {
       appId: '7HRS9V6FEL',
       apiKey: '415e178afdd1c3ea819b42fb9a6a1c99',
-      indexName: 'theoplayer',
+      indices: [{ name: 'theoplayer' }],
       contextualSearch: true,
       replaceSearchResultPathname: {
         from: '/docs/',
@@ -697,7 +699,7 @@ const config: Config = {
         // options you can specify via https://github.com/francoischalifour/medium-zoom#usage
       },
     },
-  } satisfies Preset.ThemeConfig,
+  } satisfies Preset.ThemeConfig & DocSearchThemeConfig,
 };
 
 function parseDocPath(filePath: string):

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "documentation",
       "version": "0.0.0",
       "dependencies": {
+        "@docsearch/docusaurus-adapter": "^5.0.5",
         "@docusaurus/core": "^3.10.2",
         "@docusaurus/faster": "^3.10.2",
         "@docusaurus/plugin-client-redirects": "^3.10.2",
@@ -16,7 +17,6 @@
         "@docusaurus/plugin-google-tag-manager": "^3.10.2",
         "@docusaurus/preset-classic": "^3.10.2",
         "@docusaurus/theme-classic": "^3.10.2",
-        "@docusaurus/theme-search-algolia": "^3.10.2",
         "@mdx-js/react": "^3.1.1",
         "ace-builds": "^1.44.0",
         "clsx": "^2.1.1",
@@ -67,6 +67,77 @@
       },
       "engines": {
         "node": ">=11"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "2.0.146",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.146.tgz",
+      "integrity": "sha512-kFvoUmtaK6qcyPWriiO0o3TNsDqLe2dkhS0wBTeehvZugpYASfymxfPPXkPQ3Lc1PD+ZPzeJ5fqTrAUVxs2fPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.36",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
+      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.36.tgz",
+      "integrity": "sha512-2eSw90hn32Je6n2a8Gf4dJ2EoecPJuOCWqwZCw+BkhPq2LOS01HX3s6ljgOm0iIkZiD5aAuMdpOw17rYKQF/Zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.3",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6",
+        "undici": "^5.29.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "2.0.255",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.255.tgz",
+      "integrity": "sha512-88AGv/A/Uwk2q10BVlRnpTDEJS2KwlJ67k/8JE++c+lnmyqih8S7onEFS/oG/aXpfkeZm5aXRqXrYZmURGdNVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "3.0.36",
+        "ai": "5.0.252",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1",
+        "zod": "^3.25.76 || ^4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -1982,9 +2053,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2033,6 +2104,66 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.8.0.tgz",
+      "integrity": "sha512-P0/1sxo6SBVZOklKMIedvTWqw2s2IQzi9x5bIVsXu980cuSOD4NeuRSs+/L7LZQfDkZP/uRZyGPyfFl/B1oH+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "@base-ui/utils": "0.4.0",
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-bO9fz25kKtPf+aZVyfQrC0PDmJdmVni31W2hCS5/Owb+inwdIL3XU26pCPRPlt4LSxZrBgLwubXQXQlKaFEZzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "@floating-ui/utils": "^0.2.12",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@colors/colors": {
@@ -3371,9 +3502,9 @@
       }
     },
     "node_modules/@docsearch/core": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.3.tgz",
-      "integrity": "sha512-rUOujwIpxJRgD7+kicVsI3D5sqBvdiRTquzWBpTEXZs8ZXfGbfzpus5HqumaNYTppN2HvH8E2yNuRwYdHJeOlA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-5.0.5.tgz",
+      "integrity": "sha512-p1IiedAnlnRUVHGFvFKdfkrNI5Ga3NRZdHaDicrrb41LkpPtsYuV97jFnof+uMVV0YsC2JZtJ8WVrJJmQtJ0Ig==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3393,20 +3524,84 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.3.tgz",
-      "integrity": "sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-5.0.5.tgz",
+      "integrity": "sha512-0ETIihH1MKPzIcTZjjJsXGpheg53ZIuQ7mETXZVTnRDxK8BEbUz62IBSz0RuhGa6G3jxMVzWkVKenj7Ru4vUcA==",
       "license": "MIT"
     },
-    "node_modules/@docsearch/react": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.3.tgz",
-      "integrity": "sha512-Bg2wdDsoQVlNCcEKuEJAU04tvHCqgx8rIu+uIoM4pRtcx3TBKJuXutJik3LTA8LRc9YEyHkrYUrmcC0D7BYf+g==",
+    "node_modules/@docsearch/docusaurus-adapter": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@docsearch/docusaurus-adapter/-/docusaurus-adapter-5.0.5.tgz",
+      "integrity": "sha512-HJy09ZrrbxVNWWSxBJX1WgiQndhEiH3FI1SSELVrZmFlApaAl86zjuQIR93fx9ZHTHlgiNJQZzJ0jnOmSuw1YQ==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/core": "4.6.3",
-        "@docsearch/css": "4.6.3"
+        "@docsearch/core": "5.0.5",
+        "@docsearch/modal": "5.0.5",
+        "@docsearch/react": "5.0.5",
+        "@docsearch/sidepanel": "5.0.5",
+        "@docusaurus/core": "^3.10.2",
+        "@docusaurus/plugin-content-docs": "^3.10.2",
+        "@docusaurus/theme-common": "^3.10.2",
+        "@docusaurus/theme-translations": "^3.10.2",
+        "algoliasearch": "^5.37.0",
+        "algoliasearch-helper": "^3.26.0",
+        "clsx": "^2.0.0",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "joi": "^17.9.2",
+        "search-insights": "^2.17.3",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docsearch/modal": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@docsearch/modal/-/modal-5.0.5.tgz",
+      "integrity": "sha512-WrqHXUav95yZAlezmU8JJoX+LRluc0pmA/OxU9XHDUTddbDepDItWQDo5dmYzZRNsyp8Z/5Q/7NOQ7g9RnSTxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/core": "5.0.5",
+        "@docsearch/react": "5.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 20.0.0",
+        "react": ">= 16.8.0 < 20.0.0",
+        "react-dom": ">= 16.8.0 < 20.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-5.0.5.tgz",
+      "integrity": "sha512-EyD2oQmWLMu/nVq/jh5SZ9f4uc+Ut/3aoBA5xrKqFfdArLNqiyqFbMSZYI2xddv5yS8ENHo1ZU6lYOTPW0YrZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/react": "^2.0.30",
+        "@algolia/autocomplete-core": "1.19.2",
+        "@base-ui/react": "^1.5.0",
+        "@docsearch/core": "5.0.5",
+        "@docsearch/css": "5.0.5",
+        "ai": "^5.0.30",
+        "algoliasearch": "^5.28.0",
+        "marked": "^16.3.0",
+        "zod": "^4.1.8"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3425,6 +3620,33 @@
           "optional": true
         },
         "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docsearch/sidepanel": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@docsearch/sidepanel/-/sidepanel-5.0.5.tgz",
+      "integrity": "sha512-fzX+5FZ6eFVaU80FNBfzhv6GVUEKDDEoNbGDcnkACHWF5dTJwHZRQZ9c6Cz3Eog4A1natyHudUbIns3RXeHrRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/core": "5.0.5",
+        "@docsearch/css": "5.0.5",
+        "@docsearch/react": "5.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 20.0.0",
+        "react": ">= 16.8.0 < 20.0.0",
+        "react-dom": ">= 16.8.0 < 20.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
           "optional": true
         }
       }
@@ -4430,6 +4652,53 @@
       "deprecated": "Please update to a newer version.",
       "license": "MIT"
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -4891,6 +5160,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -7019,6 +7297,15 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -7270,6 +7557,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ai": {
+      "version": "5.0.252",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.252.tgz",
+      "integrity": "sha512-DeSj6rUyptyv+dL31CBNBReWVUsFVmQWf+m3SRyPhIIVLKsNqvIg1g7fC5tdMqL/iYwffltxGvS9dA6e0Txu5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "2.0.146",
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.36",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -10870,6 +11175,15 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -13467,6 +13781,12 @@
         "foreach": "^2.0.4"
       }
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-compare": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
@@ -14054,6 +14374,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -20467,9 +20799,9 @@
       "license": "MIT"
     },
     "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.3.0.tgz",
+      "integrity": "sha512-XGoLeRAVzUTcJ1qkxPQhDJyIZ5d6zzZD9nT7AEZOaaU9UbWclhycElmhO+VD5bFeLuzhPBaOV2oXC8uG35ZSpg==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -20869,8 +21201,7 @@
       "version": "2.17.3",
       "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
       "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -22024,6 +22355,19 @@
         "webpack": ">=2"
       }
     },
+    "node_modules/swr": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.5.1.tgz",
+      "integrity": "sha512-BRw55e8r0B7SpDN20CAzoQAHl7y1yP7/Zt7oqUjMv0vSt2u2Xnkm88Ws+VypbV9BXHQVuSuyVq7zMjO16wSExw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -22159,6 +22503,18 @@
       },
       "peerDependencies": {
         "tslib": "^2"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/thunky": {
@@ -22516,6 +22872,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {
@@ -23886,7 +24254,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4283,6 +4283,65 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docsearch/core": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.7.0.tgz",
+      "integrity": "sha512-p/9xVKmPDj3FPvMfPf5naVO3Ej8SCbcUugGvx1+8GgkuBNbqxqN2Irx3WLBv8VY0jH7XpRwKWdlmjXLZsmTLsg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 20.0.0",
+        "react": ">= 16.8.0 < 20.0.0",
+        "react-dom": ">= 16.8.0 < 20.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docsearch/css": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.7.0.tgz",
+      "integrity": "sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==",
+      "license": "MIT"
+    },
+    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docsearch/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-x6oedjJ8O8/pIDBsMo5Orca3/6cQCz616/CwthVe68l43mqnj2lrJ9kFQITBqy8hMsS3nWeBWFoVO5dJ1DCFKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.19.2",
+        "@docsearch/core": "4.7.0",
+        "@docsearch/css": "4.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 20.0.0",
+        "react": ">= 16.8.0 < 20.0.0",
+        "react-dom": ">= 16.8.0 < 20.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@docusaurus/theme-translations": {
       "version": "3.10.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "fix-lint": "npm run lint -- --fix"
   },
   "dependencies": {
+    "@docsearch/docusaurus-adapter": "^5.0.5",
     "@docusaurus/core": "^3.10.2",
     "@docusaurus/faster": "^3.10.2",
     "@docusaurus/plugin-client-redirects": "^3.10.2",
@@ -32,7 +33,6 @@
     "@docusaurus/plugin-google-tag-manager": "^3.10.2",
     "@docusaurus/preset-classic": "^3.10.2",
     "@docusaurus/theme-classic": "^3.10.2",
-    "@docusaurus/theme-search-algolia": "^3.10.2",
     "@mdx-js/react": "^3.1.1",
     "ace-builds": "^1.44.0",
     "clsx": "^2.1.1",
@@ -67,6 +67,9 @@
     "unist-util-visit": "^5.1.0"
   },
   "overrides": {
+    "@docusaurus/theme-search-algolia": {
+      "@docsearch/react": "5.0.5"
+    },
     "@docusaurus/utils": {
       "gray-matter": "npm:@gr2m/gray-matter@4.0.3-with-pr-137"
     },

--- a/package.json
+++ b/package.json
@@ -67,9 +67,6 @@
     "unist-util-visit": "^5.1.0"
   },
   "overrides": {
-    "@docusaurus/theme-search-algolia": {
-      "@docsearch/react": "5.0.5"
-    },
     "@docusaurus/utils": {
       "gray-matter": "npm:@gr2m/gray-matter@4.0.3-with-pr-137"
     },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -159,6 +159,9 @@
   /* Search box */
   --docsearch-searchbox-background: var(--ifm-background-color);
   --docsearch-searchbox-focus-background: var(--ifm-color-black);
+  /* The adapter maps these to --ifm-color-secondary, which stays light in dark mode */
+  --docsearch-background-color: var(--ifm-color-emphasis-200);
+  --docsearch-hit-focus-background: var(--ifm-color-emphasis-200);
 }
 
 a:hover {


### PR DESCRIPTION
## Summary

Replaces the built-in `@docusaurus/theme-search-algolia` integration (DocSearch v4) with the official `@docsearch/docusaurus-adapter` (DocSearch v5), following https://docsearch.algolia.com/docs/migrating-from-v4/.

Config change in `docusaurus.config.ts`:

```diff
 plugins: [
   ...
+  '@docsearch/docusaurus-adapter',
 ],
 themeConfig: {
-  algolia: {
+  docsearch: {
     appId, apiKey,
-    indexName: 'theoplayer',
+    indices: [{ name: 'theoplayer' }],
     contextualSearch: true,
     replaceSearchResultPathname: { from: '/docs/', to: DOCUSAURUS_BASE_URL || '/docs/' },
   },
-} satisfies Preset.ThemeConfig,
+} satisfies Preset.ThemeConfig & DocSearchThemeConfig,
```

Ask AI, Agent Studio and the Ask AI sidepanel are intentionally not configured; only keyword search is enabled.

`@docusaurus/theme-search-algolia` is removed from direct dependencies. It is still pulled in transitively by `@docusaurus/preset-classic`, but it is inactive because `themeConfig.algolia` is no longer set.

CSS: the adapter maps `--docsearch-background-color` and `--docsearch-hit-focus-background` to `--ifm-color-secondary`, which stays light in dark mode. The selected hit and the keyboard hints in the footer were therefore unreadable in dark mode. The dark-mode `.DocSearch` block in `custom.css` now sets both to `--ifm-color-emphasis-200`. All other existing DocSearch variable overrides are still valid in v5.

Verified locally: search modal opens, queries return results from the `theoplayer` index, result links are rewritten to `/docs/...`, light and dark mode render correctly.

![light](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNmI5MTQ1Y2E0MjAxNDRmMDgyZGMxOTEyNDBlMzc1ZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNmI5MTQ1Y2E0MjAxNDRmMDgyZGMxOTEyNDBlMzc1ZjIvOTNhNzMzY2YtYjkxOC00YzczLWI4MWQtYWZkZjA2MDI3NmU4IiwiaWF0IjoxNzg4NTE2NDE0LCJleHAiOjE3ODkxMjEyMTQsImZpbGVuYW1lIjoiZG9jc2VhcmNoLXY1LXJlc3VsdHMucG5nIn0.zIai_70BnjUIn85xu4a5wCFtjKfHLXzCiBG17um1sBY)
![dark](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNmI5MTQ1Y2E0MjAxNDRmMDgyZGMxOTEyNDBlMzc1ZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNmI5MTQ1Y2E0MjAxNDRmMDgyZGMxOTEyNDBlMzc1ZjIvN2I1MDM4YTktNzUwZC00NmI4LWJiNzItNzNmOTgwZDE5ZDczIiwiaWF0IjoxNzg4NTE2NDE0LCJleHAiOjE3ODkxMjEyMTQsImZpbGVuYW1lIjoiZG9jc2VhcmNoLXY1LWRhcmstZml4ZWQucG5nIn0.xj7ToOGb-EifDUilk2Q4vcHS-5i9ZR9kAxEgg1YY0s4)

Link to Devin session: https://dolby.devinenterprise.com/sessions/680dbf2a2547484182a9fe34fcf89c36
Open in Devin Desktop: https://dolby.devinenterprise.com/desktop/session/680dbf2a2547484182a9fe34fcf89c36?variant=devin
Requested by: @MattiasBuelens