### PR TITLE
Automate OptiView Ads SDK API reference PRs

### DIFF
--- a/.github/workflows/ads-sdk-release.yml
+++ b/.github/workflows/ads-sdk-release.yml
@@ -1,0 +1,43 @@
+name: Auto-open PRs for OptiView Ads SDK releases
+on:
+  push:
+    branches:
+      - 'release/ads-sdk-**'
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create app token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.THEOPLAYER_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.THEOPLAYER_BOT_PRIVATE_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+      - name: Check if pull request already exists
+        id: check_pr_exists
+        shell: bash
+        run: |
+          pr_count=$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head "$GITHUB_REF_NAME" --state open --limit 1 --json number --jq length)
+          if ((pr_count > 0)); then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Create pull request
+        if: ${{ !steps.check_pr_exists.outputs.exists }}
+        shell: bash
+        run: |
+          ads_sdk_version=${GITHUB_REF_NAME#release/ads-sdk-}
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base main \
+            --head "$GITHUB_REF_NAME" \
+            --title "OptiView Ads SDK ${ads_sdk_version}" \
+            --body "This PR contains the Web API reference for OptiView Ads SDK version ${ads_sdk_version}."
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,7 @@
 static/theoplayer-license.txt
 theoplayer/changelog.md
 theoplayer/static/theoplayer/*/api-reference
+ads/static/ads/*/api-reference
 theoplayer_versioned_docs/*/changelog.md
 theoplayer_versioned_docs/*/static/theoplayer/*/api-reference
 ads/api/ads-client.swagger.json


### PR DESCRIPTION
## Summary
- auto-open documentation PRs when the Ads SDK pipeline pushes a `release/ads-sdk-*` branch
- exclude generated Ads API reference HTML from Prettier checks

#### Test plan
- [x] Run `npm run check-format`
- [x] Run `npm run lint`
- [x] Run `npm run typecheck`
- [x] Parse the new GitHub Actions workflow as YAML

Generated with [Devin](https://devin.ai)