### PR TITLE
Add media server 3.6.0 release notes

### DIFF
--- a/millicast/changelog/changelog-dolbyio-platform-media-server.md
+++ b/millicast/changelog/changelog-dolbyio-platform-media-server.md
@@ -2,6 +2,27 @@
 
 Updates to Dolby OptiView's Real-time Streaming Platform and Media Server.
 
+## 2026-09-07
+
+### Media Server
+
+<!-- 3.6.0 -->
+
+#### Features
+
+- Improved Adaptive Bitrate (ABR) bandwidth allocation for multiview playback. The available bandwidth is now shared across views by priority: audio first, then layers pinned by the client, then the main view, and finally the remaining views, weighted by their size on screen. Views are no longer starved when the main view takes the full bandwidth budget.
+- Non-main views in a multiview stream now start on their lowest layer instead of their highest layer, so the link is not overloaded when playback starts. ABR then ramps each view up as bandwidth allows.
+- Added an option to keep forwarding layers pinned by the client even when the pinned layers together exceed the estimated bandwidth, instead of muting them. When a pinned layer is muted because of bandwidth, the viewer can now receive a `trackMuted` event that explains why.
+- Added an opt-in fix for RTMP re-streams from WebRTC contribution. Some RTMP destinations, such as YouTube, showed glitches when the WebRTC source changed resolution during the broadcast. When enabled on the account, the media server now opens a new connection to the destination on a video configuration change, and hands over without a gap. Contact support to enable this option.
+- Added per-track logging of the encoding to bitrate and resolution mapping to make multiview layer selection easier to diagnose.
+
+#### Fixes
+
+- Fixed an issue where an RTMP re-stream could stay in a "connected" state forever, without sending any media, if the destination accepted the connection but never answered the publish request. The re-stream now fails after 10 seconds, so it can be reported and restarted.
+- Fixed an issue where ABR bandwidth estimation on Firefox counted bandwidth probes as packet loss, which could pin the estimate far below the available bandwidth and cause freezes in multiview playback.
+- Applied operating system and dependency security updates to the media server images.
+- General stability and reliability improvements.
+
 ## 2026-08-17
 
 ### Media Server

--- a/millicast/changelog/changelog-dolbyio-platform-media-server.md
+++ b/millicast/changelog/changelog-dolbyio-platform-media-server.md
@@ -20,7 +20,6 @@ Updates to Dolby OptiView's Real-time Streaming Platform and Media Server.
 
 - Fixed an issue where an RTMP re-stream could stay in a "connected" state forever, without sending any media, if the destination accepted the connection but never answered the publish request. The re-stream now fails after 10 seconds, so it can be reported and restarted.
 - Fixed an issue where ABR bandwidth estimation on Firefox counted bandwidth probes as packet loss, which could pin the estimate far below the available bandwidth and cause freezes in multiview playback.
-- Applied operating system and dependency security updates to the media server images.
 - General stability and reliability improvements.
 
 ## 2026-08-17


### PR DESCRIPTION
## Summary

Adds the Media Server 3.6.0 entry to the Platform and Media Server changelog, following the format of the 3.5.x entries.

Covers the multiview ABR bandwidth allocation improvements, the lowest-layer start for non-main multiview views, the option to keep client-pinned layers unmuted (with the `trackMuted` event), the opt-in RTMP re-stream reconnect on video configuration change for WebRTC contribution, the RTMP re-stream publish stall timeout, the Firefox bandwidth probe acknowledgement fix, and security updates.

The release date is set to 2026-09-07; adjust if the public release lands on another day.

Link to Devin session: https://dolby.devinenterprise.com/sessions/9643561454a643fe9d17adcd339acd4a
Open in Devin Desktop: https://dolby.devinenterprise.com/desktop/session/9643561454a643fe9d17adcd339acd4a?variant=devin
Requested by: @bcostdolby
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/documentation/pull/847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->