### PR TITLE
Fix build: use MDX comment in media server changelog

### DIFF
--- a/millicast/changelog/changelog-dolbyio-platform-media-server.md
+++ b/millicast/changelog/changelog-dolbyio-platform-media-server.md
@@ -6,7 +6,7 @@ Updates to Dolby OptiView's Real-time Streaming Platform and Media Server.
 
 ### Media Server
 
-<!-- 3.6.0 -->
+{/* 3.6.0 */}
 
 #### Features
 


### PR DESCRIPTION
## Summary

The `main` build is currently broken. #847 added an HTML comment (`<!-- 3.6.0 -->`) to `millicast/changelog/changelog-dolbyio-platform-media-server.md`, and #839 (strict MDX) merged afterwards, so HTML comments are no longer accepted.

This replaces it with the MDX form:

```diff
-<!-- 3.6.0 -->
+{/* 3.6.0 */}
```

No other legacy MDX syntax remains outside fenced code blocks and submodules.

Link to Devin session: https://dolby.devinenterprise.com/sessions/7f6c018f420d4e30af6cd39a2274e7e4
Open in Devin Desktop: https://dolby.devinenterprise.com/desktop/session/7f6c018f420d4e30af6cd39a2274e7e4?variant=devin
Requested by: @MattiasBuelens